### PR TITLE
Add Clerk auth, bookmark sync, and UX improvements

### DIFF
--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import {
+  getBookmarks,
+  addBookmark,
+  removeBookmark,
+  getBookmarkedArticles,
+} from "@/lib/db";
+import type { Article, CategoryId } from "@/lib/types";
+
+function unauthorized() {
+  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+// GET /api/bookmarks — returns bookmark IDs (default) or full articles (?full=1)
+export async function GET(request: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) return unauthorized();
+
+  try {
+    const full = request.nextUrl.searchParams.get("full") === "1";
+
+    if (full) {
+      const rows = await getBookmarkedArticles(userId);
+      const articles: Article[] = rows.map((row) => ({
+        id: row.id,
+        title: row.title,
+        summary: row.summary || "",
+        sourceUrl: row.source_url,
+        sourceName: row.source_name,
+        publishedDate: row.published_date ? row.published_date.toISOString() : null,
+        imageUrl: row.image_url,
+        category: row.category as CategoryId,
+        readTime: row.read_time || 1,
+      }));
+      return NextResponse.json({ articles });
+    }
+
+    const ids = await getBookmarks(userId);
+    return NextResponse.json({ ids });
+  } catch (err) {
+    console.error("Bookmarks GET error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// POST /api/bookmarks — body { articleId }
+export async function POST(request: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) return unauthorized();
+
+  try {
+    const { articleId } = await request.json();
+    if (!articleId || typeof articleId !== "string") {
+      return NextResponse.json({ error: "articleId required" }, { status: 400 });
+    }
+    await addBookmark(userId, articleId);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("Bookmarks POST error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// DELETE /api/bookmarks — body { articleId }
+export async function DELETE(request: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) return unauthorized();
+
+  try {
+    const { articleId } = await request.json();
+    if (!articleId || typeof articleId !== "string") {
+      return NextResponse.json({ error: "articleId required" }, { status: 400 });
+    }
+    await removeBookmark(userId, articleId);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("Bookmarks DELETE error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ClerkProvider } from "@clerk/nextjs";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -12,12 +13,15 @@ export const metadata: Metadata = {
   },
 };
 
+const clerkPk = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+const clerkEnabled = !!clerkPk && clerkPk.startsWith("pk_");
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
+  const inner = (
     <html lang="en">
       <body>
         <a href="#main-content" className="skip-nav">
@@ -27,4 +31,8 @@ export default function RootLayout({
       </body>
     </html>
   );
+
+  if (!clerkEnabled) return inner;
+
+  return <ClerkProvider>{inner}</ClerkProvider>;
 }

--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,12 @@
+import { SignIn } from "@clerk/nextjs";
+
+export default function SignInPage() {
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center"
+      style={{ background: "#0a0a0f" }}
+    >
+      <SignIn />
+    </div>
+  );
+}

--- a/app/sign-up/[[...sign-up]]/page.tsx
+++ b/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,12 @@
+import { SignUp } from "@clerk/nextjs";
+
+export default function SignUpPage() {
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center"
+      style={{ background: "#0a0a0f" }}
+    >
+      <SignUp />
+    </div>
+  );
+}

--- a/components/AuthButtons.tsx
+++ b/components/AuthButtons.tsx
@@ -2,7 +2,7 @@
 
 import { useUser, SignInButton, UserButton } from "@clerk/nextjs";
 
-const clerkEnabled =
+export const clerkEnabled =
   !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY &&
   process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY.startsWith("pk_");
 

--- a/components/AuthButtons.tsx
+++ b/components/AuthButtons.tsx
@@ -3,7 +3,6 @@
 import { useUser, SignInButton, UserButton } from "@clerk/nextjs";
 
 const clerkEnabled =
-  typeof window !== "undefined" &&
   !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY &&
   process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY.startsWith("pk_");
 

--- a/components/AuthButtons.tsx
+++ b/components/AuthButtons.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useUser, SignInButton, UserButton } from "@clerk/nextjs";
+
+const clerkEnabled =
+  typeof window !== "undefined" &&
+  !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY &&
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY.startsWith("pk_");
+
+function ClerkAuthButtons() {
+  const { user } = useUser();
+
+  if (user) {
+    return <UserButton afterSignOutUrl="/" />;
+  }
+
+  return (
+    <SignInButton mode="modal">
+      <button
+        className="px-3.5 py-1.5 rounded-full text-sm font-semibold cursor-pointer transition-all duration-200 font-body"
+        style={{
+          background: "transparent",
+          border: "1px solid var(--border)",
+          color: "var(--text-secondary)",
+        }}
+      >
+        Sign in
+      </button>
+    </SignInButton>
+  );
+}
+
+export default function AuthButtons() {
+  if (!clerkEnabled) return null;
+  return <ClerkAuthButtons />;
+}

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -50,6 +50,8 @@ export default function NewsAggregator() {
   const [activeCategory, setActiveCategory] = useState<CategoryId>("top");
   const [showBookmarks, setShowBookmarks] = useState(false);
 
+  const [refreshed, setRefreshed] = useState(false);
+
   const { articles, loading, error, slow, lastUpdated, loadCategory } = useNewsLoader();
   const { bookmarks, toggle: toggleBookmark, count: bookmarkCount } = useBookmarks();
   const { dark: darkMode, toggle: toggleDark } = useTheme();
@@ -57,6 +59,12 @@ export default function NewsAggregator() {
   useEffect(() => {
     loadCategory(activeCategory);
   }, [activeCategory, loadCategory]);
+
+  const handleRefresh = async () => {
+    await loadCategory(activeCategory, true);
+    setRefreshed(true);
+    setTimeout(() => setRefreshed(false), 2000);
+  };
 
   const currentArticles = useMemo(() => {
     if (showBookmarks) {
@@ -114,14 +122,18 @@ export default function NewsAggregator() {
             </button>
 
             <button
-              onClick={() => loadCategory(activeCategory, true)}
+              onClick={handleRefresh}
               disabled={loading}
               aria-label="Refresh"
-              className="flex items-center justify-center w-9 h-9 rounded-full border border-[var(--border)] bg-transparent text-[var(--text-secondary)] text-base transition-all duration-200"
-              style={{ cursor: loading ? "wait" : "pointer", opacity: loading ? 0.5 : 1 }}
+              className="flex items-center justify-center w-9 h-9 rounded-full border border-[var(--border)] bg-transparent text-base transition-all duration-200"
+              style={{
+                cursor: loading ? "wait" : "pointer",
+                opacity: loading ? 0.5 : 1,
+                color: refreshed ? "var(--accent)" : "var(--text-secondary)",
+              }}
             >
               <span className={loading ? "animate-spin-slow inline-block" : "inline-block"}>
-                ↻
+                {refreshed ? "✓" : "↻"}
               </span>
             </button>
 
@@ -172,8 +184,8 @@ export default function NewsAggregator() {
               {showBookmarks ? "Saved Articles" : activeCatLabel}
             </h2>
             {lastUpdated && !showBookmarks && (
-              <p className="text-xs text-[var(--text-muted)] mt-1">
-                Updated {timeAgo(lastUpdated.toISOString())}
+              <p className="text-xs mt-1" style={{ color: refreshed ? "var(--accent)" : "var(--text-muted)" }}>
+                {refreshed ? "Updated just now" : `Updated ${timeAgo(lastUpdated.toISOString())}`}
               </p>
             )}
           </div>

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { CATEGORIES } from "@/lib/constants";
 import { timeAgo } from "@/lib/utils";
 import { useNewsLoader, useBookmarks, useTheme } from "@/lib/hooks";
 import ArticleCard from "./ArticleCard";
 import SkeletonCard from "./SkeletonCard";
 import ErrorState from "./ErrorState";
+import AuthButtons from "./AuthButtons";
 import type { CategoryId } from "@/lib/types";
-import { useState } from "react";
 
 // ─── Theme CSS Variables ────────────────────────────────
 
@@ -132,6 +132,8 @@ export default function NewsAggregator() {
             >
               {darkMode ? "☀" : "◑"}
             </button>
+
+            <AuthButtons />
           </div>
         </div>
 

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useAuth } from "@clerk/nextjs";
 import { CATEGORIES } from "@/lib/constants";
 import { timeAgo } from "@/lib/utils";
 import { useNewsLoader, useBookmarks, useTheme } from "@/lib/hooks";
 import ArticleCard from "./ArticleCard";
 import SkeletonCard from "./SkeletonCard";
 import ErrorState from "./ErrorState";
-import AuthButtons from "./AuthButtons";
-import type { CategoryId } from "@/lib/types";
+import AuthButtons, { clerkEnabled } from "./AuthButtons";
+import type { Article, CategoryId } from "@/lib/types";
 
 // ─── Theme CSS Variables ────────────────────────────────
 
@@ -44,6 +45,15 @@ const LIGHT_VARS = {
   "--pill-text": "#ffffff",
 } as React.CSSProperties;
 
+// ─── Clerk user ID (safe when ClerkProvider absent) ─────
+
+function useClerkUserId(): string | null {
+  if (!clerkEnabled) return null;
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { userId } = useAuth();
+  return userId;
+}
+
 // ─── Component ──────────────────────────────────────────
 
 export default function NewsAggregator() {
@@ -51,14 +61,36 @@ export default function NewsAggregator() {
   const [showBookmarks, setShowBookmarks] = useState(false);
 
   const [refreshed, setRefreshed] = useState(false);
+  const [bookmarkedArticles, setBookmarkedArticles] = useState<Article[]>([]);
+  const [loadingBookmarks, setLoadingBookmarks] = useState(false);
+
+  const userId = useClerkUserId();
 
   const { articles, loading, error, slow, lastUpdated, loadCategory } = useNewsLoader();
-  const { bookmarks, toggle: toggleBookmark, count: bookmarkCount } = useBookmarks();
+  const { bookmarks, toggle: toggleBookmark, count: bookmarkCount } = useBookmarks(userId);
   const { dark: darkMode, toggle: toggleDark } = useTheme();
 
   useEffect(() => {
     loadCategory(activeCategory);
   }, [activeCategory, loadCategory]);
+
+  // Fetch full bookmarked articles from DB when viewing bookmarks (signed in)
+  useEffect(() => {
+    if (!showBookmarks || !userId) {
+      setBookmarkedArticles([]);
+      return;
+    }
+    let cancelled = false;
+    setLoadingBookmarks(true);
+    fetch("/api/bookmarks?full=1")
+      .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then((data: { articles: Article[] }) => {
+        if (!cancelled) setBookmarkedArticles(data.articles);
+      })
+      .catch((err) => console.error("Failed to fetch bookmarked articles:", err))
+      .finally(() => { if (!cancelled) setLoadingBookmarks(false); });
+    return () => { cancelled = true; };
+  }, [showBookmarks, userId, bookmarks]);
 
   const handleRefresh = async () => {
     await loadCategory(activeCategory, true);
@@ -68,10 +100,14 @@ export default function NewsAggregator() {
 
   const currentArticles = useMemo(() => {
     if (showBookmarks) {
+      // Signed in: use server-fetched articles; signed out: filter loaded ones
+      if (userId && bookmarkedArticles.length > 0) {
+        return bookmarkedArticles;
+      }
       return Object.values(articles).flat().filter((a) => bookmarks.has(a.id));
     }
     return articles[activeCategory] || [];
-  }, [articles, activeCategory, showBookmarks, bookmarks]);
+  }, [articles, activeCategory, showBookmarks, bookmarks, userId, bookmarkedArticles]);
 
   const hasData = currentArticles.length > 0;
   const activeCatLabel = CATEGORIES.find((c) => c.id === activeCategory)?.label;
@@ -222,7 +258,7 @@ export default function NewsAggregator() {
         )}
 
         {/* Empty bookmarks */}
-        {showBookmarks && !hasData && !loading && (
+        {showBookmarks && !hasData && !loading && !loadingBookmarks && (
           <div className="text-center py-20 px-5 text-[var(--text-muted)]">
             <div className="text-5xl mb-4 opacity-30">☆</div>
             <p className="text-base font-semibold text-[var(--text-secondary)]">

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -51,4 +51,41 @@ export async function healthCheck(): Promise<boolean> {
   }
 }
 
+// ─── Bookmarks ─────────────────────────────────────────
+
+export async function getBookmarks(userId: string): Promise<string[]> {
+  const result = await pool.query<{ article_id: string }>(
+    "SELECT article_id FROM bookmarks WHERE user_id = $1 ORDER BY created_at DESC",
+    [userId]
+  );
+  return result.rows.map((r) => r.article_id);
+}
+
+export async function addBookmark(userId: string, articleId: string): Promise<void> {
+  await pool.query(
+    "INSERT INTO bookmarks (user_id, article_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+    [userId, articleId]
+  );
+}
+
+export async function removeBookmark(userId: string, articleId: string): Promise<void> {
+  await pool.query(
+    "DELETE FROM bookmarks WHERE user_id = $1 AND article_id = $2",
+    [userId, articleId]
+  );
+}
+
+export async function getBookmarkedArticles(userId: string): Promise<DbArticle[]> {
+  const result = await pool.query<DbArticle>(
+    `SELECT a.id, a.title, a.summary, a.source_url, a.source_name, a.image_url,
+            a.category, a.published_date, a.read_time, a.created_at
+     FROM articles a
+     JOIN bookmarks b ON b.article_id = a.id
+     WHERE b.user_id = $1
+     ORDER BY b.created_at DESC`,
+    [userId]
+  );
+  return result.rows;
+}
+
 export default pool;

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { STORAGE_KEYS, SLOW_THRESHOLD_MS, API_TIMEOUT_MS } from "./constants";
 import type { Article, ArticleCache, CategoryId, NewsApiResponse } from "./types";
 
@@ -28,23 +28,71 @@ function useLocalStorage<T>(key: string, initialValue: T): [T, (val: T | ((prev:
 
 // ─── useBookmarks ───────────────────────────────────────
 
-export function useBookmarks() {
-  const [ids, setIds] = useLocalStorage<string[]>(STORAGE_KEYS.bookmarks, []);
-  const bookmarkSet = new Set(ids);
+export function useBookmarks(userId?: string | null) {
+  // localStorage fallback for signed-out users
+  const [localIds, setLocalIds] = useLocalStorage<string[]>(STORAGE_KEYS.bookmarks, []);
+
+  // Server-synced state for signed-in users
+  const [serverIds, setServerIds] = useState<string[]>([]);
+  const [synced, setSynced] = useState(false);
+
+  const isSignedIn = !!userId;
+
+  // Fetch bookmarks from API on mount when signed in
+  useEffect(() => {
+    if (!isSignedIn) {
+      setSynced(false);
+      return;
+    }
+    let cancelled = false;
+    fetch("/api/bookmarks")
+      .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then((data: { ids: string[] }) => {
+        if (!cancelled) {
+          setServerIds(data.ids);
+          setSynced(true);
+        }
+      })
+      .catch((err) => console.error("Failed to fetch bookmarks:", err));
+    return () => { cancelled = true; };
+  }, [isSignedIn]);
+
+  const ids = isSignedIn && synced ? serverIds : localIds;
+  const bookmarkSet = useMemo(() => new Set(ids), [ids]);
 
   const toggle = useCallback(
     (id: string) => {
-      setIds((prev) => {
-        const set = new Set(prev);
-        if (set.has(id)) {
-          set.delete(id);
-        } else {
-          set.add(id);
-        }
-        return [...set];
-      });
+      if (isSignedIn) {
+        // Optimistic update
+        setServerIds((prev) => {
+          const set = new Set(prev);
+          const removing = set.has(id);
+          if (removing) {
+            set.delete(id);
+          } else {
+            set.add(id);
+          }
+          // Fire API call in background
+          fetch("/api/bookmarks", {
+            method: removing ? "DELETE" : "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ articleId: id }),
+          }).catch((err) => console.error("Bookmark sync error:", err));
+          return [...set];
+        });
+      } else {
+        setLocalIds((prev) => {
+          const set = new Set(prev);
+          if (set.has(id)) {
+            set.delete(id);
+          } else {
+            set.add(id);
+          }
+          return [...set];
+        });
+      }
     },
-    [setIds]
+    [isSignedIn, setLocalIds]
   );
 
   return { bookmarks: bookmarkSet, toggle, count: ids.length };

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,20 @@
+import { clerkMiddleware } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const clerkPk = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+const clerkEnabled = !!clerkPk && clerkPk.startsWith("pk_");
+
+const clerk = clerkEnabled ? clerkMiddleware() : undefined;
+
+export default function middleware(request: NextRequest) {
+  if (clerk) return clerk(request, {} as any);
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    "/(api|trpc)(.*)",
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.80.0",
+        "@clerk/nextjs": "^7.0.7",
         "next": "^15.1.0",
         "pg": "^8.20.0",
         "react": "^19.0.0",
@@ -598,6 +599,87 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@clerk/backend": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.3.tgz",
+      "integrity": "sha512-I3YLnSioYFG+EVFBYm0ilN28+FC8H+hkqMgB5Pdl7AcotQOn3JhiZMqLel2H0P390p8FEJKQNnrvXk3BemeKKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.3.2",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      }
+    },
+    "node_modules/@clerk/nextjs": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.0.7.tgz",
+      "integrity": "sha512-Iqg4q0ns1LZZrAdC66r/QUFMY+Rs3HAJcAb/IR0uFBj7ZAZusxdVKMmNkZP9UP6sk3OOorCsJTdE0rTMoXD2YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^3.2.3",
+        "@clerk/react": "^6.1.3",
+        "@clerk/shared": "^4.3.2",
+        "server-only": "0.0.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "next": "^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0",
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/react": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.1.3.tgz",
+      "integrity": "sha512-9t5C8eM5cTmOmpBO5nb8FDA40biQqeQLUW+cVwAE0t5hnGRwiC6mSv83vqHg+9qQBqtliR013BGVjpCz53gVCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.3.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.3.2.tgz",
+      "integrity": "sha512-tYYzdY4Fxb02TO4RHoLRFzEjXJn0iFDfoKhWtGyqf2AaIgkprTksunQtX0hnVssHMr3XD/E2S00Vrb+PzX3jCQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.16",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -2058,6 +2140,12 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2065,6 +2153,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.16",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
+      "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -4226,7 +4324,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5165,6 +5262,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5516,6 +5619,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/globals": {
       "version": "14.0.0",
@@ -7355,6 +7464,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -9213,6 +9331,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -9505,6 +9629,22 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
+    "@clerk/nextjs": "^7.0.7",
     "next": "^15.1.0",
     "pg": "^8.20.0",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary
- **Clerk auth integration** with graceful degradation — app works identically with or without Clerk keys configured
- **Bookmark sync to Postgres** — signed-in users get server-persisted bookmarks with optimistic updates; signed-out users keep localStorage fallback
- **UX improvements**: refresh button shows checkmark + "Updated just now" flash, hydration mismatch fix

## Changes
- `components/AuthButtons.tsx` — Clerk sign-in/sign-out UI, conditional on valid key
- `components/NewsAggregator.tsx` — userId passed to useBookmarks, bookmarked articles fetched from DB
- `lib/hooks.ts` — dual-mode useBookmarks (API + localStorage)
- `lib/db.ts` — bookmark DB functions (get/add/remove/getArticles)
- `app/api/bookmarks/route.ts` — GET/POST/DELETE endpoints, auth-gated
- `middleware.ts`, `app/sign-in/`, `app/sign-up/` — Clerk routing

## Test plan
- [x] Signed out: bookmarks work via localStorage as before
- [x] Signed in: bookmark an article → verify in DB
- [x] Signed in: refresh page → bookmarks persist
- [x] Signed in: bookmarks tab shows full articles from DB
- [x] App works with no Clerk keys configured
- [x] `npm test` passes (39 tests)

