### PR TITLE
Add CI workflow and production deployment config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  typecheck-test:
+    name: Type Check & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: npm test -- --ci --coverage

--- a/app/api/cron/refresh/route.ts
+++ b/app/api/cron/refresh/route.ts
@@ -20,9 +20,7 @@ export async function GET(request: NextRequest) {
         "Content-Type": "application/json",
         "X-Pipeline-Key": SIFT_API_KEY,
       },
-      body: JSON.stringify({
-        categories: ["top", "technology", "business", "science", "energy", "world", "health"],
-      }),
+      body: JSON.stringify({}),
       signal: AbortSignal.timeout(300_000), // 5 min timeout for full pipeline
     });
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   },
   description:
     "AI-curated news summaries from 100+ sources across technology, business, science, energy, world, and health. Updated every 10 minutes.",
-  metadataBase: new URL("https://siftnews.ai"),
+  metadataBase: new URL("https://siftnews.kristenmartino.ai"),
   openGraph: {
     title: "Sift — AI-Curated News",
     description:


### PR DESCRIPTION
## Summary
- Adds GitHub Actions CI workflow (tsc type check + jest tests on PR/push to main)
- Updates metadataBase to `siftnews.kristenmartino.ai` for production
- Removes dead `categories` field from cron refresh POST body (pipeline uses ALL_CATEGORIES internally)

## Test plan
- [x] `npx tsc --noEmit` passes clean
- [x] `npm test -- --ci` — 39/39 tests pass
- [ ] CI workflow runs on this PR

