### PR TITLE
B2: SiftLogo component with diamond brand mark

### DIFF
--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -17,17 +17,15 @@ export default function AppleIcon() {
           borderRadius: 36,
         }}
       >
-        <span
-          style={{
-            fontSize: 120,
-            fontWeight: 700,
-            color: "#fff",
-            fontFamily: "Georgia, serif",
-            lineHeight: 1,
-          }}
+        {/* Diamond mark — ◆ */}
+        <svg
+          width="120"
+          height="120"
+          viewBox="0 0 24 24"
+          fill="#fff"
         >
-          S
-        </span>
+          <path d="M12 2L22 12L12 22L2 12Z" />
+        </svg>
       </div>
     ),
     { ...size },

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -17,17 +17,15 @@ export default function Icon() {
           borderRadius: 6,
         }}
       >
-        <span
-          style={{
-            fontSize: 22,
-            fontWeight: 700,
-            color: "#fff",
-            fontFamily: "Georgia, serif",
-            lineHeight: 1,
-          }}
+        {/* Diamond mark — ◆ */}
+        <svg
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="#fff"
         >
-          S
-        </span>
+          <path d="M12 2L22 12L12 22L2 12Z" />
+        </svg>
       </div>
     ),
     { ...size },

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -19,16 +19,16 @@ export default function OGImage() {
           fontFamily: "Georgia, serif",
         }}
       >
-        {/* Accent line */}
-        <div
-          style={{
-            width: 60,
-            height: 4,
-            background: "#818cf8",
-            borderRadius: 2,
-            marginBottom: 32,
-          }}
-        />
+        {/* Diamond mark */}
+        <svg
+          width="48"
+          height="48"
+          viewBox="0 0 24 24"
+          fill="#818cf8"
+          style={{ marginBottom: 24 }}
+        >
+          <path d="M12 2L22 12L12 22L2 12Z" />
+        </svg>
 
         {/* Wordmark */}
         <span

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { CATEGORIES, CATEGORY_COLORS } from "@/lib/constants";
 import { useTheme } from "@/lib/hooks";
+import SiftLogo from "./SiftLogo";
 import type { CategoryId } from "@/lib/types";
 
 // ─── Feature cards data ─────────────────────────────────
@@ -112,9 +113,7 @@ export default function LandingPage() {
       >
         <div className="max-w-[1200px] mx-auto px-6 h-14 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <span className="font-heading text-xl font-bold tracking-tight text-[var(--text)]">
-              Sift
-            </span>
+            <SiftLogo variant="full" size={20} />
             <span
               className="px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-widest"
               style={{
@@ -343,7 +342,7 @@ export default function LandingPage() {
 
       {/* ── Footer ────────────────────────────────── */}
       <footer className="border-t border-[var(--border)] py-6 px-6 text-center text-xs text-[var(--text-muted)] max-w-[1200px] mx-auto">
-        <span className="font-heading font-semibold">Sift</span>
+        <SiftLogo variant="full" size={14} />
         {" — "}AI-curated news powered by Claude. Articles link to original sources.
       </footer>
     </div>

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -10,6 +10,7 @@ import SkeletonCard from "./SkeletonCard";
 import ErrorState from "./ErrorState";
 import TopicSearch from "./TopicSearch";
 import CompareView from "./CompareView";
+import SiftLogo from "./SiftLogo";
 import AuthButtons, { clerkEnabled } from "./AuthButtons";
 import type { Article, CategoryId } from "@/lib/types";
 
@@ -146,9 +147,7 @@ export default function NewsAggregator() {
             className="flex items-baseline gap-3 cursor-pointer"
             onClick={() => { setShowBookmarks(false); setSearchMode(false); clearTopicSearch(); exitCompareMode(); setActiveCategory("top"); }}
           >
-            <h1 className="font-heading text-[28px] font-extrabold tracking-tight text-[var(--text)] leading-none">
-              Sift
-            </h1>
+            <SiftLogo variant="full" size={28} />
             <span className="text-[10px] font-bold tracking-widest uppercase text-[var(--accent)] opacity-80">
               AI-Curated
             </span>
@@ -480,7 +479,7 @@ export default function NewsAggregator() {
 
       {/* ── Footer ──────────────────────────────────── */}
       <footer className="border-t border-[var(--border)] py-6 px-6 text-center text-xs text-[var(--text-muted)] max-w-[1200px] mx-auto">
-        <span className="font-heading font-semibold">Sift</span>
+        <SiftLogo variant="full" size={14} />
         {" — "}AI-curated news powered by Claude. Articles link to original sources.
       </footer>
     </div>

--- a/components/SiftLogo.tsx
+++ b/components/SiftLogo.tsx
@@ -1,0 +1,77 @@
+interface SiftLogoProps {
+  variant?: "full" | "compact" | "mark" | "wordmark";
+  size?: number;
+  className?: string;
+}
+
+/**
+ * Brand mark: ◆ diamond rendered as SVG so it scales perfectly
+ * and inherits theme colors via var(--accent).
+ */
+function DiamondMark({ size }: { size: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="var(--accent)"
+      aria-hidden="true"
+    >
+      <path d="M12 2L22 12L12 22L2 12Z" />
+    </svg>
+  );
+}
+
+export default function SiftLogo({
+  variant = "full",
+  size = 28,
+  className = "",
+}: SiftLogoProps) {
+  const markSize = Math.round(size * 0.5);
+
+  if (variant === "mark") {
+    return (
+      <span className={`inline-flex items-center ${className}`}>
+        <DiamondMark size={markSize} />
+      </span>
+    );
+  }
+
+  if (variant === "wordmark") {
+    return (
+      <span
+        className={`font-heading font-extrabold tracking-tight leading-none ${className}`}
+        style={{ fontSize: size, color: "var(--text)" }}
+      >
+        Sift
+      </span>
+    );
+  }
+
+  if (variant === "compact") {
+    return (
+      <span className={`inline-flex items-center gap-1 ${className}`}>
+        <DiamondMark size={markSize} />
+        <span
+          className="font-heading font-extrabold tracking-tight leading-none"
+          style={{ fontSize: size, color: "var(--text)" }}
+        >
+          S
+        </span>
+      </span>
+    );
+  }
+
+  // variant === "full"
+  return (
+    <span className={`inline-flex items-center gap-1.5 ${className}`}>
+      <DiamondMark size={markSize} />
+      <span
+        className="font-heading font-extrabold tracking-tight leading-none"
+        style={{ fontSize: size, color: "var(--text)" }}
+      >
+        Sift
+      </span>
+    </span>
+  );
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,5 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle"
-        font-family="Georgia, 'Times New Roman', serif" font-weight="700"
-        font-size="26" fill="#4338ca">S</text>
+  <path d="M16 2L30 16L16 30L2 16Z" fill="#4338ca"/>
 </svg>


### PR DESCRIPTION
## Summary
- Create `SiftLogo.tsx` component with `variant` prop: `full` (◆ Sift), `compact` (◆ S), `mark` (◆), `wordmark` (Sift)
- SVG diamond mark scales perfectly and inherits theme color via `var(--accent)`
- Replace all hardcoded "Sift" text in NewsAggregator header/footer and LandingPage header/footer
- Update favicon.svg, icon.tsx, apple-icon.tsx to render diamond mark instead of letter "S"
- Update OG image to show diamond mark above wordmark

## Files changed (7)
- `components/SiftLogo.tsx` — **New** — reusable logo component
- `components/NewsAggregator.tsx` — header + footer use SiftLogo
- `components/LandingPage.tsx` — nav header + footer use SiftLogo
- `app/icon.tsx` — diamond mark favicon (32x32)
- `app/apple-icon.tsx` — diamond mark apple icon (180x180)
- `app/opengraph-image.tsx` — diamond mark above wordmark
- `public/favicon.svg` — SVG diamond path

## Test plan
- [ ] Header shows ◆ Sift with diamond mark on /news
- [ ] Landing page nav shows ◆ Sift with diamond mark on /
- [ ] Both footers show small ◆ Sift
- [ ] Favicon shows diamond in browser tab
- [ ] Diamond inherits accent color and adapts to light/dark mode
- [ ] `npx next build` passes
- [ ] `tsc --noEmit` passes

