### PR TITLE
B4: Named color palettes — Newsprint & Late Edition

### DIFF
--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -13,7 +13,7 @@ export default function AppleIcon() {
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          background: "#6366f1",
+          background: "#4338ca",
           borderRadius: 36,
         }}
       >

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,37 +6,46 @@
 @import url("https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700;800;900&family=Source+Sans+3:wght@300;400;500;600;700&display=swap");
 
 /* ─── Theme Variables ─────────────────────────────────── */
-/* Default: dark (matches server render and blocking script default) */
+/*
+ * Late Edition (dark) — deep ink tones, the late-night newsroom.
+ * Dark but not black; there's always warmth in the shadows.
+ *
+ * Newsprint (light) — warm off-white paper tones, like a quality
+ * broadsheet. Not clinical white; the kind of paper that has warmth.
+ */
+
+/* Default: Late Edition (matches server render and blocking script) */
 :root,
 html[data-theme="dark"] {
-  --bg: #0a0a0f;
-  --card-bg: #16161f;
-  --text: #eeeef0;
-  --text-secondary: #9d9daa;
-  --text-muted: #5a5a6e;
-  --border: #222233;
+  --bg: #0c0a09;
+  --card-bg: #1c1917;
+  --text: #f5f5f4;
+  --text-secondary: #a8a29e;
+  --text-muted: #57534e;
+  --border: #292524;
   --shadow: rgba(0, 0, 0, 0.4);
   --shadow-hover: rgba(0, 0, 0, 0.6);
-  --skeleton: #1e1e2a;
-  --accent: #6366f1;
-  --nav-bg: rgba(14, 14, 22, 0.92);
-  --pill-active: #6366f1;
-  --pill-text: #eeeef0;
+  --skeleton: #292524;
+  --accent: #818cf8;
+  --nav-bg: rgba(12, 10, 9, 0.92);
+  --pill-active: #818cf8;
+  --pill-text: #f5f5f4;
 }
 
+/* Newsprint */
 html[data-theme="light"] {
-  --bg: #f5f3f0;
+  --bg: #f5f2ed;
   --card-bg: #ffffff;
-  --text: #1a1a1a;
-  --text-secondary: #555566;
-  --text-muted: #8888a0;
-  --border: #e0ddd8;
+  --text: #1c1917;
+  --text-secondary: #57534e;
+  --text-muted: #a8a29e;
+  --border: #e7e5e4;
   --shadow: rgba(0, 0, 0, 0.06);
   --shadow-hover: rgba(0, 0, 0, 0.12);
-  --skeleton: #e8e5e0;
-  --accent: #4f46e5;
-  --nav-bg: rgba(245, 243, 240, 0.92);
-  --pill-active: #1a1a1a;
+  --skeleton: #e7e5e4;
+  --accent: #4338ca;
+  --nav-bg: rgba(245, 242, 237, 0.92);
+  --pill-active: #1c1917;
   --pill-text: #ffffff;
 }
 

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -13,7 +13,7 @@ export default function Icon() {
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          background: "#6366f1",
+          background: "#4338ca",
           borderRadius: 6,
         }}
       >

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
       "AI-curated news summaries from 100+ sources. Get the key points in 60 seconds.",
   },
   other: {
-    "theme-color": "#0a0a0f",
+    "theme-color": "#0c0a09",
     "color-scheme": "dark light",
   },
 };

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -6,8 +6,8 @@ export default function manifest(): MetadataRoute.Manifest {
     short_name: "Sift",
     start_url: "/news",
     display: "standalone",
-    background_color: "#0a0a0f",
-    theme_color: "#6366f1",
+    background_color: "#0c0a09",
+    theme_color: "#4338ca",
     icons: [
       { src: "/favicon.svg", sizes: "any", type: "image/svg+xml" },
     ],

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -15,7 +15,7 @@ export default function OGImage() {
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
-          background: "#0a0a0f",
+          background: "#0c0a09",
           fontFamily: "Georgia, serif",
         }}
       >
@@ -24,7 +24,7 @@ export default function OGImage() {
           style={{
             width: 60,
             height: 4,
-            background: "#6366f1",
+            background: "#818cf8",
             borderRadius: 2,
             marginBottom: 32,
           }}
@@ -66,7 +66,7 @@ export default function OGImage() {
             letterSpacing: "0.05em",
           }}
         >
-          100+ sources &middot; 7 categories &middot; Updated every 10 min
+          100+ sources &middot; 10 categories &middot; Updated every 10 min
         </span>
       </div>
     ),

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -13,7 +13,7 @@ const FEATURES = [
     title: "AI-Written Summaries",
     description:
       "Every article distilled into a concise summary by Claude. Get the key points without clicking through.",
-    accent: "#6366f1",
+    accent: "#818cf8",
   },
   {
     icon: "◆",
@@ -41,7 +41,7 @@ const FEATURES = [
     title: "Synced Bookmarks",
     description:
       "Save articles to read later. Sign in to sync bookmarks across devices, or use local storage.",
-    accent: "#ea580c",
+    accent: "#d97706",
   },
   {
     icon: "↻",

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -21,19 +21,30 @@ export const VALID_CATEGORIES = new Set<CategoryId>([
 ]);
 
 // ─── Colors ─────────────────────────────────────────────
-// Using rgb tuples so we can compose with rgba() — no hex+alpha hack
+// Each color is chosen for meaning, not decoration.
+//
+//   top           Vermilion   — breaking-news urgency, universal "pay attention"
+//   technology    Electric Blue — screens, interfaces, the digital world
+//   business      Forest Green — money, growth, markets
+//   science       Deep Violet  — mystery, discovery, rare knowledge
+//   energy        Teal         — power, sustainability, industry meets nature
+//   world         Amber        — old maps, parchment, things that span centuries
+//   health        Rose         — life, vitality, warm without being clinical
+//   politics      Indigo       — authority, institutions, the weight of governance
+//   sports        Cyan         — motion, open sky, the energy of competition
+//   entertainment Crimson      — curtain-call red, drama, spectacle
 
 export const CATEGORY_COLORS: Record<CategoryId, { hex: string; rgb: string }> = {
-  top:        { hex: "#dc2626", rgb: "220,38,38" },
-  technology: { hex: "#2563eb", rgb: "37,99,235" },
-  business:   { hex: "#059669", rgb: "5,150,105" },
-  science:    { hex: "#7c3aed", rgb: "124,58,237" },
-  energy:     { hex: "#ea580c", rgb: "234,88,12" },
-  world:      { hex: "#d97706", rgb: "217,119,6" },
-  health:     { hex: "#db2777", rgb: "219,39,119" },
-  politics:   { hex: "#6366f1", rgb: "99,102,241" },
-  sports:     { hex: "#0891b2", rgb: "8,145,178" },
-  entertainment: { hex: "#e11d48", rgb: "225,29,72" },
+  top:            { hex: "#dc2626", rgb: "220,38,38" },
+  technology:     { hex: "#2563eb", rgb: "37,99,235" },
+  business:       { hex: "#059669", rgb: "5,150,105" },
+  science:        { hex: "#7c3aed", rgb: "124,58,237" },
+  energy:         { hex: "#0d9488", rgb: "13,148,136" },
+  world:          { hex: "#d97706", rgb: "217,119,6" },
+  health:         { hex: "#db2777", rgb: "219,39,119" },
+  politics:       { hex: "#6366f1", rgb: "99,102,241" },
+  sports:         { hex: "#0891b2", rgb: "8,145,178" },
+  entertainment:  { hex: "#e11d48", rgb: "225,29,72" },
 };
 
 export const GRADIENTS: Record<CategoryId, string> = {
@@ -41,7 +52,7 @@ export const GRADIENTS: Record<CategoryId, string> = {
   technology: "linear-gradient(135deg, #0c1220 0%, #1a1a3e 50%, #1e3a5f 100%)",
   business: "linear-gradient(135deg, #0a1f1a 0%, #1a2f2a 50%, #0f3d2e 100%)",
   science: "linear-gradient(135deg, #1a0f2e 0%, #2d1b4e 50%, #1a1040 100%)",
-  energy: "linear-gradient(135deg, #1f1008 0%, #2a1a0a 50%, #3d1f0f 100%)",
+  energy: "linear-gradient(135deg, #0a1a1a 0%, #0f2a2a 50%, #0a3d3a 100%)",
   world: "linear-gradient(135deg, #1f1408 0%, #2a1f0a 50%, #3d2a0f 100%)",
   health: "linear-gradient(135deg, #200a1a 0%, #2e1525 50%, #3d0f2a 100%)",
   politics: "linear-gradient(135deg, #0f0f2e 0%, #1a1a4e 50%, #1e1e5f 100%)",

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
   <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle"
         font-family="Georgia, 'Times New Roman', serif" font-weight="700"
-        font-size="26" fill="#6366f1">S</text>
+        font-size="26" fill="#4338ca">S</text>
 </svg>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -26,8 +26,12 @@ const config: Config = {
           technology: "#2563eb",
           business: "#059669",
           science: "#7c3aed",
+          energy: "#0d9488",
           world: "#d97706",
           health: "#db2777",
+          politics: "#6366f1",
+          sports: "#0891b2",
+          entertainment: "#e11d48",
         },
       },
       keyframes: {


### PR DESCRIPTION
## Summary
- Retune dark theme ("Late Edition") with warm stone tones (`#0c0a09` bg, `#1c1917` cards, `#818cf8` accent) instead of cool blue-blacks
- Retune light theme ("Newsprint") with warmer paper (`#f5f2ed`, `#4338ca` accent) for editorial warmth
- Change energy category from orange (`#ea580c`) to teal (`#0d9488`) — sustainability meets industry
- Add semantic color comments explaining why each category has its color
- Align all accent references across icons, OG image, manifest, and favicon
- Fix OG image to show "10 categories" instead of "7"

## Files changed (10)
- `app/globals.css` — new palette values + theme name comments
- `lib/constants.ts` — energy color + meaning comments
- `tailwind.config.ts` — added missing category colors, updated energy
- `app/layout.tsx` — theme-color meta tag
- `app/icon.tsx`, `app/apple-icon.tsx` — accent color
- `app/opengraph-image.tsx` — bg + accent + category count
- `app/manifest.ts` — bg + theme colors
- `public/favicon.svg` — accent color
- `components/LandingPage.tsx` — feature card accents

## Test plan
- [ ] Dark mode renders with warm stone tones, not blue-gray
- [ ] Light mode renders with warm paper background
- [ ] Energy category pill/cards show teal instead of orange
- [ ] Favicon and app icons render with deep indigo
- [ ] OG image shows correct background and "10 categories"
- [ ] `npx next build` passes
- [ ] `tsc --noEmit` passes

