### PR TITLE
Add micro-interactions with branded personality (B9)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -49,6 +49,12 @@ html[data-theme="light"] {
   --pill-text: #ffffff;
 }
 
+/* ─── Theme Transition ─────────────────────────────────── */
+/* Smooth cross-fade when toggling between Late Edition / Newsprint */
+html {
+  transition: background-color 0.3s ease, color 0.2s ease;
+}
+
 /* ─── Base Reset ───────────────────────────────────────── */
 * {
   box-sizing: border-box;
@@ -62,6 +68,7 @@ body {
   color: var(--text);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  transition: background-color 0.3s ease;
 }
 
 /* ─── Scrollbar ────────────────────────────────────────── */
@@ -97,4 +104,60 @@ a:focus-visible {
 }
 .skip-nav:focus {
   left: 0;
+}
+
+/* ─── Theme Transition on Cards & Elements ────────────── */
+/* Smooth background transitions when switching themes */
+header,
+main,
+footer,
+article,
+[style*="background: var(--card-bg)"],
+[style*="background: var(--nav-bg)"] {
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.2s ease;
+}
+
+/* ─── Bookmark Pop Animation ──────────────────────────── */
+@keyframes bookmark-pop {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.35); }
+  60%  { transform: scale(0.95); }
+  100% { transform: scale(1.15); }
+}
+@keyframes bookmark-burst {
+  0%   { opacity: 1; transform: scale(0.5); }
+  100% { opacity: 0; transform: scale(1.8); }
+}
+
+/* ─── Card Entrance Stagger (fan-out) ─────────────────── */
+@keyframes card-enter-left {
+  from { opacity: 0; transform: translateY(16px) translateX(-8px); }
+  to   { opacity: 1; transform: translateY(0) translateX(0); }
+}
+@keyframes card-enter-right {
+  from { opacity: 0; transform: translateY(16px) translateX(8px); }
+  to   { opacity: 1; transform: translateY(0) translateX(0); }
+}
+
+/* ─── Branded Refresh Spinner ─────────────────────────── */
+@keyframes sift-refresh {
+  0%   { transform: rotate(0deg) scale(1); opacity: 0.5; }
+  50%  { transform: rotate(180deg) scale(1.1); opacity: 1; }
+  100% { transform: rotate(360deg) scale(1); opacity: 0.5; }
+}
+
+/* ─── Story Expand Animation ──────────────────────────── */
+@keyframes story-expand {
+  from { max-height: 0; opacity: 0; transform: translateY(-8px); }
+  to   { max-height: 500px; opacity: 1; transform: translateY(0); }
+}
+
+/* ─── Category Fade Transition ────────────────────────── */
+@keyframes category-fade-out {
+  from { opacity: 1; }
+  to   { opacity: 0; transform: translateY(4px); }
+}
+@keyframes category-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
 }

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -1,11 +1,21 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { CATEGORIES, CATEGORY_COLORS } from "@/lib/constants";
 import { COPY } from "@/lib/copy";
 import { timeAgo } from "@/lib/utils";
 import CardImage from "./CardImage";
 import type { ArticleCardProps } from "@/lib/types";
+
+// Fan-out stagger: even-indexed cards drift from left, odd from right
+function getEntranceStyle(index: number): React.CSSProperties {
+  if (index === 0) return {}; // first card: center (default fade-slide-in)
+  const direction = index % 2 === 0 ? "card-enter-left" : "card-enter-right";
+  return {
+    animation: `${direction} 0.5s ease-out both`,
+    animationDelay: `${index * 60}ms`,
+  };
+}
 
 export default function ArticleCard({
   article,
@@ -16,9 +26,25 @@ export default function ArticleCard({
   onCompare,
 }: ArticleCardProps) {
   const [hovered, setHovered] = useState(false);
+  const [bookmarkAnimating, setBookmarkAnimating] = useState(false);
+  const prevBookmarked = useRef(isBookmarked);
   const cat = CATEGORIES.find((c) => c.id === article.category) || CATEGORIES[0];
   const color = CATEGORY_COLORS[article.category] || CATEGORY_COLORS.top;
   const hasImage = !!article.imageUrl;
+
+  // Trigger pop animation when bookmark state changes to true
+  useEffect(() => {
+    if (isBookmarked && !prevBookmarked.current) {
+      setBookmarkAnimating(true);
+      const timer = setTimeout(() => setBookmarkAnimating(false), 400);
+      return () => clearTimeout(timer);
+    }
+    prevBookmarked.current = isBookmarked;
+  }, [isBookmarked]);
+
+  const entranceStyle = index === 0
+    ? { animationDelay: "0ms" }
+    : getEntranceStyle(index);
 
   return (
     <article
@@ -26,23 +52,34 @@ export default function ArticleCard({
       onMouseLeave={() => setHovered(false)}
       className={`
         bg-[var(--card-bg)] rounded-[14px] overflow-hidden cursor-pointer
-        border border-[var(--border)] animate-fade-slide-in
+        border border-[var(--border)] ${index === 0 ? "animate-fade-slide-in" : ""}
         ${featured && hasImage ? "col-span-full grid grid-cols-1 md:grid-cols-2" : ""}
       `}
       style={{
-        transition: "transform 0.4s cubic-bezier(0.16,1,0.3,1), box-shadow 0.4s cubic-bezier(0.16,1,0.3,1)",
+        position: "relative",
+        transition: "transform 0.4s cubic-bezier(0.16,1,0.3,1), box-shadow 0.4s cubic-bezier(0.16,1,0.3,1), background-color 0.3s ease, border-color 0.3s ease",
         transform: hovered ? "translateY(-4px)" : "translateY(0)",
         boxShadow: hovered
           ? "0 20px 60px var(--shadow-hover)"
           : "0 2px 16px var(--shadow)",
-        animationDelay: `${index * 60}ms`,
         // Text-first card: thin accent bar at top when no image
         borderTop: !hasImage ? `3px solid ${color.hex}` : undefined,
+        ...entranceStyle,
       }}
       onClick={() =>
         article.sourceUrl && window.open(article.sourceUrl, "_blank", "noopener")
       }
     >
+      {/* Hover glow — accent-colored bar at top edge */}
+      <div
+        className="absolute top-0 left-0 right-0 h-[2px] transition-opacity duration-300 pointer-events-none"
+        style={{
+          background: color.hex,
+          opacity: hovered ? 0.6 : 0,
+          zIndex: 1,
+        }}
+      />
+
       {/* Image area — only rendered if article has an image */}
       {hasImage && (
         <CardImage
@@ -77,13 +114,25 @@ export default function ArticleCard({
               onBookmark(article.id);
             }}
             aria-label={isBookmarked ? "Remove bookmark" : "Add bookmark"}
-            className="bg-transparent border-none cursor-pointer text-lg p-1 transition-all duration-200"
+            className={`bg-transparent border-none cursor-pointer text-lg p-1 relative ${
+              bookmarkAnimating ? "animate-bookmark-pop" : "transition-all duration-200"
+            }`}
             style={{
               color: isBookmarked ? "#f59e0b" : "var(--text-muted)",
-              transform: isBookmarked ? "scale(1.15)" : "scale(1)",
+              transform: !bookmarkAnimating && isBookmarked ? "scale(1.15)" : !bookmarkAnimating ? "scale(1)" : undefined,
             }}
           >
             {isBookmarked ? "\u2605" : "\u2606"}
+            {/* Particle burst ring */}
+            {bookmarkAnimating && (
+              <span
+                className="absolute inset-0 rounded-full pointer-events-none"
+                style={{
+                  border: "2px solid #f59e0b",
+                  animation: "bookmark-burst 0.4s ease-out forwards",
+                }}
+              />
+            )}
           </button>
         </div>
 

--- a/components/CompareView.tsx
+++ b/components/CompareView.tsx
@@ -203,7 +203,13 @@ export default function CompareView({
 
               {/* Disputed details */}
               {isExpanded && isDisputed && (
-                <div className="mt-3 pt-3 border-t border-[var(--border)] text-xs space-y-1.5 animate-fade-slide-in">
+                <div
+                  className="mt-3 pt-3 border-t border-[var(--border)] text-xs space-y-1.5"
+                  style={{
+                    animation: "story-expand 0.3s ease-out both",
+                    overflow: "hidden",
+                  }}
+                >
                   {claim.sources_for && claim.sources_for.length > 0 && (
                     <div className="flex items-start gap-2">
                       <span className="font-semibold" style={{ color: "#059669" }}>For:</span>

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
 import { CATEGORIES, COMPARE_SOURCES, DEFAULT_COMPARE_SOURCES } from "@/lib/constants";
 import { COPY } from "@/lib/copy";
@@ -36,7 +36,10 @@ export default function NewsAggregator() {
   const [selectedSources, setSelectedSources] = useState<string[]>([...DEFAULT_COMPARE_SOURCES]);
   const [sourcesExpanded, setSourcesExpanded] = useState(false);
 
+  const [categoryFading, setCategoryFading] = useState(false);
   const [refreshed, setRefreshed] = useState(false);
+  const pillContainerRef = useRef<HTMLDivElement>(null);
+  const [indicatorStyle, setIndicatorStyle] = useState<{ left: number; width: number } | null>(null);
   const [bookmarkedArticles, setBookmarkedArticles] = useState<Article[]>([]);
   const [loadingBookmarks, setLoadingBookmarks] = useState(false);
 
@@ -73,6 +76,35 @@ export default function NewsAggregator() {
   useEffect(() => {
     loadCategory(activeCategory);
   }, [activeCategory, loadCategory]);
+
+  // Category switch with fade-out/fade-in
+  const switchCategory = useCallback((catId: CategoryId) => {
+    if (catId === activeCategory) return;
+    setCategoryFading(true);
+    // Brief fade-out, then switch & fade-in
+    setTimeout(() => {
+      setActiveCategory(catId);
+      setCategoryFading(false);
+    }, 120);
+  }, [activeCategory]);
+
+  // Position the sliding indicator under the active pill
+  const updateIndicator = useCallback(() => {
+    const container = pillContainerRef.current;
+    if (!container) return;
+    const activeBtn = container.querySelector<HTMLButtonElement>("[data-active='true']");
+    if (!activeBtn) { setIndicatorStyle(null); return; }
+    const containerRect = container.getBoundingClientRect();
+    const btnRect = activeBtn.getBoundingClientRect();
+    setIndicatorStyle({
+      left: btnRect.left - containerRect.left,
+      width: btnRect.width,
+    });
+  }, []);
+
+  useEffect(() => {
+    updateIndicator();
+  }, [activeCategory, showBookmarks, searchMode, compareMode, updateIndicator]);
 
   // Fetch full bookmarked articles from DB when viewing bookmarks (signed in)
   useEffect(() => {
@@ -234,8 +266,8 @@ export default function NewsAggregator() {
                 color: refreshed ? "var(--accent)" : "var(--text-secondary)",
               }}
             >
-              <span className={loading ? "animate-spin-slow inline-block" : "inline-block"}>
-                {refreshed ? "✓" : "↻"}
+              <span className={loading ? "animate-sift-refresh inline-block" : "inline-block"}>
+                {refreshed ? "✓" : loading ? "◆" : "↻"}
               </span>
             </button>
 
@@ -253,15 +285,16 @@ export default function NewsAggregator() {
           </div>
         </div>
 
-        {/* Category pills */}
+        {/* Category pills with sliding indicator */}
         {!showBookmarks && !searchMode && !compareMode && (
-          <div className="max-w-[1200px] mx-auto px-6 pb-3 flex gap-1.5 overflow-x-auto">
+          <div ref={pillContainerRef} className="max-w-[1200px] mx-auto px-6 pb-3 flex gap-1.5 overflow-x-auto relative">
             {CATEGORIES.map((cat) => {
               const active = activeCategory === cat.id;
               return (
                 <button
                   key={cat.id}
-                  onClick={() => setActiveCategory(cat.id)}
+                  data-active={active}
+                  onClick={() => switchCategory(cat.id)}
                   className="flex items-center gap-1.5 px-4 py-1.5 rounded-full text-[13px] whitespace-nowrap cursor-pointer transition-all duration-200 font-body"
                   style={{
                     background: active ? "var(--pill-active)" : "transparent",
@@ -275,6 +308,18 @@ export default function NewsAggregator() {
                 </button>
               );
             })}
+            {/* Sliding indicator under active pill */}
+            {indicatorStyle && (
+              <div
+                className="absolute bottom-0 h-[2px] rounded-full"
+                style={{
+                  left: indicatorStyle.left,
+                  width: indicatorStyle.width,
+                  background: "var(--accent)",
+                  transition: "left 0.3s cubic-bezier(0.16,1,0.3,1), width 0.3s cubic-bezier(0.16,1,0.3,1)",
+                }}
+              />
+            )}
           </div>
         )}
 
@@ -389,7 +434,7 @@ export default function NewsAggregator() {
             {/* Compare loading */}
             {compareLoading && (
               <div className="text-center py-20 px-5 animate-fade-slide-in">
-                <div className="text-4xl mb-5 animate-spin-slow inline-block">⇌</div>
+                <div className="text-4xl mb-5 animate-sift-refresh inline-block text-[var(--accent)]">◆</div>
                 <p className="text-base font-semibold text-[var(--text-secondary)]">
                   {COPY.compare.loading}
                 </p>
@@ -505,9 +550,16 @@ export default function NewsAggregator() {
               />
             )}
 
-            {/* Articles grid */}
+            {/* Articles grid — fades on category switch */}
             {hasData && (
-              <div className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-5">
+              <div
+                className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-5"
+                style={{
+                  transition: "opacity 0.12s ease-out, transform 0.12s ease-out",
+                  opacity: categoryFading ? 0 : 1,
+                  transform: categoryFading ? "translateY(4px)" : "translateY(0)",
+                }}
+              >
                 {currentArticles.map((article, i) => (
                   <ArticleCard
                     key={article.id}
@@ -525,7 +577,7 @@ export default function NewsAggregator() {
             {/* Loading toast for refresh */}
             {loading && hasData && (
               <div className="fixed bottom-8 left-1/2 -translate-x-1/2 bg-[var(--card-bg)] border border-[var(--border)] rounded-full px-6 py-2.5 text-sm font-semibold text-[var(--text-secondary)] flex items-center gap-2.5 shadow-lg z-50 animate-fade-slide-in">
-                <span className="animate-spin-slow inline-block">↻</span>
+                <span className="animate-sift-refresh inline-block text-[var(--accent)]">◆</span>
                 {COPY.loading.refresh}
               </div>
             )}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -46,11 +46,29 @@ const config: Config = {
         spin: {
           to: { transform: "rotate(360deg)" },
         },
+        "bookmark-pop": {
+          "0%": { transform: "scale(1)" },
+          "40%": { transform: "scale(1.35)" },
+          "60%": { transform: "scale(0.95)" },
+          "100%": { transform: "scale(1.15)" },
+        },
+        "sift-refresh": {
+          "0%": { transform: "rotate(0deg) scale(1)", opacity: "0.5" },
+          "50%": { transform: "rotate(180deg) scale(1.1)", opacity: "1" },
+          "100%": { transform: "rotate(360deg) scale(1)", opacity: "0.5" },
+        },
+        "category-fade-in": {
+          from: { opacity: "0", transform: "translateY(8px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
       },
       animation: {
         shimmer: "shimmer 1.8s ease-in-out infinite",
         "fade-slide-in": "fade-slide-in 0.5s ease-out both",
         "spin-slow": "spin 1s linear infinite",
+        "bookmark-pop": "bookmark-pop 0.4s cubic-bezier(0.16,1,0.3,1) both",
+        "sift-refresh": "sift-refresh 1.2s ease-in-out infinite",
+        "category-fade-in": "category-fade-in 0.3s ease-out both",
       },
     },
   },


### PR DESCRIPTION
## Summary
- Theme toggle cross-fade (300ms) for smooth Late Edition / Newsprint switching
- Bookmark pop animation (two-phase bounce + particle burst ring) on star toggle
- Card entrance fan-out stagger (even cards from left, odd from right)
- Category switch fade-out/fade-in (120ms) with sliding accent indicator under active pill
- Hover glow (category-colored 2px bar at card top edge)
- Branded diamond (◆) refresh spinner replacing generic ↻ in refresh button, toast, and compare loading
- Story expand animation for disputed claim details in CompareView

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run build` clean
- [x] All 39 tests pass
- [ ] Toggle theme — backgrounds cross-fade smoothly
- [ ] Star an article — bookmark pops with burst ring
- [ ] Switch categories — articles fade out then fan in
- [ ] Check sliding indicator under active pill
- [ ] Hover article card — accent glow bar appears at top
- [ ] Refresh — diamond mark rotates and pulses
- [ ] Expand disputed claim in compare — smooth height reveal

