### PR TITLE
Update all docs to reflect production state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,108 +1,121 @@
 # Sift
 
-AI-curated news aggregator powered by Claude and the Anthropic `web_search` tool. Surfaces the top stories across 7 categories with real-time, AI-generated summaries from live web search.
+AI-curated news aggregator. 100+ RSS sources, 10 categories, Claude Haiku summaries, Voyage AI embeddings, multi-source comparison. Updated every 10 minutes.
 
-## Quick Start
+**Live:** [siftnews.kristenmartino.ai](https://siftnews.kristenmartino.ai)
+
+## Architecture
+
+```
+Browser --> Vercel (Next.js) --reads--> Neon Postgres (pgvector)
+                |
+                +----- cron /10min ----> Railway (FastAPI + LangGraph) --writes--> Neon Postgres
+                +----- /api/compare ---> Railway
+```
+
+- **sift** (this repo): Next.js 15 frontend on Vercel — reads from Postgres, serves UI
+- **sift-api**: Python FastAPI + LangGraph on Railway — background pipeline + comparison workflow
+- **Database**: Neon Postgres (pgvector) — shared source of truth
+
+## Features
+
+- **10 categories**: Top, Technology, Business, Science, Energy, World, Health, Politics, Sports, Entertainment
+- **AI summaries**: Every article summarized by Claude Haiku 4.5
+- **Topic search**: Vector similarity (Voyage AI embeddings + pgvector), SSE streaming, Claude web search fallback
+- **Multi-source comparison**: LangGraph workflow — fan-out web search across outlets, extract claims, compare
+- **Bookmarks**: localStorage + Clerk server sync
+- **Dark/light themes**: "Late Edition" (dark) and "Newsprint" (light) with warm editorial tones
+- **SiftLogo**: Diamond mark brand identity across all touchpoints
+- **Landing page**: Marketing page with feature showcase
+- **Auth**: Clerk (free to 10K MAU)
+
+## Quick start
 
 ```bash
-# 1. Clone and install
-git clone <your-repo-url>
-cd sift
 npm install
-
-# 2. Configure API key
 cp .env.local.example .env.local
-# Edit .env.local and add your Anthropic API key
-
-# 3. Run
+# Add: DATABASE_URL, ANTHROPIC_API_KEY, VOYAGE_API_KEY, SIFT_API_URL, SIFT_API_KEY, CRON_SECRET
 npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000).
 
-## Architecture
+## Project structure
 
 ```
 sift/
 ├── app/
-│   ├── api/news/route.ts    # Server-side API proxy (Claude web_search)
-│   ├── globals.css           # Tailwind + CSS variables
-│   ├── layout.tsx            # Root layout, metadata, skip-nav
-│   └── page.tsx              # Home page
+│   ├── api/
+│   │   ├── news/route.ts          # Category articles (Postgres read)
+│   │   ├── news/topic/route.ts    # Topic search (vector + SSE + fallback)
+│   │   ├── compare/route.ts       # Proxy to Railway compare endpoint
+│   │   ├── cron/refresh/route.ts  # Pipeline trigger (Railway)
+│   │   └── bookmarks/route.ts     # Bookmark sync (Clerk + Postgres)
+│   ├── sign-in/                   # Clerk auth pages
+│   ├── sign-up/
+│   ├── globals.css                # Theme variables (Newsprint / Late Edition)
+│   ├── layout.tsx                 # Root layout, metadata, theme script
+│   ├── page.tsx                   # Landing page
+│   ├── icon.tsx                   # Diamond mark favicon
+│   ├── apple-icon.tsx             # Diamond mark apple icon
+│   ├── opengraph-image.tsx        # OG image with diamond mark
+│   └── manifest.ts               # PWA manifest
 ├── components/
-│   ├── NewsAggregator.tsx    # Main orchestrator (state, layout)
-│   ├── ArticleCard.tsx       # Individual article display
-│   ├── CardImage.tsx         # Image with gradient fallback
-│   ├── ErrorState.tsx        # Error UI with retry
-│   └── SkeletonCard.tsx      # Loading placeholder
+│   ├── NewsAggregator.tsx         # Main app (state, layout, tabs)
+│   ├── ArticleCard.tsx            # Article display
+│   ├── SiftLogo.tsx               # Brand mark (full/compact/mark/wordmark)
+│   ├── LandingPage.tsx            # Marketing landing page
+│   ├── TopicSearch.tsx            # Search input + SSE consumer
+│   ├── CompareView.tsx            # Comparison results
+│   ├── SkeletonCard.tsx           # Loading placeholder
+│   ├── ErrorState.tsx             # Error UI
+│   └── AuthButtons.tsx            # Clerk sign-in/out
 ├── lib/
-│   ├── constants.ts          # Categories, colors, timing, storage keys
-│   ├── hooks.ts              # useNewsLoader, useBookmarks, useTheme
-│   ├── types.ts              # TypeScript interfaces (single source of truth)
-│   └── utils.ts              # Pure functions (hash, parse, time, domain)
-└── __tests__/
-    ├── utils.test.ts          # Unit tests for all utility functions
-    ├── api.test.ts            # API route integration tests
-    └── ErrorState.test.tsx    # Component rendering tests
+│   ├── constants.ts               # Categories, colors (semantic), gradients
+│   ├── hooks.ts                   # useNewsLoader, useBookmarks, useTheme, useTopicSearch, useCompare
+│   ├── types.ts                   # TypeScript interfaces
+│   ├── db.ts                      # Neon serverless Postgres client
+│   ├── sse.ts                     # SSE event parser
+│   └── utils.ts                   # Hash, parse, time, domain helpers
+├── __tests__/                     # Jest + RTL
+└── docs/                          # Architecture, decisions, specs
 ```
 
-### Data Flow
+## Environment variables
 
-```
-User clicks category
-  → useNewsLoader dispatches fetch to /api/news?category=X
-  → API route checks two-tier cache (30min fresh / 60min stale)
-  → If miss: calls Claude with web_search tool for AI-curated articles
-  → Claude searches the web, summarizes top stories as JSON
-  → extractJsonArray() parses LLM output (3-strategy robust parser)
-  → Returns normalized Article[] to client
-  → Client renders ArticleCard grid with animations
-```
-
-### Key Design Decisions
-
-| Decision | Why |
-|----------|-----|
-| Claude web_search over NewsAPI | AI-generated summaries, broader source diversity, no syndication dependency |
-| "Summarize" prompt framing | Avoids model refusals from rigid JSON extraction commands |
-| Server-side API proxy | API key never reaches the client |
-| Two-tier stale-while-revalidate cache | Near-instant repeat loads despite AI latency |
-| 3-strategy JSON parser | Handles LLM output variability (prose-wrapped, markdown-fenced, truncated) |
-| Stable URL-based IDs | Bookmarks survive page refresh |
-| CSS variables for theming | Dark/light toggle without class rewrite |
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DATABASE_URL` | Yes | Neon Postgres pooled connection string |
+| `ANTHROPIC_API_KEY` | Yes | Claude API key (topic search fallback) |
+| `VOYAGE_API_KEY` | Yes | Voyage AI key (topic search embeddings) |
+| `SIFT_API_URL` | Yes | Railway sift-api URL |
+| `SIFT_API_KEY` | Yes | Shared secret for pipeline trigger |
+| `CRON_SECRET` | Yes | Cron endpoint auth |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | No | Clerk auth (optional) |
+| `CLERK_SECRET_KEY` | No | Clerk auth (optional) |
 
 ## Scripts
 
 ```bash
-npm run dev          # Start development server
+npm run dev          # Dev server (port 3000)
 npm run build        # Production build
-npm run start        # Start production server
-npm run lint         # ESLint check
-npm run test         # Run tests
-npm run test:watch   # Watch mode
-npm run test:coverage # Coverage report
+npm run start        # Production server
+npm run test         # Jest tests
+npm run test:coverage
 ```
 
-## Deployment (Vercel)
+## Deployment
 
-```bash
-npm i -g vercel
-vercel
-vercel env add ANTHROPIC_API_KEY
-vercel --prod
-```
+Auto-deploys to Vercel on push to `main`. CI runs on every PR via GitHub Actions (`tsc --noEmit`).
 
-## Environment Variables
+## Tech stack
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `ANTHROPIC_API_KEY` | Yes | Your Anthropic API key ([console.anthropic.com](https://console.anthropic.com)) |
-
-## Tech Stack
-
-- **Framework:** Next.js 15 (App Router)
-- **Language:** TypeScript
-- **AI Engine:** Anthropic Claude + web_search tool
-- **Styling:** Tailwind CSS + CSS custom properties
-- **Testing:** Jest + React Testing Library
-- **Deployment:** Vercel (recommended)
+- **Framework**: Next.js 15 (App Router)
+- **Language**: TypeScript
+- **Styling**: Tailwind CSS + CSS custom properties
+- **Database**: Neon Postgres + pgvector
+- **Auth**: Clerk
+- **AI**: Claude Haiku 4.5 (summaries + comparison), Voyage AI (embeddings)
+- **Testing**: Jest + React Testing Library
+- **Hosting**: Vercel
+- **CI**: GitHub Actions

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,8 @@
 # Sift — Architecture
 
-**Version:** 2.0
-**Date:** March 28, 2026
+**Version:** 2.1
+**Date:** March 31, 2026
+**Live:** siftnews.kristenmartino.ai
 
 ---
 
@@ -13,7 +14,7 @@
                     └────────────┬─────────────┘
                                  │
                     ┌────────────▼─────────────┐
-                    │     VERCEL PRO ($20/mo)   │
+                    │       VERCEL (Hobby)      │
                     │                           │
                     │  Next.js 15 (App Router)  │
                     │  ┌─────────────────────┐  │
@@ -32,8 +33,8 @@
               ┌──────────────────┼──────────────────┐
               ▼                                      ▼
 ┌─────────────────────────┐          ┌─────────────────────────┐
-│   RAILWAY ($5/mo)        │          │  VERCEL POSTGRES (free)  │
-│                          │          │  (Neon)                  │
+│   RAILWAY (~$5/mo)       │          │  NEON POSTGRES (free)    │
+│                          │          │  (standalone)            │
 │  FastAPI + LangGraph     │          │                          │
 │  ┌────────────────────┐  │          │  articles (+ pgvector)   │
 │  │ /pipeline/refresh  │──┼──────▶   │  custom_topics           │
@@ -61,7 +62,7 @@ User opens Sift → clicks "Technology"
       SELECT * FROM articles
       WHERE category = 'technology'
       ORDER BY published_date DESC
-      LIMIT 7
+      LIMIT 10
   → Returns JSON in <50ms
   → Client renders article cards with staggered animation
 ```
@@ -93,17 +94,14 @@ User types "AI policy in European healthcare"
 
 ---
 
-## Data flow: background pipeline (every 10-15 min)
+## Data flow: background pipeline (every 10 min)
 
 ```
-Vercel Cron fires
-  → GET /api/cron/refresh (Next.js)
-  → Verifies CRON_SECRET
-  → POST to Railway: /pipeline/refresh
+Railway asyncio scheduler fires (or Vercel cron fallback)
   → LangGraph pipeline workflow:
 
       ┌──────────┐
-      │ fetch_rss │  Fetch all RSS feeds (~28 feeds, <2s total)
+      │ fetch_rss │  Fetch all RSS feeds (~100+ feeds, <5s total)
       └─────┬─────┘
             ▼
       ┌────────────┐
@@ -172,7 +170,7 @@ User clicks "Compare coverage" on a story
 | AI out of request path | Background pipeline generates; API routes serve from DB |
 | Right tool for each job | Next.js for frontend + simple reads; LangGraph for multi-step workflows |
 | Single source of truth | Postgres stores everything; no in-memory cache to lose |
-| Cost scales with content, not users | Claude costs are fixed (~$4/mo for pipeline). 1 user or 10,000 users costs the same. |
+| Cost scales with content, not users | Claude costs are fixed (~$4/mo for pipeline). 1 user or 10,000 users costs the same. Total: ~$9/mo. |
 | Progressive enhancement | Fixed categories work without auth. Custom topics and comparison require sign-in. |
 | Graceful degradation | If pipeline fails, articles are stale but still served. If comparison fails, user gets an error, not a crash. |
 
@@ -188,9 +186,9 @@ User clicks "Compare coverage" on a story
 | AI (summaries) | Claude Haiku 4.5 | Cheapest, fast enough for news summaries |
 | AI (search) | Claude + web_search | Used in comparison workflow and custom topic fallback |
 | Embeddings | Voyage AI (voyage-3-lite) | Free 50M tokens/mo, high-quality retrieval embeddings |
-| Database | PostgreSQL + pgvector | Relational + vector search in one; managed by Neon |
+| Database | Neon PostgreSQL + pgvector | Relational + vector search in one; auto-suspend, pooled connections |
 | Auth | Clerk | 5-min setup, free to 10K MAU, polished UI |
-| Hosting (web) | Vercel Pro | Cron, analytics, preview deploys, CDN |
+| Hosting (web) | Vercel (Hobby) | Preview deploys, CDN, auto-deploy from GitHub |
 | Hosting (api) | Railway | Persistent process for LangGraph, $5/mo |
 | Monitoring | Sentry + Vercel Analytics | Errors + usage, both free tier |
 
@@ -200,7 +198,7 @@ User clicks "Compare coverage" on a story
 
 | Users | What changes | Cost |
 |-------|-------------|------|
-| 1-1K | Nothing. Current architecture handles it. | ~$30/mo |
+| 1-1K | Nothing. Current architecture handles it. | ~$9/mo |
 | 1K-10K | Add Postgres connection pooling (PgBouncer). Increase pipeline frequency. | ~$50/mo |
 | 10K-50K | Upgrade Neon plan. Add Redis for hot cache layer. Multiple Railway instances. | ~$200/mo |
 | 50K+ | Dedicated Postgres. Background workers on dedicated compute. You have revenue. | $500+ |

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,7 +1,7 @@
 # Sift — Architecture Decision Register
 
-**Last updated:** March 28, 2026
-**Status:** All decisions locked — ready to build
+**Last updated:** March 31, 2026
+**Status:** All decisions implemented — production live at siftnews.kristenmartino.ai
 
 ---
 
@@ -10,8 +10,8 @@
 | # | Decision | Choice | Cost | Status |
 |---|----------|--------|------|--------|
 | D1 | Content engine | RSS hybrid (RSS discovery + Claude Haiku summaries) | ~$4/mo | SETTLED |
-| D2 | Hosting | Vercel Pro (frontend) + Railway (Python backend) | $25/mo | SETTLED |
-| D3 | Caching / persistence | Vercel Postgres + pgvector as source of truth | $0-20/mo | SETTLED |
+| D2 | Hosting | Vercel (frontend) + Railway (Python backend) | ~$5/mo | SETTLED |
+| D3 | Caching / persistence | Neon Postgres + pgvector as source of truth | $0 (free tier) | SETTLED |
 | D4 | Prompt strategy | "Summarize" framing with structured subtopics | $0 | SETTLED |
 | D5 | Card design | Mixed — RSS images when available, text-first accent bar when not | $0 | SETTLED |
 | D6 | Content source identity | Anthropic API (not NewsAPI) — this IS the product | $0 | SETTLED |
@@ -24,7 +24,7 @@
 | D13 | Streaming | Build as part of initial launch (SSE article delivery) | $0 | SETTLED |
 | D14 | Embedding provider | Voyage AI (free 50M tokens/mo) | $0 | SETTLED |
 | D15 | Image handling | RSS feed images only — no OG scraping, no proxy | $0 | SETTLED |
-| D16 | Background refresh | Vercel Cron (every 10-15 min on Pro plan) | $0 (included) | SETTLED |
+| D16 | Background refresh | Railway asyncio scheduler (every 10 min) + Vercel cron fallback | $0 | SETTLED |
 | D17 | Model selection | Haiku 4.5 (upgrade to Sonnet is one-line change) | ~$4/mo | SETTLED |
 
 **Total estimated monthly cost: ~$30-50/mo**
@@ -181,7 +181,7 @@ Now applied specifically to the summary step: Claude receives article titles and
 Vercel Cron (every 10-15 min)
   → POST /pipeline/refresh to Railway
   → LangGraph pipeline:
-      1. Fetch RSS feeds for all 7 categories
+      1. Fetch RSS feeds for all 10 categories
       2. Deduplicate against existing articles in Postgres
       3. Batch new articles → Claude Haiku for summaries
       4. Batch new articles → Voyage AI for embeddings
@@ -301,9 +301,10 @@ RSS feeds include image URLs via `enclosure`, `media:content`, or `media:thumbna
 ---
 
 ### D16. Background refresh
-**Decision:** Vercel Cron (included with Pro plan)
+**Decision:** Railway asyncio scheduler (primary) + Vercel cron route (fallback)
+**Changed from:** Vercel Cron (requires Pro plan)
 
-Triggers the pipeline endpoint on Railway every 10-15 minutes. Content is always fresh in Postgres. User requests never trigger AI calls.
+Railway's FastAPI service runs an asyncio background task that refreshes every 10 minutes in production. A Vercel cron route also exists as a manual fallback. This avoids the $20/mo Vercel Pro requirement.
 
 ---
 
@@ -314,44 +315,45 @@ With the RSS hybrid, Claude is only summarizing, not searching. Haiku is suffici
 
 ---
 
-## Cost summary
+## Cost summary (actual, March 2026)
 
 | Component | Monthly cost |
 |-----------|-------------|
-| Vercel Pro | $20 |
-| Railway (Python service) | $5 |
-| Vercel Postgres (Neon free tier) | $0 |
-| Claude Haiku API (~7 cats × 6 refreshes/hr × $0.003) | ~$4 |
+| Vercel (Hobby plan) | $0 |
+| Railway (Python service) | ~$5 |
+| Neon Postgres (free tier) | $0 |
+| Claude Haiku 4.5 API (~10 cats x 6 refreshes/hr) | ~$4 |
 | Voyage AI embeddings (free tier) | $0 |
 | Clerk auth (free to 10K MAU) | $0 |
-| Sentry (free to 5K events/mo) | $0 |
-| Domain (siftnews.ai) | ~$1.25 |
-| **Total** | **~$30/mo** |
+| Domain (subdomain of kristenmartino.ai) | $0 |
+| **Total** | **~$9/mo** |
 
 ---
 
-## Build sequence
+## Build sequence (actual)
+
+All phases complete. Production live at siftnews.kristenmartino.ai as of March 31, 2026.
 
 ```
-Week 1:  Postgres schema + Python FastAPI + LangGraph pipeline
-         RSS feed integration + Claude summary step
-         Voyage AI embedding step
-         Vercel Cron trigger
+Phase 1:  Postgres schema + Python FastAPI + LangGraph pipeline     ✓
+          RSS feed integration (100+ feeds, 10 categories)          ✓
+          Claude Haiku summaries + Voyage AI embeddings              ✓
 
-Week 2:  Next.js API routes (DB reads only)
-         Card redesign (text-first + RSS images)
-         Clerk auth integration
-         SSE streaming for article delivery
+Phase 2:  Next.js API routes rewrite (Postgres reads)               ✓
+          Card redesign (text-first + RSS images)                    ✓
+          Clerk auth + bookmarks sync                                ✓
+          SSE streaming for topic search                             ✓
+          3 new categories (politics, sports, entertainment)         ✓
 
-Week 3:  LangGraph comparison workflow
-         Custom topics (vector search + fallback)
-         Landing page + favicon + OG image
-         Sentry + Vercel Analytics
+Phase 3:  LangGraph comparison workflow (web search fan-out)        ✓
+          Topic search (vector + web search fallback)               ✓
+          Landing page + OG image + favicon                         ✓
+          Dark/light themes (Newsprint / Late Edition)              ✓
 
-Week 4:  QA all 7 categories + custom topics
-         Mobile testing
-         Deploy to production
-         Share with 10 people
+Phase 4:  Deploy to production (Vercel + Railway + Neon)            ✓
+          CI/CD (GitHub Actions on both repos)                      ✓
+          DNS (siftnews.kristenmartino.ai)                          ✓
+          Brand identity (SiftLogo diamond mark, color story)       ✓
 ```
 
 ---
@@ -382,3 +384,35 @@ D7 (Pipeline) ──→ D8 (Postgres) ──→ D9 (Custom topics)
 
 All dependencies resolved. No blockers.
 ```
+
+---
+
+### D18. Database provider
+**Decision:** Neon free tier (standalone) instead of Vercel Postgres
+**Changed from:** Vercel Postgres (which is Neon under the hood)
+
+Standalone Neon gives more control: 0.5 GiB storage, pgvector native, connection pooling, auto-suspend. Both Vercel (pooled) and Railway (direct) connect to the same Neon instance. Pooled connection for serverless functions, direct for long-running Railway service.
+
+---
+
+### D19. Domain
+**Decision:** siftnews.kristenmartino.ai (subdomain) instead of siftnews.ai
+**Changed from:** siftnews.ai (separate domain)
+
+Uses existing portfolio domain via CNAME to Vercel. Zero cost, consistent branding under the portfolio umbrella.
+
+---
+
+### D20. Categories — expanded to 10
+**Decision:** Added Politics, Sports, Entertainment to the original 7
+
+Each category has 8-11 RSS feeds. Expanded total from ~56 feeds to 100+ feeds. Category colors have semantic meaning (e.g., energy = teal for sustainability, politics = indigo for authority).
+
+---
+
+### D21. Brand identity
+**Decision:** Named theme palettes + SVG diamond brand mark
+
+- Themes: "Late Edition" (dark, warm stone tones) and "Newsprint" (light, warm paper)
+- Brand mark: SVG diamond rendered at all sizes via SiftLogo component with full/compact/mark/wordmark variants
+- Category colors: each chosen for semantic meaning, not decoration

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,21 +1,22 @@
 # Sift — Product Requirements Document
 
-**Version:** 2.0
-**Date:** March 28, 2026
+**Version:** 2.1
+**Date:** March 31, 2026
 **Author:** Martino
-**Domain:** siftnews.ai
+**Domain:** siftnews.kristenmartino.ai
+**Status:** Production live
 
 ---
 
 ## Vision
 
-Sift is a news reader where AI does the reading for you. Open it, see 5 stories that matter across any topic, each with a concise summary written for comprehension — not a headline written for clicks. Close it. 60 seconds. That's the experience.
+Sift is a news reader where AI does the reading for you. Open it, see the top stories across 10 categories, each with a concise summary written for comprehension — not a headline written for clicks. Search any topic, compare coverage across outlets. Close it. 60 seconds. That's the experience.
 
 ## Value proposition
 
-**For users:** "Open Sift. In 60 seconds, know what's happening across tech, business, science, energy, world news, and health. Create your own topics — 'AI in healthcare,' 'Florida utilities,' anything. Every summary is AI-written. Every comparison is multi-source."
+**For users:** "Open Sift. In 60 seconds, know what's happening across 10 categories — tech, business, science, energy, world, health, politics, sports, entertainment, and curated top stories. Search any topic. Compare how different outlets cover the same story. Every summary is AI-written."
 
-**For hiring managers:** "I built a hybrid AI system from 0 to 1: Next.js frontend on Vercel, Python/LangGraph backend on Railway, Postgres with pgvector, background content pipeline, multi-source comparison via fan-out search, custom topics via vector similarity — all for $30/month."
+**For hiring managers:** "I built a hybrid AI system from 0 to 1: Next.js frontend on Vercel, Python/LangGraph backend on Railway, Neon Postgres with pgvector, background content pipeline with 100+ RSS feeds, multi-source comparison via fan-out web search, topic search via vector similarity with SSE streaming — all for ~$9/month."
 
 ---
 
@@ -41,13 +42,13 @@ Sift is a news reader where AI does the reading for you. Open it, see 5 stories 
 
 Two services, one database:
 
-- **Next.js on Vercel Pro** — frontend, API routes (Postgres reads), Clerk auth, Vercel Cron
-- **Python FastAPI + LangGraph on Railway** — background pipeline (RSS → Claude → Voyage → Postgres), multi-source comparison
-- **Vercel Postgres (Neon) + pgvector** — single source of truth for articles, embeddings, custom topics, bookmarks
+- **Next.js on Vercel** — frontend, API routes (Postgres reads), Clerk auth, SSE streaming
+- **Python FastAPI + LangGraph on Railway** — background pipeline (RSS → Claude → Voyage → Postgres), multi-source comparison, asyncio scheduler
+- **Neon Postgres + pgvector** — single source of truth for articles, embeddings, custom topics, bookmarks
 
-Content pipeline runs every 10-15 minutes via Vercel Cron. User requests never touch Claude — they read from Postgres in <50ms.
+Content pipeline runs every 10 minutes via Railway's background scheduler. User requests never touch Claude — they read from Postgres in <50ms.
 
-Total cost: ~$30/month.
+Total cost: ~$9/month.
 
 Full technical details: SIFT_ARCHITECTURE_v2.md and SIFT_TECHNICAL_SPEC.md.
 
@@ -62,7 +63,7 @@ Full technical details: SIFT_ARCHITECTURE_v2.md and SIFT_TECHNICAL_SPEC.md.
 | S0 | Postgres schema + migrations | 2 hr |
 | S1 | Python FastAPI service scaffold on Railway | 3 hr |
 | S2 | LangGraph pipeline workflow (RSS → Claude → Voyage → store) | 6 hr |
-| S3 | RSS feed integration (28 feeds, 7 categories) | 4 hr |
+| S3 | RSS feed integration (100+ feeds, 10 categories) | 4 hr |
 | S4 | Next.js API routes rewrite (Postgres reads) | 3 hr |
 | S5 | Card redesign — text-first + RSS images | 3 hr |
 | S6 | Vercel Cron configuration | 30 min |
@@ -76,7 +77,7 @@ Full technical details: SIFT_ARCHITECTURE_v2.md and SIFT_TECHNICAL_SPEC.md.
 | T2 | SSE streaming for article delivery | 4 hr |
 | T3 | LangGraph comparison workflow | 6 hr |
 | T4 | Bookmarks synced to Postgres (via Clerk user ID) | 2 hr |
-| T5 | Landing page at siftnews.ai | 4 hr |
+| T5 | Landing page at siftnews.kristenmartino.ai | 4 hr |
 
 ### Tier 2 — Differentiation (Week 3-4)
 

--- a/docs/PRODUCT_STORY.md
+++ b/docs/PRODUCT_STORY.md
@@ -56,20 +56,20 @@ Demonstrate the complete product development lifecycle: requirements analysis, a
 
 **Shipped product:**
 
-Sift is a fully functional AI-curated news aggregator serving 7 categories with real-time content generated from live web search. The interface features a responsive card grid with article images, gradient fallbacks, dark/light themes, persistent bookmarks, and staggered loading animations. Articles link to original sources. The product runs locally with a single `npm run dev` command and is deployment-ready for Vercel.
+Sift is a production AI-curated news aggregator live at siftnews.kristenmartino.ai, serving 10 categories with 100+ RSS sources, AI summaries from Claude Haiku 4.5, vector-powered topic search, and multi-source comparison. The interface features text-first article cards with RSS images, named dark/light themes ("Late Edition" / "Newsprint"), persistent bookmarks with Clerk sync, SSE streaming for topic search, and a diamond brand mark. Articles link to original sources.
+
+**Architecture (v2):**
+
+The v2 architecture split the system into three services: Next.js frontend on Vercel (reads from Postgres, serves UI), Python FastAPI + LangGraph on Railway (background pipeline + comparison workflow), and Neon Postgres with pgvector (shared source of truth). Content pipeline runs every 10 minutes via asyncio scheduler. User requests are pure database reads (<50ms). Multi-source comparison uses a LangGraph workflow with fan-out web search across outlets. Topic search uses Voyage AI embeddings with pgvector cosine similarity and Claude web search fallback. Total cost: ~$9/month.
 
 **Technical outcomes:**
 
-The codebase grew from 831 lines in a single file to 1,786 lines across 22 source files — a clean decomposition that separated concerns without overengineering. The server-side API route includes 5-minute response caching, IP-based rate limiting, and typed error responses. The test suite covers the three areas with highest defect density: utility functions (25 tests), API response parsing (10 tests), and component rendering (3 tests). TypeScript catches type errors at build time. The JSON parser handles 14 distinct input patterns including model refusals and truncated responses.
+Two repositories totaling ~5,000+ lines across 50+ source files. The Next.js frontend includes 7 custom hooks, SSE streaming, Clerk auth, and CI via GitHub Actions. The Python backend includes two LangGraph workflows (pipeline + comparison), 100+ RSS feeds, and CI with ruff + pytest. Neon Postgres stores articles with 1024-dim Voyage AI embeddings and an IVFFlat index for fast similarity search. 21 architectural decisions documented with rationale.
 
-**Measurable improvements over prototype:**
+**Measurable improvements over v1 prototype:**
 
-Security: API key exposure eliminated (moved server-side). Reliability: silent failures eliminated (every error path surfaces to the user). Performance: server-side caching reduces redundant API calls by ~80% during repeat visits. Persistence: bookmarks and theme survive page refresh. Testability: 30+ automated tests versus zero.
-
-**Product development artifacts:**
-
-The project includes a comprehensive audit document covering current state assessment, bug inventory with severity ratings, technical debt remediation plan, prioritized feature backlog (15 features across 3 tiers), testing strategy, deployment checklist, and 6-week execution timeline. An architecture document details the hybrid Next.js + LangGraph design with deployment topology, workflow diagrams, and implementation phasing. A decision log captures every significant technical choice with rationale and revisit triggers.
+Architecture: AI moved from request path to background pipeline (<50ms reads vs 10-20s Claude calls). Scale: 7 categories → 10 categories, ~56 RSS feeds → 100+ feeds. Features: added topic search (vector + fallback), multi-source comparison (LangGraph fan-out), landing page, brand identity. Cost: reduced from projected ~$30/mo to actual ~$9/mo by using Vercel Hobby + Neon free tier + Railway asyncio scheduler. Deployment: full CI/CD with auto-deploy on both repos.
 
 **Key lessons documented:**
 
-The single most impactful lesson was that API behavior discovery should happen before integration, not during debugging. A 2-hour spike on the Anthropic web_search tool's response format and refusal patterns would have prevented 6+ hours of debugging caused by compounding failures from an untested prompt change. The second lesson was that prompt engineering is product design — the shift from "format as JSON" to "summarize in your own words" wasn't a technical fix, it was a reframing of what we were asking the AI to do, and it only worked because I understood the model's behavior at the product level, not just the API level.
+The single most impactful lesson was that API behavior discovery should happen before integration, not during debugging. A 2-hour spike on the Anthropic web_search tool's response format and refusal patterns would have prevented 6+ hours of debugging caused by compounding failures from an untested prompt change. The second lesson was that prompt engineering is product design — the shift from "format as JSON" to "summarize in your own words" wasn't a technical fix, it was a reframing of what we were asking the AI to do. The third lesson was about deployment: Railway auto-injects PORT environment variables that override user settings, and model IDs like `claude-haiku-4-5-20251001` require the full date suffix — both discovered through production debugging.

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -1,55 +1,50 @@
 # Sift — Project Plan & Status
 
 **Date:** February 23, 2026
-**Last Updated:** March 28, 2026
-**Status:** Week 1 complete — Python pipeline live, 479 articles in Postgres, starting Week 2
-**Stack:** Next.js 15 / TypeScript / Tailwind CSS / Python FastAPI + LangGraph / Postgres + pgvector
+**Last Updated:** March 31, 2026
+**Status:** Production live at siftnews.kristenmartino.ai — all features shipped
+**Stack:** Next.js 15 / TypeScript / Tailwind CSS / Python FastAPI + LangGraph / Neon Postgres + pgvector
 
 ---
 
-## Current state
+## Current state — Production (March 31, 2026)
 
-### v1.5 frontend (sift/) — working, pending v2 rewrite
-
-The Next.js app is live on `localhost:3000` with Claude `web_search` as the content engine. All 7 categories load AI-generated summaries. This will be rewritten in Week 2 to read from Postgres instead.
+### Frontend (sift/) — live on Vercel
 
 | Layer | Implementation | Status |
 |-------|---------------|--------|
-| UI Framework | React components in Next.js App Router | Working |
-| State Management | Custom hooks + localStorage | Working |
-| API Integration | Server-side Claude `web_search` | Working (to be replaced) |
-| Styling | Tailwind CSS + CSS custom properties | Working |
-| Caching | In-memory Map + persistent disk (`/tmp/sift-cache/`) | Working (to be replaced) |
-| Image pipeline | Claude → OG scraping → HEAD validation | Working (to be simplified) |
-| Testing | Jest + RTL, 80 test cases | Passing |
-| Dark/light mode | CSS variables + localStorage toggle | Working |
-| Bookmarks | localStorage persistence | Working |
+| UI Framework | React + Next.js 15 App Router | **Live** |
+| State Management | Custom hooks + localStorage + Clerk sync | **Live** |
+| API Integration | Postgres reads (categories), SSE streaming (topics), Railway proxy (compare) | **Live** |
+| Styling | Tailwind CSS + CSS custom properties (Newsprint/Late Edition themes) | **Live** |
+| Brand Identity | SiftLogo component (diamond mark, 4 variants) | **Live** |
+| Topic Search | Voyage AI embeddings + pgvector + Claude web search fallback | **Live** |
+| Multi-Source Compare | Proxied to Railway LangGraph workflow | **Live** |
+| Auth | Clerk (sign-in, bookmarks sync) | **Live** |
+| Testing | Jest + RTL | Passing |
+| CI/CD | GitHub Actions (tsc) + Vercel auto-deploy | **Live** |
 
-### v2 backend (sift-api/) — Week 1 complete
-
-The Python FastAPI + LangGraph pipeline service is built and tested end-to-end. Running locally on `localhost:8000` with Docker Postgres on `localhost:5432`.
+### Backend (sift-api/) — live on Railway
 
 | Layer | Implementation | Status |
 |-------|---------------|--------|
-| FastAPI server | Health endpoint, CORS, lifespan DB pool | **Done** |
-| Postgres schema | 4 tables: articles, custom_topics, bookmarks, pipeline_state | **Done** |
-| Docker Compose | pgvector/pgvector:pg16 on port 5432 | **Done** |
-| LangGraph pipeline | fetch_rss → deduplicate → summarize → embed → store | **Done** |
-| RSS feeds | 56 feeds across 7 categories | **Done** |
-| Claude summarization | Haiku 4.5 batch summaries, 3-strategy JSON parser | **Done** |
-| Voyage AI embeddings | voyage-3-lite, 1024-dim (needs API key) | **Scaffolded** |
-| Pipeline auth | X-Pipeline-Key header validation | **Done** |
-| Deduplication | Batch URL check against Postgres | **Done** |
-| Dockerfile + Railway config | Production-ready | **Done** |
-| Tests | 40 passing (RSS, summarizer, health, router) | **Passing** |
-| Git repo | 3 commits on main | **Done** |
+| FastAPI server | Health, CORS, lifespan DB pool, background scheduler | **Live** |
+| LangGraph pipeline | fetch_rss → deduplicate → summarize → embed → store | **Live** |
+| LangGraph compare | search_sources → extract_and_compare → format_response | **Live** |
+| RSS feeds | 100+ feeds across 10 categories | **Live** |
+| Claude Haiku 4.5 | Batch summaries + comparison analysis + web search | **Live** |
+| Voyage AI embeddings | voyage-3-lite, 1024-dim | **Live** |
+| Background refresh | asyncio scheduler, every 10 minutes | **Live** |
+| CI/CD | GitHub Actions (ruff + pytest) + Railway auto-deploy | **Live** |
 
-**Pipeline results (full run):**
-- 479 articles stored across all 7 categories
-- All with AI summaries from Claude Haiku
-- Zero errors
-- Deduplication verified: second run skips all existing articles
-- ~6.5 minutes for full 56-feed refresh
+### Database — Neon Postgres (free tier)
+
+| Table | Purpose | Status |
+|-------|---------|--------|
+| articles | News articles + embeddings + summaries | **Live** (IVFFlat index) |
+| custom_topics | User-defined topic queries | **Live** |
+| bookmarks | User bookmarks (Clerk ID) | **Live** |
+| pipeline_state | Last refresh timestamps | **Live** |
 
 ### File maps
 
@@ -102,38 +97,26 @@ sift-api/                      (16 source files, ~1,200 LOC)
 
 ---
 
-## v2 build sequence
+## Build sequence — all complete
 
 | # | Task | Status |
 |---|------|--------|
 | 1 | Postgres schema + migrations | **Done** |
 | 2 | Python FastAPI service scaffold | **Done** |
 | 3 | LangGraph pipeline workflow (RSS → Claude → Voyage → store) | **Done** |
-| 4 | RSS feed integration (56 feeds, 7 categories) | **Done** |
-| 5 | Next.js API routes rewrite (Postgres reads) | Pending (Week 2) |
-| 6 | Card redesign — text-first + RSS images | Pending (Week 2) |
-| 7 | Vercel Cron configuration | Pending (Week 2) |
-| 8 | Clerk auth integration | Pending (Week 2) |
-| 9 | Custom topics — vector search + fallback | Pending (Week 3) |
-| 10 | SSE streaming for article delivery | Pending (Week 2) |
-| 11 | LangGraph comparison workflow | Pending (Week 3) |
-| 12 | Landing page at siftnews.ai | Pending (Week 3) |
-
----
-
-## What's next: Week 2
-
-Rewrite the Next.js frontend to read from Postgres instead of calling Claude directly. This is the core v2 shift — AI moves out of the request path.
-
-**Key changes:**
-1. **New `lib/db.ts`** — Postgres client (Neon serverless driver or @vercel/postgres)
-2. **Rewrite `app/api/news/route.ts`** — `SELECT * FROM articles WHERE category = $1 ORDER BY published_date DESC LIMIT 7` instead of Claude web_search
-3. **Add `app/api/cron/refresh/route.ts`** — Vercel Cron handler that triggers Railway pipeline
-4. **Remove `lib/cache.ts`** — Postgres is the cache now
-5. **Simplify `CardImage.tsx`** — RSS images or text-first, no OG scraping
-6. **Update `ArticleCard.tsx`** — text-first variant for articles without images
-7. **Add Clerk auth** — ClerkProvider, middleware, sign-in/sign-up pages
-8. **Update tests** — adapt to Postgres reads instead of Claude mocks
+| 4 | RSS feed integration (100+ feeds, 10 categories) | **Done** |
+| 5 | Next.js API routes rewrite (Postgres reads) | **Done** |
+| 6 | Card redesign — text-first + RSS images | **Done** |
+| 7 | Background refresh (Railway asyncio scheduler) | **Done** |
+| 8 | Clerk auth integration | **Done** |
+| 9 | Custom topics — vector search + web search fallback (SSE) | **Done** |
+| 10 | SSE streaming for topic search | **Done** |
+| 11 | LangGraph comparison workflow | **Done** |
+| 12 | Landing page | **Done** |
+| 13 | 3 new categories (politics, sports, entertainment) | **Done** |
+| 14 | Production deploy (Vercel + Railway + Neon) | **Done** |
+| 15 | CI/CD (GitHub Actions both repos) | **Done** |
+| 16 | Brand identity (B4 color story + B2 SiftLogo) | **Done** |
 
 ---
 
@@ -170,3 +153,9 @@ Rewrite the Next.js frontend to read from Postgres instead of calling Claude dir
 | 3/28/26 | Persistent disk cache | Cold start: 20s → <400ms |
 | 3/28/26 | v2: RSS hybrid + Postgres + LangGraph | Background pipeline, <50ms reads (see DECISIONS.md) |
 | 3/28/26 | 56 RSS feeds (expanded from 28) | Added Axios, Hacker News, Economist, ArXiv, etc. |
+| 3/29/26 | Neon Postgres (standalone) over Vercel Postgres | More control, same tech, free tier |
+| 3/29/26 | Railway asyncio scheduler over Vercel Cron | Avoids Pro plan requirement |
+| 3/30/26 | 10 categories (added politics, sports, entertainment) | Broader coverage, portfolio showcase |
+| 3/30/26 | Production deploy: Vercel + Railway + Neon | siftnews.kristenmartino.ai live |
+| 3/31/26 | B4: Named color palettes (Newsprint / Late Edition) | Warm editorial tones, semantic category colors |
+| 3/31/26 | B2: SiftLogo diamond mark component | Replaces hardcoded text everywhere |

--- a/docs/TECHNICAL_SPEC.md
+++ b/docs/TECHNICAL_SPEC.md
@@ -1,8 +1,9 @@
 # Sift — Technical Specification
 
-**Version:** 1.0
-**Date:** March 28, 2026
-**Companion doc:** SIFT_DECISIONS_v2.md (all architectural decisions)
+**Version:** 1.1
+**Date:** March 31, 2026
+**Companion doc:** DECISIONS.md (all architectural decisions)
+**Live:** siftnews.kristenmartino.ai
 
 ---
 
@@ -12,9 +13,9 @@ Two services + one database:
 
 | Service | Platform | Language | Purpose |
 |---------|----------|----------|---------|
-| sift-web | Vercel Pro | TypeScript (Next.js 15) | Frontend, API routes (DB reads), Clerk auth, Vercel Cron trigger |
-| sift-api | Railway | Python (FastAPI + LangGraph) | Background pipeline, multi-source comparison |
-| sift-db | Vercel Postgres (Neon) | PostgreSQL 16 + pgvector | Shared database, single source of truth |
+| sift-web | Vercel (Hobby) | TypeScript (Next.js 15) | Frontend, API routes (DB reads), Clerk auth, SSE streaming |
+| sift-api | Railway | Python (FastAPI + LangGraph) | Background pipeline (10-min scheduler), multi-source comparison |
+| sift-db | Neon (free tier) | PostgreSQL 17 + pgvector | Shared database, single source of truth |
 
 ---
 
@@ -112,7 +113,7 @@ CREATE TABLE pipeline_state (
 
 ## 3. API Contract — sift-api (Python / Railway)
 
-Base URL: `https://sift-api.up.railway.app` (or custom domain)
+Base URL: `https://sift-api-production.up.railway.app`
 
 ### POST /pipeline/refresh
 
@@ -386,7 +387,7 @@ Feeds to be consumed by the background pipeline. Grouped by category. Each feed 
 | Fierce Healthcare | `https://www.fiercehealthcare.com/rss/xml` | RSS 2.0 |
 | CDC MMWR | `https://tools.cdc.gov/api/v2/resources/media/342778.rss` | RSS 2.0 |
 
-**Total: 56 feeds across 7 categories.**
+**Total: 100+ feeds across 10 categories.** (Politics, Sports, and Entertainment feeds added March 2026.)
 
 **Image extraction from RSS:**
 Most RSS feeds include images via one of these tags:
@@ -446,7 +447,7 @@ VOYAGE_API_KEY=va-...
 PIPELINE_API_KEY=shared-secret-for-pipeline-trigger
 
 # App
-PORT=8000
+PORT=8080  # Railway auto-injects this; do not hardcode 8000
 ENVIRONMENT=production
 LOG_LEVEL=info
 ```
@@ -532,14 +533,6 @@ httpx>=0.28.0
 - `app/sign-up/[[...sign-up]]/page.tsx` — Clerk sign-up page
 - `middleware.ts` — Clerk auth middleware
 
-### vercel.json (Cron configuration):
-```json
-{
-  "crons": [
-    {
-      "path": "/api/cron/refresh",
-      "schedule": "*/10 * * * *"
-    }
-  ]
-}
-```
+### Background refresh
+
+Pipeline refresh runs via Railway's asyncio background scheduler (every 10 minutes in production). A Vercel cron route (`/api/cron/refresh`) exists as a manual fallback but is not actively scheduled (avoids Vercel Pro requirement). `vercel.json` is empty (`{}`).


### PR DESCRIPTION
## Summary
- Rewrite README for current production architecture and features
- Update DECISIONS.md: add D18-D21 (Neon, domain, 10 cats, brand identity), fix costs to actual ~$9/mo
- Mark all PROJECT_PLAN.md tasks complete, update decision log through 3/31
- Fix ARCHITECTURE.md: Vercel Hobby (not Pro), Neon standalone, Railway scheduler, 10 categories
- Update PRD.md: domain, categories, cost, value proposition
- Rewrite PRODUCT_STORY.md results section for v2 production
- Update TECHNICAL_SPEC.md: Railway port note, 100+ feeds, scheduler over cron

## Test plan
- [ ] All markdown renders correctly on GitHub
- [ ] No stale references to 7 categories, siftnews.ai, Vercel Pro, $30/mo, or "stub"

