### PR TITLE
B5: Custom 404 page and reusable EmptyState component

### DIFF
--- a/__tests__/ErrorState.test.tsx
+++ b/__tests__/ErrorState.test.tsx
@@ -1,22 +1,23 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import ErrorState from "@/components/ErrorState";
+import { COPY } from "@/lib/copy";
 
 describe("ErrorState", () => {
   it("renders error message", () => {
     render(<ErrorState message="Something broke" onRetry={() => {}} />);
     expect(screen.getByText("Something broke")).toBeInTheDocument();
-    expect(screen.getByText("Couldn't load articles")).toBeInTheDocument();
+    expect(screen.getByText(COPY.error.title)).toBeInTheDocument();
   });
 
   it("renders fallback message when none provided", () => {
     render(<ErrorState message="" onRetry={() => {}} />);
-    expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
+    expect(screen.getByText(COPY.error.body)).toBeInTheDocument();
   });
 
   it("calls onRetry when button clicked", () => {
     const onRetry = jest.fn();
     render(<ErrorState message="Error" onRetry={onRetry} />);
-    fireEvent.click(screen.getByText("Try Again"));
+    fireEvent.click(screen.getByText(COPY.error.button));
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { COPY } from "@/lib/copy";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Page Not Found",
+};
+
+export default function NotFound() {
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center px-5"
+      style={{ background: "var(--bg)", color: "var(--text)" }}
+    >
+      <div className="text-center max-w-[400px]">
+        <div
+          className="text-[80px] leading-none mb-6 text-[var(--accent)]"
+          style={{ opacity: 0.15 }}
+        >
+          &#x25C6;
+        </div>
+        <p className="font-heading text-xl font-bold text-[var(--text-secondary)] mb-2">
+          {COPY.notFound.title}
+        </p>
+        <p className="text-sm text-[var(--text-muted)] leading-relaxed mb-6">
+          {COPY.notFound.body}
+        </p>
+        <Link
+          href="/"
+          className="inline-block bg-[var(--accent)] text-white px-7 py-2.5 rounded-full text-sm font-semibold font-body hover:opacity-90 transition-opacity no-underline"
+        >
+          {COPY.notFound.button}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+interface EmptyStateProps {
+  title: string;
+  body: string;
+  action?: { label: string; onClick: () => void };
+}
+
+export default function EmptyState({ title, body, action }: EmptyStateProps) {
+  return (
+    <div className="text-center py-20 px-5">
+      <div
+        className="text-[80px] leading-none mb-6 text-[var(--accent)]"
+        style={{ opacity: 0.15 }}
+      >
+        &#x25C6;
+      </div>
+      <p className="font-heading text-lg font-bold text-[var(--text-secondary)] mb-2">
+        {title}
+      </p>
+      <p className="text-sm text-[var(--text-muted)] max-w-[360px] mx-auto leading-relaxed mb-5">
+        {body}
+      </p>
+      {action && (
+        <button
+          onClick={action.onClick}
+          className="bg-[var(--accent)] text-white border-none px-7 py-2.5 rounded-full text-sm font-semibold cursor-pointer font-body hover:opacity-90 transition-opacity"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -8,6 +8,7 @@ import { timeAgo } from "@/lib/utils";
 import { useNewsLoader, useBookmarks, useTheme, useTopicSearch, useCompare } from "@/lib/hooks";
 import ArticleCard from "./ArticleCard";
 import SkeletonCard from "./SkeletonCard";
+import EmptyState from "./EmptyState";
 import ErrorState from "./ErrorState";
 import TopicSearch from "./TopicSearch";
 import CompareView from "./CompareView";
@@ -425,15 +426,10 @@ export default function NewsAggregator() {
 
             {/* Compare empty state (input shown, no results yet) */}
             {!compareLoading && !compareError && !compareComparison && (
-              <div className="text-center py-20 px-5 text-[var(--text-muted)]">
-                <div className="text-5xl mb-4 opacity-30">⇌</div>
-                <p className="text-base font-semibold text-[var(--text-secondary)]">
-                  {COPY.compare.emptyTitle}
-                </p>
-                <p className="text-sm mt-2">
-                  {COPY.compare.emptyBody}
-                </p>
-              </div>
+              <EmptyState
+                title={COPY.compare.emptyTitle}
+                body={COPY.compare.emptyBody}
+              />
             )}
           </>
         ) : (
@@ -494,15 +490,19 @@ export default function NewsAggregator() {
 
             {/* Empty bookmarks */}
             {showBookmarks && !hasData && !loading && !loadingBookmarks && (
-              <div className="text-center py-20 px-5 text-[var(--text-muted)]">
-                <div className="text-5xl mb-4 opacity-30">☆</div>
-                <p className="text-base font-semibold text-[var(--text-secondary)]">
-                  {COPY.bookmarks.emptyTitle}
-                </p>
-                <p className="text-sm mt-2">
-                  {COPY.bookmarks.emptyBody}
-                </p>
-              </div>
+              <EmptyState
+                title={COPY.bookmarks.emptyTitle}
+                body={COPY.bookmarks.emptyBody}
+              />
+            )}
+
+            {/* Empty search results */}
+            {searchMode && !topicLoading && !topicError && !hasData && topicQuery && (
+              <EmptyState
+                title={COPY.searchEmpty.title}
+                body={COPY.searchEmpty.body}
+                action={{ label: COPY.searchEmpty.button, onClick: () => { setSearchMode(false); clearTopicSearch(); } }}
+              />
             )}
 
             {/* Articles grid */}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -46,5 +46,17 @@ export const COPY = {
   articles: {
     updated: "Updated just now",
     searchTopics: "Search Topics",
+    emptyTitle: "No stories yet for this topic",
+    emptyBody: "Check back in a bit \u2014 the AI is still looking.",
+  },
+  notFound: {
+    title: "This page wandered off",
+    body: "We looked everywhere \u2014 even had the AI search for it. Let\u2019s get you back to the stories.",
+    button: "Back to Sift",
+  },
+  searchEmpty: {
+    title: "Nothing matched that search",
+    body: "Try different words \u2014 or let the AI surprise you.",
+    button: "Browse today\u2019s stories",
   },
 } as const;


### PR DESCRIPTION
## Summary
- Creates `app/not-found.tsx` — branded 404 page with diamond mark and "This page wandered off" copy
- Creates `components/EmptyState.tsx` — reusable component (diamond mark at 15% opacity, headline, body, optional CTA)
- Replaces inline bookmarks/compare empty states with `<EmptyState>`
- Adds search empty state with "Browse today's stories" CTA button
- Updates ErrorState tests for B3 copy changes

## Test plan
- [ ] Visit `/nonexistent-page` — see branded 404 with diamond mark and "Back to Sift" link
- [ ] Empty bookmarks — shows diamond mark + "Nothing saved yet"
- [ ] Compare empty state — shows diamond mark + branded copy
- [ ] Search with no results — shows "Nothing matched that search" + browse button
- [ ] `npx jest --ci` passes (39/39)
- [ ] `npx tsc --noEmit` passes

