### PR TITLE
Add compare source picker (12 outlets, collapsed chip selector)

### DIFF
--- a/components/CompareView.tsx
+++ b/components/CompareView.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { COMPARE_SOURCES } from "@/lib/constants";
 import type { CompareClaim } from "@/lib/types";
+
+const MAX_SOURCES = 5;
+const MIN_SOURCES = 2;
 
 interface CompareViewProps {
   topic: string;
@@ -9,8 +13,10 @@ interface CompareViewProps {
   sourcesChecked: string[];
   claims: CompareClaim[];
   durationMs: number;
-  onCompareAnother: (topic: string) => void;
+  onCompareAnother: (topic: string, sources: string[]) => void;
   onClose: () => void;
+  selectedSources: string[];
+  onToggleSource: (key: string) => void;
 }
 
 const AGREEMENT_STYLES: Record<string, { label: string; bg: string; color: string; border: string; dot: string }> = {
@@ -52,20 +58,27 @@ export default function CompareView({
   durationMs,
   onCompareAnother,
   onClose,
+  selectedSources,
+  onToggleSource,
 }: CompareViewProps) {
   const [inputValue, setInputValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const [expandedClaim, setExpandedClaim] = useState<number | null>(null);
+  const [sourcesExpanded, setSourcesExpanded] = useState(false);
 
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "smooth" });
   }, []);
 
+  const selectedLabels = selectedSources
+    .map((key) => COMPARE_SOURCES.find((s) => s.key === key)?.label ?? key)
+    .join(", ");
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = inputValue.trim();
-    if (trimmed.length >= 3) {
-      onCompareAnother(trimmed);
+    if (trimmed.length >= 3 && selectedSources.length >= MIN_SOURCES) {
+      onCompareAnother(trimmed, selectedSources);
       setInputValue("");
     }
   };
@@ -248,18 +261,59 @@ export default function CompareView({
           />
           <button
             type="submit"
-            disabled={inputValue.trim().length < 3}
+            disabled={inputValue.trim().length < 3 || selectedSources.length < MIN_SOURCES}
             aria-label="Compare"
             className="flex items-center justify-center w-9 h-9 rounded-full text-sm cursor-pointer transition-all duration-200 shrink-0"
             style={{
-              background: inputValue.trim().length >= 3 ? "var(--accent)" : "transparent",
-              color: inputValue.trim().length >= 3 ? "#fff" : "var(--text-muted)",
-              border: `1px solid ${inputValue.trim().length >= 3 ? "var(--accent)" : "var(--border)"}`,
+              background: inputValue.trim().length >= 3 && selectedSources.length >= MIN_SOURCES ? "var(--accent)" : "transparent",
+              color: inputValue.trim().length >= 3 && selectedSources.length >= MIN_SOURCES ? "#fff" : "var(--text-muted)",
+              border: `1px solid ${inputValue.trim().length >= 3 && selectedSources.length >= MIN_SOURCES ? "var(--accent)" : "var(--border)"}`,
             }}
           >
             &rarr;
           </button>
         </form>
+
+        {/* Source picker */}
+        <div className="mt-3">
+          <button
+            type="button"
+            onClick={() => setSourcesExpanded(!sourcesExpanded)}
+            className="text-xs text-[var(--text-muted)] cursor-pointer bg-transparent border-none p-0 transition-colors duration-200"
+            style={{ color: sourcesExpanded ? "var(--accent)" : undefined }}
+          >
+            Comparing: {selectedLabels} {sourcesExpanded ? "▴" : "▾"}
+          </button>
+          {sourcesExpanded && (
+            <div className="flex flex-wrap gap-1.5 mt-2 animate-fade-slide-in">
+              {COMPARE_SOURCES.map((source) => {
+                const isSelected = selectedSources.includes(source.key);
+                const atMax = selectedSources.length >= MAX_SOURCES;
+                const disabled = !isSelected && atMax;
+                return (
+                  <button
+                    key={source.key}
+                    type="button"
+                    onClick={() => !disabled && onToggleSource(source.key)}
+                    className="px-2.5 py-1 rounded-full text-[11px] font-medium cursor-pointer transition-all duration-200 border"
+                    style={{
+                      background: isSelected ? "var(--accent)" : "transparent",
+                      color: isSelected ? "#fff" : disabled ? "var(--text-muted)" : "var(--text-secondary)",
+                      borderColor: isSelected ? "var(--accent)" : "var(--border)",
+                      opacity: disabled ? 0.4 : 1,
+                      cursor: disabled ? "not-allowed" : "pointer",
+                    }}
+                  >
+                    {source.label}
+                  </button>
+                );
+              })}
+              <span className="text-[10px] text-[var(--text-muted)] self-center ml-1">
+                {selectedSources.length}/{MAX_SOURCES} selected
+              </span>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
-import { CATEGORIES } from "@/lib/constants";
+import { CATEGORIES, COMPARE_SOURCES, DEFAULT_COMPARE_SOURCES } from "@/lib/constants";
 import { timeAgo } from "@/lib/utils";
 import { useNewsLoader, useBookmarks, useTheme, useTopicSearch, useCompare } from "@/lib/hooks";
 import ArticleCard from "./ArticleCard";
@@ -31,6 +31,8 @@ export default function NewsAggregator() {
   const [searchMode, setSearchMode] = useState(false);
   const [compareMode, setCompareMode] = useState(false);
   const [compareInputValue, setCompareInputValue] = useState("");
+  const [selectedSources, setSelectedSources] = useState<string[]>([...DEFAULT_COMPARE_SOURCES]);
+  const [sourcesExpanded, setSourcesExpanded] = useState(false);
 
   const [refreshed, setRefreshed] = useState(false);
   const [bookmarkedArticles, setBookmarkedArticles] = useState<Article[]>([]);
@@ -94,12 +96,24 @@ export default function NewsAggregator() {
     setTimeout(() => setRefreshed(false), 2000);
   };
 
-  const handleCompare = (topic: string) => {
+  const toggleSource = (key: string) => {
+    setSelectedSources((prev) => {
+      if (prev.includes(key)) return prev.filter((s) => s !== key);
+      if (prev.length >= 5) return prev;
+      return [...prev, key];
+    });
+  };
+
+  const selectedLabels = selectedSources
+    .map((key) => COMPARE_SOURCES.find((s) => s.key === key)?.label ?? key)
+    .join(", ");
+
+  const handleCompare = (topic: string, sources?: string[]) => {
     setCompareMode(true);
     setShowBookmarks(false);
     setSearchMode(false);
     clearTopicSearch();
-    runCompare(topic);
+    runCompare(topic, sources || selectedSources);
   };
 
   const exitCompareMode = () => {
@@ -281,7 +295,7 @@ export default function NewsAggregator() {
               onSubmit={(e) => {
                 e.preventDefault();
                 const trimmed = compareInputValue.trim();
-                if (trimmed.length >= 3) handleCompare(trimmed);
+                if (trimmed.length >= 3 && selectedSources.length >= 2) handleCompare(trimmed, selectedSources);
               }}
               className="flex items-center gap-2"
             >
@@ -322,6 +336,45 @@ export default function NewsAggregator() {
                 </button>
               </div>
             </form>
+            <div className="mt-2 ml-11">
+              <button
+                type="button"
+                onClick={() => setSourcesExpanded(!sourcesExpanded)}
+                className="text-xs text-[var(--text-muted)] cursor-pointer bg-transparent border-none p-0 transition-colors duration-200"
+                style={{ color: sourcesExpanded ? "var(--accent)" : undefined }}
+              >
+                Comparing: {selectedLabels} {sourcesExpanded ? "▴" : "▾"}
+              </button>
+              {sourcesExpanded && (
+                <div className="flex flex-wrap gap-1.5 mt-2 animate-fade-slide-in">
+                  {COMPARE_SOURCES.map((source) => {
+                    const isSelected = selectedSources.includes(source.key);
+                    const atMax = selectedSources.length >= 5;
+                    const disabled = !isSelected && atMax;
+                    return (
+                      <button
+                        key={source.key}
+                        type="button"
+                        onClick={() => !disabled && toggleSource(source.key)}
+                        className="px-2.5 py-1 rounded-full text-[11px] font-medium cursor-pointer transition-all duration-200 border"
+                        style={{
+                          background: isSelected ? "var(--accent)" : "transparent",
+                          color: isSelected ? "#fff" : disabled ? "var(--text-muted)" : "var(--text-secondary)",
+                          borderColor: isSelected ? "var(--accent)" : "var(--border)",
+                          opacity: disabled ? 0.4 : 1,
+                          cursor: disabled ? "not-allowed" : "pointer",
+                        }}
+                      >
+                        {source.label}
+                      </button>
+                    );
+                  })}
+                  <span className="text-[10px] text-[var(--text-muted)] self-center ml-1">
+                    {selectedSources.length}/5
+                  </span>
+                </div>
+              )}
+            </div>
           </div>
         )}
       </header>
@@ -364,6 +417,8 @@ export default function NewsAggregator() {
                 durationMs={compareDuration!}
                 onCompareAnother={handleCompare}
                 onClose={exitCompareMode}
+                selectedSources={selectedSources}
+                onToggleSource={toggleSource}
               />
             )}
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,6 +26,10 @@
 | D15 | Image handling | RSS feed images only — no OG scraping, no proxy | $0 | SETTLED |
 | D16 | Background refresh | Railway asyncio scheduler (every 10 min) + Vercel cron fallback | $0 | SETTLED |
 | D17 | Model selection | Haiku 4.5 (upgrade to Sonnet is one-line change) | ~$4/mo | SETTLED |
+| D22 | Compare source picker | Collapsed-by-default chip selector, 12 curated outlets | $0 | SETTLED |
+| D23 | Compare source list | Curated outlets, not freeform input | $0 | SETTLED |
+| D24 | Compare source limits | Min 2, max 5 sources per comparison | $0 | SETTLED |
+| D25 | Per-source timeout | 20s timeout per source in compare workflow | $0 | SETTLED |
 
 **Total estimated monthly cost: ~$30-50/mo**
 
@@ -416,3 +420,35 @@ Each category has 8-11 RSS feeds. Expanded total from ~56 feeds to 100+ feeds. C
 - Themes: "Late Edition" (dark, warm stone tones) and "Newsprint" (light, warm paper)
 - Brand mark: SVG diamond rendered at all sizes via SiftLogo component with full/compact/mark/wordmark variants
 - Category colors: each chosen for semantic meaning, not decoration
+
+### D22. Compare source picker — collapsed by default
+**Decision:** Add a chip selector UI for choosing which outlets to compare, collapsed behind a "Comparing: Reuters, BBC, AP — Change" toggle.
+
+- Default 3 sources (Reuters, BBC, AP) preserves current behavior — zero friction for quick comparisons
+- Expanded state shows 12 curated outlets as toggleable chips
+- Alternative considered: always-visible source grid. Rejected because it clutters the compare form for the common case (most users accept defaults)
+- Alternative considered: freeform text input. Rejected because Claude web_search reliability varies with arbitrary outlet names
+
+### D23. Compare source list — curated, not freeform
+**Decision:** 12 pre-selected outlets spanning wire services (Reuters, AP), broadcast (BBC, CNN, Al Jazeera, NPR), print (Guardian, NYT, Washington Post, Economist, FT), and digital-native (Axios).
+
+- Each outlet tested against Claude's `web_search` tool for reliable results
+- Geographic and editorial diversity: US, UK, Middle East, wire services
+- Matches sources already in the RSS feed list for consistency
+- Labels are abbreviated for chip display (NYT, AP, Wash. Post, FT, Economist)
+
+### D24. Compare source limits — min 2, max 5
+**Decision:** Minimum 2 sources (comparison needs at least 2), maximum 5 (caps latency and cost).
+
+- Each source triggers a Claude web_search call (~$0.004 each)
+- 5 sources run in parallel but Claude rate limits may serialize them
+- Backend already validates `len(sources) > 5` → 400 error
+- Frontend disables unselected chips when 5 are selected, disables submit when < 2
+
+### D25. Per-source timeout — 20 seconds
+**Decision:** Wrap each source's Claude API call in `asyncio.wait_for(_, timeout=20)`.
+
+- Without per-source timeout, one slow/stuck source blocks the entire comparison
+- 20s is generous for a single web_search + summary call (typically 5-12s)
+- On timeout, source returns empty and is logged as an error — remaining sources still produce results
+- Graceful degradation: 3/5 sources succeeding is better than 0/5 from a global timeout

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -60,6 +60,25 @@ export const GRADIENTS: Record<CategoryId, string> = {
   entertainment: "linear-gradient(135deg, #200a15 0%, #2e1020 50%, #3d0f25 100%)",
 };
 
+// ─── Compare Sources ────────────────────────────────────
+
+export const COMPARE_SOURCES = [
+  { key: "reuters", label: "Reuters" },
+  { key: "bbc", label: "BBC" },
+  { key: "associated press", label: "AP" },
+  { key: "cnn", label: "CNN" },
+  { key: "the guardian", label: "The Guardian" },
+  { key: "the new york times", label: "NYT" },
+  { key: "the washington post", label: "Wash. Post" },
+  { key: "al jazeera", label: "Al Jazeera" },
+  { key: "npr", label: "NPR" },
+  { key: "axios", label: "Axios" },
+  { key: "the economist", label: "Economist" },
+  { key: "financial times", label: "FT" },
+] as const;
+
+export const DEFAULT_COMPARE_SOURCES = ["reuters", "bbc", "associated press"];
+
 // ─── Timing ─────────────────────────────────────────────
 
 export const API_TIMEOUT_MS = 10_000; // 10s — DB reads are fast, no need for 90s

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -113,6 +113,13 @@ export interface ErrorStateProps {
   onRetry: () => void;
 }
 
+// ─── Compare Source Types ───────────────────────────────
+
+export interface CompareSource {
+  key: string;
+  label: string;
+}
+
 // ─── State Types ────────────────────────────────────────
 
 export interface ArticleCache {


### PR DESCRIPTION
## Summary
- Adds source picker UI to both the top compare input bar and the bottom "Compare Another Topic" form
- 12 curated outlets (Reuters, BBC, AP, CNN, Guardian, NYT, Wash. Post, Al Jazeera, NPR, Axios, Economist, FT)
- Collapsed by default showing "Comparing: Reuters, BBC, AP ▾", expands to toggleable chip grid
- Min 2 / max 5 sources, shared state between top and bottom pickers
- Documents D22–D25 in DECISIONS.md

## Files changed
- `lib/types.ts` — CompareSource interface
- `lib/constants.ts` — COMPARE_SOURCES + DEFAULT_COMPARE_SOURCES
- `components/CompareView.tsx` — source picker in results view, accepts shared state via props
- `components/NewsAggregator.tsx` — source picker in header, lifted state, wires sources through handleCompare
- `docs/DECISIONS.md` — D22–D25

## Test plan
- [ ] Enter compare mode — see "Comparing: Reuters, BBC, AP ▾" below input
- [ ] Click ▾ — chip grid expands with 12 outlets, 3 selected
- [ ] Select 2 more — chips highlight, counter shows 5/5
- [ ] Try selecting 6th — disabled
- [ ] Deselect to 1 — submit disabled
- [ ] Run comparison with custom sources — results show selected outlets
- [ ] "Compare Another Topic" at bottom shows same picker in sync

