### PR TITLE
Remove Vercel cron config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,1 @@
-{
-  "crons": [
-    {
-      "path": "/api/cron/refresh",
-      "schedule": "*/10 * * * *"
-    }
-  ]
-}
+{}


### PR DESCRIPTION
## Summary
- Removes Vercel cron configuration (hobby plan limited to 1 cron/day)
- Pipeline refresh is now handled by sift-api's background scheduler (every 10 min)

## Test plan
- [x] vercel.json is now empty `{}`
- [ ] Verify sift-api logs show scheduled refresh running in production

