### PR TITLE
Add SSE streaming, visual identity, and 3 new categories

### DIFF
--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -6,6 +6,7 @@ import type { CategoryId, Article, NewsApiResponse, NewsApiError } from "@/lib/t
 
 const VALID_CATEGORIES = new Set<string>([
   "top", "technology", "business", "science", "energy", "world", "health",
+  "politics", "sports", "entertainment",
 ]);
 
 // ─── Route Handler ──────────────────────────────────────

--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
 import { searchArticlesByEmbedding, insertArticle } from "@/lib/db";
 import { stableHash, estimateReadTime } from "@/lib/utils";
-import type { Article, CategoryId, TopicSearchResponse } from "@/lib/types";
+import type { Article, CategoryId } from "@/lib/types";
 
 const SIMILARITY_THRESHOLD = 0.35;
 const MIN_STRONG_RESULTS = 3;
@@ -103,7 +103,15 @@ function setCachedEmbedding(query: string, embedding: number[]) {
   embeddingCache.set(query.toLowerCase(), { embedding, ts: Date.now() });
 }
 
-// ─── Route Handler ──────────────────────────────────────
+// ─── SSE Helpers ────────────────────────────────────────
+
+const encoder = new TextEncoder();
+
+function sseEvent(event: string, data: unknown): Uint8Array {
+  return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+// ─── Route Handler (SSE streaming) ─────────────────────
 
 export async function GET(request: NextRequest) {
   const query = request.nextUrl.searchParams.get("q")?.trim();
@@ -115,74 +123,101 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  try {
-    // 1. Embed the query (with cache)
-    let embedding = getCachedEmbedding(query);
-    if (!embedding) {
-      embedding = await embedQuery(query);
-      setCachedEmbedding(query, embedding);
-    }
+  const stream = new ReadableStream({
+    async start(controller) {
+      let totalArticles = 0;
+      let fallbackUsed = false;
 
-    // 2. Vector similarity search in Postgres
-    const rows = await searchArticlesByEmbedding(
-      embedding,
-      SIMILARITY_THRESHOLD,
-      MAX_RESULTS
-    );
-
-    // 3. Map DB rows to Article type
-    const articles: Article[] = rows.map((row) => ({
-      id: row.id,
-      title: row.title,
-      summary: row.summary || "",
-      sourceUrl: row.source_url,
-      sourceName: row.source_name,
-      publishedDate: row.published_date
-        ? row.published_date.toISOString()
-        : null,
-      imageUrl: row.image_url,
-      category: row.category as CategoryId,
-      readTime: row.read_time || 1,
-    }));
-
-    // 4. If < 3 results, run Claude web_search (blocking)
-    //    Wait for results so the user sees them immediately
-    let fallbackUsed = false;
-    let allArticles = articles;
-
-    if (articles.length < MIN_STRONG_RESULTS) {
-      fallbackUsed = true;
       try {
-        const fallbackArticles = await webSearchFallback(query);
-        // Combine: vector results first, then fallback (deduped by id)
-        const seenIds = new Set(articles.map((a) => a.id));
-        for (const a of fallbackArticles) {
-          if (!seenIds.has(a.id)) {
-            allArticles.push(a);
-            seenIds.add(a.id);
+        // 1. Embed the query (with cache)
+        let embedding = getCachedEmbedding(query);
+        if (!embedding) {
+          embedding = await embedQuery(query);
+          setCachedEmbedding(query, embedding);
+        }
+
+        // 2. Vector similarity search in Postgres
+        const rows = await searchArticlesByEmbedding(
+          embedding,
+          SIMILARITY_THRESHOLD,
+          MAX_RESULTS
+        );
+
+        // 3. Map DB rows to Article type
+        const articles: Article[] = rows.map((row) => ({
+          id: row.id,
+          title: row.title,
+          summary: row.summary || "",
+          sourceUrl: row.source_url,
+          sourceName: row.source_name,
+          publishedDate: row.published_date
+            ? row.published_date.toISOString()
+            : null,
+          imageUrl: row.image_url,
+          category: row.category as CategoryId,
+          readTime: row.read_time || 1,
+        }));
+
+        // 4. Stream vector results immediately
+        if (articles.length > 0) {
+          controller.enqueue(
+            sseEvent("results", { articles, source: "vector" })
+          );
+        }
+        totalArticles = articles.length;
+
+        // 5. If < 3 results, run Claude web_search fallback
+        if (articles.length < MIN_STRONG_RESULTS) {
+          fallbackUsed = true;
+          controller.enqueue(sseEvent("fallback-start", {}));
+
+          try {
+            const fallbackArticles = await webSearchFallback(query);
+            // Dedupe against vector results
+            const seenIds = new Set(articles.map((a) => a.id));
+            const newArticles = fallbackArticles.filter(
+              (a) => !seenIds.has(a.id)
+            );
+
+            if (newArticles.length > 0) {
+              controller.enqueue(
+                sseEvent("results", {
+                  articles: newArticles,
+                  source: "web-search",
+                })
+              );
+              totalArticles += newArticles.length;
+            }
+          } catch (err) {
+            console.error("Web search fallback error:", err);
           }
         }
+
+        // 6. Done
+        const matchQuality: "strong" | "weak" =
+          totalArticles >= MIN_STRONG_RESULTS ? "strong" : "weak";
+
+        controller.enqueue(
+          sseEvent("done", { matchQuality, fallbackUsed, query })
+        );
       } catch (err) {
-        console.error("Web search fallback error:", err);
+        console.error("Topic search error:", err);
+        controller.enqueue(
+          sseEvent("error", { message: String(err) })
+        );
+      } finally {
+        controller.close();
       }
-    }
+    },
+  });
 
-    const matchQuality: "strong" | "weak" =
-      allArticles.length >= MIN_STRONG_RESULTS ? "strong" : "weak";
-
-    return NextResponse.json<TopicSearchResponse>({
-      articles: allArticles,
-      matchQuality,
-      fallbackUsed,
-      query,
-    });
-  } catch (err) {
-    console.error("Topic search error:", err);
-    return NextResponse.json(
-      { error: "Search failed", details: String(err) },
-      { status: 500 }
-    );
-  }
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
 }
 
 // ─── Voyage AI Embedding ────────────────────────────────

--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -14,7 +14,7 @@ const CATEGORY_DESCRIPTIONS: Record<string, string> = {
   technology:
     "Technology news: software engineering, hardware devices, artificial intelligence, machine learning, programming, cybersecurity, tech startups, smartphones, cloud computing, robotics, semiconductors",
   business:
-    "Business and finance news: stock market, corporate earnings, mergers, venture capital, banking, real estate, retail sales, employment, GDP, inflation, Federal Reserve",
+    "Wall Street and finance news: stock market, corporate earnings, mergers and acquisitions, IPOs, venture capital, banking, interest rates, Federal Reserve, employment data, GDP, inflation, corporate strategy, trade policy, institutional investing",
   science:
     "Scientific research: physics, chemistry, biology, space exploration, NASA, astronomy, peer-reviewed papers, laboratory research, geology, paleontology",
   energy:
@@ -23,8 +23,14 @@ const CATEGORY_DESCRIPTIONS: Record<string, string> = {
     "International news: foreign affairs, diplomacy, wars, military conflicts, international elections, government policy, immigration, United Nations, human rights, sanctions",
   health:
     "Health and medicine: medical research, clinical trials, disease outbreaks, pharmaceuticals, mental health, nutrition, vaccines, public health, FDA approvals",
+  politics:
+    "Politics: elections, voting, political parties, legislation, Congress, Senate, governors, campaigns, lobbying, political debate, government policy, Supreme Court, executive orders",
+  sports:
+    "Sports news: NFL, NBA, MLB, NHL, soccer, tennis, golf, Olympics, college sports, esports, player trades, game results, championships, athletics",
+  entertainment:
+    "Entertainment news: movies, TV shows, streaming, music, celebrities, awards, box office, concerts, video games, books, theater, pop culture, Hollywood, consumer product launches, brand collaborations, viral consumer trends",
   top:
-    "General interest: breaking news, popular culture, entertainment, celebrity, lifestyle, music, movies, sports, food, travel, arts, fashion, viral stories",
+    "General interest: breaking news, cross-cutting stories that transcend a single topic, lifestyle, food, travel, arts, fashion, viral stories",
 };
 
 let categoryEmbeddingsCache: { embeddings: number[][]; categories: string[] } | null = null;

--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -1,0 +1,35 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#6366f1",
+          borderRadius: 36,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 120,
+            fontWeight: 700,
+            color: "#fff",
+            fontFamily: "Georgia, serif",
+            lineHeight: 1,
+          }}
+        >
+          S
+        </span>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,8 +5,10 @@
 /* ─── Google Fonts ─────────────────────────────────────── */
 @import url("https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700;800;900&family=Source+Sans+3:wght@300;400;500;600;700&display=swap");
 
-/* ─── CSS Variable Defaults (dark) ─────────────────────── */
-:root {
+/* ─── Theme Variables ─────────────────────────────────── */
+/* Default: dark (matches server render and blocking script default) */
+:root,
+html[data-theme="dark"] {
   --bg: #0a0a0f;
   --card-bg: #16161f;
   --text: #eeeef0;
@@ -20,6 +22,22 @@
   --nav-bg: rgba(14, 14, 22, 0.92);
   --pill-active: #6366f1;
   --pill-text: #eeeef0;
+}
+
+html[data-theme="light"] {
+  --bg: #f5f3f0;
+  --card-bg: #ffffff;
+  --text: #1a1a1a;
+  --text-secondary: #555566;
+  --text-muted: #8888a0;
+  --border: #e0ddd8;
+  --shadow: rgba(0, 0, 0, 0.06);
+  --shadow-hover: rgba(0, 0, 0, 0.12);
+  --skeleton: #e8e5e0;
+  --accent: #4f46e5;
+  --nav-bg: rgba(245, 243, 240, 0.92);
+  --pill-active: #1a1a1a;
+  --pill-text: #ffffff;
 }
 
 /* ─── Base Reset ───────────────────────────────────────── */

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,0 +1,35 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 32, height: 32 };
+export const contentType = "image/png";
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#6366f1",
+          borderRadius: 6,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 22,
+            fontWeight: 700,
+            color: "#fff",
+            fontFamily: "Georgia, serif",
+            lineHeight: 1,
+          }}
+        >
+          S
+        </span>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,13 +3,30 @@ import { ClerkProvider } from "@clerk/nextjs";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Sift — AI-Curated News",
+  title: {
+    default: "Sift — AI-Curated News, Already Read for You",
+    template: "%s | Sift",
+  },
   description:
-    "Stay informed with AI-curated news summaries across the topics you care about.",
+    "AI-curated news summaries from 100+ sources across technology, business, science, energy, world, and health. Updated every 10 minutes.",
+  metadataBase: new URL("https://siftnews.ai"),
   openGraph: {
-    title: "Sift",
-    description: "AI-curated news powered by Claude",
+    title: "Sift — AI-Curated News",
+    description:
+      "AI-curated news summaries from 100+ sources. Get the key points in 60 seconds.",
+    siteName: "Sift",
     type: "website",
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Sift — AI-Curated News",
+    description:
+      "AI-curated news summaries from 100+ sources. Get the key points in 60 seconds.",
+  },
+  other: {
+    "theme-color": "#0a0a0f",
+    "color-scheme": "dark light",
   },
 };
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,13 +33,20 @@ export const metadata: Metadata = {
 const clerkPk = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
 const clerkEnabled = !!clerkPk && clerkPk.startsWith("pk_");
 
+// Blocking script that sets data-theme on <html> before first paint.
+// Reads from localStorage; defaults to "dark" if unset.
+const themeScript = `(function(){try{var t=JSON.parse(localStorage.getItem("sift-theme"));document.documentElement.dataset.theme=t===false?"light":"dark"}catch(e){document.documentElement.dataset.theme="dark"}})()`;
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   const inner = (
-    <html lang="en">
+    <html lang="en" data-theme="dark" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+      </head>
       <body>
         <a href="#main-content" className="skip-nav">
           Skip to content

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Sift — AI-Curated News",
+    short_name: "Sift",
+    start_url: "/news",
+    display: "standalone",
+    background_color: "#0a0a0f",
+    theme_color: "#6366f1",
+    icons: [
+      { src: "/favicon.svg", sizes: "any", type: "image/svg+xml" },
+    ],
+  };
+}

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import NewsAggregator from "@/components/NewsAggregator";
 
 export const metadata: Metadata = {
-  title: "News — Sift",
+  title: "News",
   description:
     "AI-curated news summaries across technology, business, science, energy, world, and health.",
 };

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,75 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "Sift — AI-Curated News";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OGImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#0a0a0f",
+          fontFamily: "Georgia, serif",
+        }}
+      >
+        {/* Accent line */}
+        <div
+          style={{
+            width: 60,
+            height: 4,
+            background: "#6366f1",
+            borderRadius: 2,
+            marginBottom: 32,
+          }}
+        />
+
+        {/* Wordmark */}
+        <span
+          style={{
+            fontSize: 96,
+            fontWeight: 700,
+            color: "#ffffff",
+            lineHeight: 1,
+            letterSpacing: "-0.02em",
+          }}
+        >
+          Sift
+        </span>
+
+        {/* Tagline */}
+        <span
+          style={{
+            fontSize: 28,
+            color: "rgba(255,255,255,0.6)",
+            marginTop: 20,
+            fontFamily: "sans-serif",
+            fontWeight: 400,
+          }}
+        >
+          AI-Curated News, Already Read for You
+        </span>
+
+        {/* Stats line */}
+        <span
+          style={{
+            fontSize: 16,
+            color: "rgba(255,255,255,0.3)",
+            marginTop: 40,
+            fontFamily: "sans-serif",
+            letterSpacing: "0.05em",
+          }}
+        >
+          100+ sources &middot; 7 categories &middot; Updated every 10 min
+        </span>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import LandingPage from "@/components/LandingPage";
 
 export const metadata: Metadata = {
-  title: "Sift — AI-Curated News, Already Read for You",
+  title: {
+    absolute: "Sift — AI-Curated News, Already Read for You",
+  },
   description:
     "AI-curated news summaries from 100+ sources across technology, business, science, energy, world, and health. Updated every 10 minutes.",
 };

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -17,9 +17,9 @@ const FEATURES = [
   },
   {
     icon: "◆",
-    title: "7 Categories",
+    title: "10 Categories",
     description:
-      "Technology, business, science, energy, world news, health — plus curated top stories.",
+      "Technology, business, science, energy, world news, health, politics, sports, entertainment — plus curated top stories.",
     accent: "#dc2626",
   },
   {
@@ -166,7 +166,7 @@ export default function LandingPage() {
           <span className="opacity-30">&middot;</span>
           <span>Updated every 10 min</span>
           <span className="opacity-30">&middot;</span>
-          <span>7 categories</span>
+          <span>10 categories</span>
         </div>
         <Link
           href="/news"
@@ -246,7 +246,7 @@ export default function LandingPage() {
       {/* ── Category Showcase ─────────────────────── */}
       <section className="max-w-[1200px] mx-auto px-6 pb-20">
         <h2 className="font-heading text-2xl font-bold text-center text-[var(--text)] mb-8">
-          7 categories, 100+ sources
+          10 categories, 100+ sources
         </h2>
         <div className="flex flex-wrap justify-center gap-2 mb-6">
           {CATEGORIES.map((cat) => {
@@ -274,6 +274,9 @@ export default function LandingPage() {
           · CleanTechnica · Electrek · Canary Media · Carbon Brief · Grist · Inside Climate News
           · Al Jazeera · The Guardian · DW News · France 24 · South China Morning Post · Foreign Policy
           · STAT News · WHO · The BMJ · NIH · The Lancet · Medscape
+          · Politico · The Hill · FiveThirtyEight · RealClearPolitics
+          · ESPN · BBC Sport · The Athletic · CBS Sports · Sports Illustrated
+          · Variety · Hollywood Reporter · Deadline · Rolling Stone · Pitchfork · IGN
           · Vox · The Atlantic · ProPublica · Rest of World · and more
         </p>
       </section>

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import Link from "next/link";
-import { CATEGORIES, CATEGORY_COLORS, DARK_VARS, LIGHT_VARS } from "@/lib/constants";
+import { CATEGORIES, CATEGORY_COLORS } from "@/lib/constants";
 import { useTheme } from "@/lib/hooks";
 import type { CategoryId } from "@/lib/types";
 
@@ -94,18 +93,12 @@ const ARCHITECTURE_POINTS = [
 // ─── Component ──────────────────────────────────────────
 
 export default function LandingPage() {
-  const { dark: darkMode, toggle: toggleDark } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => setMounted(true), []);
-
-  const themeVars = darkMode ? DARK_VARS : LIGHT_VARS;
+  const { dark: darkMode, toggle: toggleDark, mounted } = useTheme();
 
   return (
     <div
       id="main-content"
       style={{
-        ...themeVars,
         background: "var(--bg)",
         color: "var(--text)",
         minHeight: "100vh",

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
-import { CATEGORIES, DARK_VARS, LIGHT_VARS } from "@/lib/constants";
+import { CATEGORIES } from "@/lib/constants";
 import { timeAgo } from "@/lib/utils";
 import { useNewsLoader, useBookmarks, useTheme, useTopicSearch, useCompare } from "@/lib/hooks";
 import ArticleCard from "./ArticleCard";
@@ -39,7 +39,7 @@ export default function NewsAggregator() {
 
   const { articles, loading, error, slow, lastUpdated, loadCategory } = useNewsLoader();
   const { bookmarks, toggle: toggleBookmark, count: bookmarkCount } = useBookmarks(userId);
-  const { dark: darkMode, toggle: toggleDark } = useTheme();
+  const { dark: darkMode, toggle: toggleDark, mounted } = useTheme();
   const {
     articles: topicArticles,
     loading: topicLoading,
@@ -128,7 +128,6 @@ export default function NewsAggregator() {
     <div
       className="min-h-screen font-body"
       style={{
-        ...(darkMode ? DARK_VARS : LIGHT_VARS),
         background: "var(--bg)",
         color: "var(--text)",
       }}
@@ -225,13 +224,15 @@ export default function NewsAggregator() {
               </span>
             </button>
 
-            <button
-              onClick={toggleDark}
-              aria-label={darkMode ? "Switch to light mode" : "Switch to dark mode"}
-              className="flex items-center justify-center w-9 h-9 rounded-full border border-[var(--border)] bg-transparent text-[var(--text-secondary)] text-base cursor-pointer transition-all duration-200"
-            >
-              {darkMode ? "☀" : "◑"}
-            </button>
+            {mounted && (
+              <button
+                onClick={toggleDark}
+                aria-label={darkMode ? "Switch to light mode" : "Switch to dark mode"}
+                className="flex items-center justify-center w-9 h-9 rounded-full border border-[var(--border)] bg-transparent text-[var(--text-secondary)] text-base cursor-pointer transition-all duration-200"
+              >
+                {darkMode ? "☀" : "◑"}
+              </button>
+            )}
 
             <AuthButtons />
           </div>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,4 +1,3 @@
-import type React from "react";
 import type { Category, CategoryId } from "./types";
 
 // ─── Categories ─────────────────────────────────────────
@@ -39,40 +38,6 @@ export const GRADIENTS: Record<CategoryId, string> = {
   world: "linear-gradient(135deg, #1f1408 0%, #2a1f0a 50%, #3d2a0f 100%)",
   health: "linear-gradient(135deg, #200a1a 0%, #2e1525 50%, #3d0f2a 100%)",
 };
-
-// ─── Theme Variables ────────────────────────────────────
-
-export const DARK_VARS = {
-  "--bg": "#0a0a0f",
-  "--card-bg": "#16161f",
-  "--text": "#eeeef0",
-  "--text-secondary": "#9d9daa",
-  "--text-muted": "#5a5a6e",
-  "--border": "#222233",
-  "--shadow": "rgba(0,0,0,0.4)",
-  "--shadow-hover": "rgba(0,0,0,0.6)",
-  "--skeleton": "#1e1e2a",
-  "--accent": "#6366f1",
-  "--nav-bg": "rgba(14,14,22,0.92)",
-  "--pill-active": "#6366f1",
-  "--pill-text": "#eeeef0",
-} as React.CSSProperties;
-
-export const LIGHT_VARS = {
-  "--bg": "#f5f3f0",
-  "--card-bg": "#ffffff",
-  "--text": "#1a1a1a",
-  "--text-secondary": "#555566",
-  "--text-muted": "#8888a0",
-  "--border": "#e0ddd8",
-  "--shadow": "rgba(0,0,0,0.06)",
-  "--shadow-hover": "rgba(0,0,0,0.12)",
-  "--skeleton": "#e8e5e0",
-  "--accent": "#4f46e5",
-  "--nav-bg": "rgba(245,243,240,0.92)",
-  "--pill-active": "#1a1a1a",
-  "--pill-text": "#ffffff",
-} as React.CSSProperties;
 
 // ─── Timing ─────────────────────────────────────────────
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -10,10 +10,14 @@ export const CATEGORIES: Category[] = [
   { id: "energy", label: "Energy", icon: "⚡" },
   { id: "world", label: "World", icon: "◐" },
   { id: "health", label: "Health", icon: "✦" },
+  { id: "politics", label: "Politics", icon: "⚖" },
+  { id: "sports", label: "Sports", icon: "⬢" },
+  { id: "entertainment", label: "Entertainment", icon: "♦" },
 ];
 
 export const VALID_CATEGORIES = new Set<CategoryId>([
   "top", "technology", "business", "science", "energy", "world", "health",
+  "politics", "sports", "entertainment",
 ]);
 
 // ─── Colors ─────────────────────────────────────────────
@@ -27,6 +31,9 @@ export const CATEGORY_COLORS: Record<CategoryId, { hex: string; rgb: string }> =
   energy:     { hex: "#ea580c", rgb: "234,88,12" },
   world:      { hex: "#d97706", rgb: "217,119,6" },
   health:     { hex: "#db2777", rgb: "219,39,119" },
+  politics:   { hex: "#6366f1", rgb: "99,102,241" },
+  sports:     { hex: "#0891b2", rgb: "8,145,178" },
+  entertainment: { hex: "#e11d48", rgb: "225,29,72" },
 };
 
 export const GRADIENTS: Record<CategoryId, string> = {
@@ -37,6 +44,9 @@ export const GRADIENTS: Record<CategoryId, string> = {
   energy: "linear-gradient(135deg, #1f1008 0%, #2a1a0a 50%, #3d1f0f 100%)",
   world: "linear-gradient(135deg, #1f1408 0%, #2a1f0a 50%, #3d2a0f 100%)",
   health: "linear-gradient(135deg, #200a1a 0%, #2e1525 50%, #3d0f2a 100%)",
+  politics: "linear-gradient(135deg, #0f0f2e 0%, #1a1a4e 50%, #1e1e5f 100%)",
+  sports: "linear-gradient(135deg, #0a1a20 0%, #0f2a35 50%, #0a3040 100%)",
+  entertainment: "linear-gradient(135deg, #200a15 0%, #2e1020 50%, #3d0f25 100%)",
 };
 
 // ─── Timing ─────────────────────────────────────────────

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -2,28 +2,39 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { STORAGE_KEYS, SLOW_THRESHOLD_MS, API_TIMEOUT_MS } from "./constants";
-import type { Article, ArticleCache, CategoryId, NewsApiResponse, TopicSearchResponse, CompareResponse, CompareClaim } from "./types";
+import type { Article, ArticleCache, CategoryId, NewsApiResponse, CompareResponse, CompareClaim, SSEResultsEvent, SSEDoneEvent, SSEErrorEvent } from "./types";
+import { readSSE } from "./sse";
 
 // ─── useLocalStorage ────────────────────────────────────
 
 function useLocalStorage<T>(key: string, initialValue: T): [T, (val: T | ((prev: T) => T)) => void] {
-  const [stored, setStored] = useState<T>(() => {
-    if (typeof window === "undefined") return initialValue;
-    try {
-      const item = localStorage.getItem(key);
-      return item ? JSON.parse(item) : initialValue;
-    } catch {
-      return initialValue;
-    }
-  });
+  // Always initialize with default to avoid SSR/client hydration mismatch.
+  // localStorage is read in useEffect after hydration.
+  const [stored, setStored] = useState<T>(initialValue);
 
+  // Sync from localStorage after hydration (client-only)
   useEffect(() => {
     try {
-      localStorage.setItem(key, JSON.stringify(stored));
+      const item = localStorage.getItem(key);
+      if (item !== null) setStored(JSON.parse(item));
     } catch {}
-  }, [key, stored]);
+  }, [key]);
 
-  return [stored, setStored];
+  // Custom setter that also persists to localStorage
+  const setValue = useCallback(
+    (val: T | ((prev: T) => T)) => {
+      setStored((prev) => {
+        const next = val instanceof Function ? val(prev) : val;
+        try {
+          localStorage.setItem(key, JSON.stringify(next));
+        } catch {}
+        return next;
+      });
+    },
+    [key]
+  );
+
+  return [stored, setValue];
 }
 
 // ─── useBookmarks ───────────────────────────────────────
@@ -101,9 +112,30 @@ export function useBookmarks(userId?: string | null) {
 // ─── useTheme ───────────────────────────────────────────
 
 export function useTheme() {
-  const [dark, setDark] = useLocalStorage(STORAGE_KEYS.theme, true);
-  const toggle = useCallback(() => setDark((d) => !d), [setDark]);
-  return { dark, toggle };
+  // Always initialize as dark to match server render — prevents hydration mismatch.
+  // The blocking script in <head> already set the correct data-theme on <html>,
+  // so CSS variables are correct from first paint. This state only drives the toggle icon.
+  const [dark, setDark] = useState(true);
+  const [mounted, setMounted] = useState(false);
+
+  // After hydration, read actual theme from the DOM (set by blocking script)
+  useEffect(() => {
+    setDark(document.documentElement.dataset.theme !== "light");
+    setMounted(true);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setDark((prev) => {
+      const next = !prev;
+      document.documentElement.dataset.theme = next ? "dark" : "light";
+      try {
+        localStorage.setItem(STORAGE_KEYS.theme, JSON.stringify(next));
+      } catch {}
+      return next;
+    });
+  }, []);
+
+  return { dark, toggle, mounted };
 }
 
 // ─── useNewsLoader ──────────────────────────────────────
@@ -203,7 +235,7 @@ export function useNewsLoader() {
   return { ...state, loadCategory };
 }
 
-// ─── useTopicSearch ──────────────────────────────────────
+// ─── useTopicSearch (SSE streaming) ─────────────────────
 
 const TOPIC_TIMEOUT_MS = 45_000; // Longer — Claude web search fallback can take 15-20s
 
@@ -262,27 +294,74 @@ export function useTopicSearch() {
         throw new Error(body.error || `HTTP ${res.status}`);
       }
 
-      const data: TopicSearchResponse = await res.json();
+      // Consume SSE stream — articles arrive incrementally
+      let receivedAny = false;
+      for await (const { event, data } of readSSE(res)) {
+        if (controller.signal.aborted) break;
 
-      if (data.articles.length === 0) {
-        throw new Error("No articles found for this topic. Try a different search.");
+        switch (event) {
+          case "results": {
+            const d = data as SSEResultsEvent;
+            receivedAny = receivedAny || d.articles.length > 0;
+            setState((s) => ({
+              ...s,
+              articles: [...s.articles, ...d.articles],
+              slow: false, // Got results, clear slow indicator
+            }));
+            break;
+          }
+          case "fallback-start":
+            // Keep loading, reset slow timer for fallback phase
+            setState((s) => ({ ...s, slow: false }));
+            clearTimeout(slowTimer);
+            setTimeout(
+              () => setState((s) => (s.loading ? { ...s, slow: true } : s)),
+              SLOW_THRESHOLD_MS
+            );
+            break;
+          case "done": {
+            const d = data as SSEDoneEvent;
+            setState((s) => ({
+              ...s,
+              loading: false,
+              slow: false,
+              matchQuality: d.matchQuality,
+              fallbackUsed: d.fallbackUsed,
+            }));
+            break;
+          }
+          case "error": {
+            const d = data as SSEErrorEvent;
+            setState((s) => ({
+              ...s,
+              loading: false,
+              slow: false,
+              error: d.message,
+            }));
+            break;
+          }
+        }
       }
 
-      setState({
-        articles: data.articles,
-        loading: false,
-        error: null,
-        slow: false,
-        matchQuality: data.matchQuality,
-        fallbackUsed: data.fallbackUsed,
-        query,
-      });
+      // If stream ended without any articles
+      if (!receivedAny) {
+        setState((s) =>
+          s.loading
+            ? {
+                ...s,
+                loading: false,
+                slow: false,
+                error: "No articles found for this topic. Try a different search.",
+              }
+            : s
+        );
+      }
     } catch (err: unknown) {
       if (err instanceof DOMException && err.name === "AbortError") {
         setState((s) => ({
           ...s,
           loading: false,
-          error: "Search timed out. Try a simpler query.",
+          error: s.articles.length > 0 ? null : "Search timed out. Try a simpler query.",
           slow: false,
         }));
         return;

--- a/lib/sse.ts
+++ b/lib/sse.ts
@@ -1,0 +1,46 @@
+/**
+ * Parse Server-Sent Events from a fetch Response stream.
+ * Yields {event, data} objects as they arrive.
+ */
+export async function* readSSE<T = unknown>(
+  response: Response,
+): AsyncGenerator<{ event: string; data: T }> {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      // Split on double-newline (SSE event boundary)
+      const parts = buffer.split("\n\n");
+      // Last element is incomplete — keep it in the buffer
+      buffer = parts.pop()!;
+
+      for (const part of parts) {
+        if (!part.trim()) continue;
+        let event = "message";
+        let dataStr = "";
+        for (const line of part.split("\n")) {
+          if (line.startsWith("event: ")) {
+            event = line.slice(7);
+          } else if (line.startsWith("data: ")) {
+            dataStr += line.slice(6);
+          }
+        }
+        if (dataStr) {
+          try {
+            yield { event, data: JSON.parse(dataStr) as T };
+          } catch {
+            // Skip malformed JSON
+          }
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,7 +7,10 @@ export type CategoryId =
   | "science"
   | "energy"
   | "world"
-  | "health";
+  | "health"
+  | "politics"
+  | "sports"
+  | "entertainment";
 
 export interface Category {
   id: CategoryId;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -66,6 +66,23 @@ export interface CompareResponse {
   duration_ms: number;
 }
 
+// ─── SSE Event Types (topic search streaming) ──────────
+
+export interface SSEResultsEvent {
+  articles: Article[];
+  source: "vector" | "web-search";
+}
+
+export interface SSEDoneEvent {
+  matchQuality: "strong" | "weak";
+  fallbackUsed: boolean;
+  query: string;
+}
+
+export interface SSEErrorEvent {
+  message: string;
+}
+
 // ─── Component Props ────────────────────────────────────
 
 export interface ArticleCardProps {

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle"
+        font-family="Georgia, 'Times New Roman', serif" font-weight="700"
+        font-size="26" fill="#6366f1">S</text>
+</svg>


### PR DESCRIPTION
## Summary
- **T10**: Favicon (SVG + PNG), Apple touch icon, OG image, web manifest, and full metadata in layout.tsx
- **T2**: SSE streaming for topic search — vector results appear in <500ms, Claude web search fallback streams incrementally
- **Theme fix**: Blocking script in `<head>` prevents flash on refresh; hydration-safe `useTheme` hook with `mounted` guard
- **3 new categories**: Politics, Sports, Entertainment — types, constants, colors, gradients, API validation, classification prompts, and landing page copy updated (7 → 10)
- **Business classification tuned**: Scoped to Wall Street/finance; consumer/pop-culture stories route to entertainment
- **Reclassified 965 existing articles** using updated category embeddings

## Test plan
- [ ] Verify favicon renders in browser tab
- [ ] Verify OG image at `/opengraph-image`
- [ ] Search a common topic — vector results appear instantly
- [ ] Search a niche topic — fallback-start then web results stream in
- [ ] Toggle light/dark mode, refresh — no flash
- [ ] Browse all 10 category tabs — articles load correctly
- [ ] Check business tab has finance-focused content, not consumer/entertainment stories

