### PR TITLE
Smart category-aware compare sources

### DIFF
--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -180,7 +180,7 @@ export default function ArticleCard({
               <button
                 onClick={(e) => {
                   e.stopPropagation();
-                  onCompare(article.title);
+                  onCompare(article.title, article.sourceName);
                 }}
                 className="bg-transparent border-none p-0 cursor-pointer text-xs font-medium transition-colors duration-200"
                 style={{ color: "var(--accent)" }}

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
-import { CATEGORIES, COMPARE_SOURCES, DEFAULT_COMPARE_SOURCES } from "@/lib/constants";
+import { CATEGORIES, COMPARE_SOURCES, CATEGORY_COMPARE_DEFAULTS, DEFAULT_COMPARE_SOURCES } from "@/lib/constants";
 import { COPY } from "@/lib/copy";
 import { timeAgo } from "@/lib/utils";
 import { useNewsLoader, useBookmarks, useTheme, useTopicSearch, useCompare } from "@/lib/hooks";
@@ -143,12 +143,37 @@ export default function NewsAggregator() {
     .map((key) => COMPARE_SOURCES.find((s) => s.key === key)?.label ?? key)
     .join(", ");
 
-  const handleCompare = (topic: string, sources?: string[]) => {
+  const startCompare = (topic: string, sources: string[]) => {
     setCompareMode(true);
     setShowBookmarks(false);
     setSearchMode(false);
     clearTopicSearch();
-    runCompare(topic, sources || selectedSources);
+    runCompare(topic, sources);
+  };
+
+  const handleCompareFromArticle = (topic: string, sourceName?: string) => {
+    // Start with category-aware defaults
+    const categoryDefaults = CATEGORY_COMPARE_DEFAULTS[activeCategory] || DEFAULT_COMPARE_SOURCES;
+    let sources = [...categoryDefaults];
+
+    // Ensure the article's own source is included
+    if (sourceName) {
+      const nameLower = sourceName.toLowerCase();
+      const alreadyIncluded = sources.some((key) => {
+        const cs = COMPARE_SOURCES.find((s) => s.key === key);
+        if (cs) return nameLower.includes(cs.key) || cs.key.includes(nameLower) || nameLower === cs.label.toLowerCase();
+        return key === nameLower;
+      });
+      if (!alreadyIncluded) {
+        const match = COMPARE_SOURCES.find(
+          (s) => nameLower.includes(s.key) || s.key.includes(nameLower) || nameLower === s.label.toLowerCase()
+        );
+        sources = [match?.key || nameLower, ...sources].slice(0, 5);
+      }
+    }
+
+    setSelectedSources(sources);
+    startCompare(topic, sources);
   };
 
   const exitCompareMode = () => {
@@ -268,6 +293,7 @@ export default function NewsAggregator() {
                   setShowBookmarks(false);
                   setSearchMode(false);
                   clearTopicSearch();
+                  setSelectedSources([...(CATEGORY_COMPARE_DEFAULTS[activeCategory] || DEFAULT_COMPARE_SOURCES)]);
                 }
               }}
               aria-label="Compare coverage"
@@ -368,7 +394,7 @@ export default function NewsAggregator() {
               onSubmit={(e) => {
                 e.preventDefault();
                 const trimmed = compareInputValue.trim();
-                if (trimmed.length >= 3 && selectedSources.length >= 2) handleCompare(trimmed, selectedSources);
+                if (trimmed.length >= 3 && selectedSources.length >= 2) startCompare(trimmed, selectedSources);
               }}
               className="flex items-center gap-2"
             >
@@ -488,7 +514,7 @@ export default function NewsAggregator() {
                 sourcesChecked={compareSources}
                 claims={compareClaims}
                 durationMs={compareDuration!}
-                onCompareAnother={handleCompare}
+                onCompareAnother={startCompare}
                 onClose={exitCompareMode}
                 selectedSources={selectedSources}
                 onToggleSource={toggleSource}
@@ -595,7 +621,7 @@ export default function NewsAggregator() {
                       onBookmark={toggleBookmark}
                       bookmarks={bookmarks}
                       index={i}
-                      onCompare={handleCompare}
+                      onCompare={handleCompareFromArticle}
                     />
                   ) : (
                     <ArticleCard
@@ -605,7 +631,7 @@ export default function NewsAggregator() {
                       onBookmark={toggleBookmark}
                       isBookmarked={bookmarks.has(item.data.id)}
                       index={i}
-                      onCompare={handleCompare}
+                      onCompare={handleCompareFromArticle}
                     />
                   )
                 )}

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -235,7 +235,7 @@ export default function StoryCard({
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      onCompare(article.title);
+                      onCompare(article.title, article.sourceName);
                     }}
                     className="bg-transparent border-none p-0 cursor-pointer text-[10px] font-medium shrink-0 transition-colors duration-200"
                     style={{ color: "var(--accent)" }}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -62,22 +62,64 @@ export const GRADIENTS: Record<CategoryId, string> = {
 
 // ─── Compare Sources ────────────────────────────────────
 
+// Sources organized by type. Claude web_search works with any outlet name,
+// but these are the ones with the most reliable, distinctive coverage.
 export const COMPARE_SOURCES = [
+  // Wire services & general news
   { key: "reuters", label: "Reuters" },
   { key: "bbc", label: "BBC" },
   { key: "associated press", label: "AP" },
   { key: "cnn", label: "CNN" },
+  { key: "npr", label: "NPR" },
+  { key: "al jazeera", label: "Al Jazeera" },
+  { key: "france 24", label: "France 24" },
+  // Print / longform
   { key: "the guardian", label: "The Guardian" },
   { key: "the new york times", label: "NYT" },
   { key: "the washington post", label: "Wash. Post" },
-  { key: "al jazeera", label: "Al Jazeera" },
-  { key: "npr", label: "NPR" },
-  { key: "axios", label: "Axios" },
-  { key: "the economist", label: "Economist" },
+  { key: "the atlantic", label: "The Atlantic" },
+  { key: "vox", label: "Vox" },
+  { key: "politico", label: "Politico" },
+  { key: "the hill", label: "The Hill" },
+  // Business & finance
+  { key: "bloomberg", label: "Bloomberg" },
   { key: "financial times", label: "FT" },
+  { key: "the economist", label: "Economist" },
+  { key: "cnbc", label: "CNBC" },
+  { key: "fortune", label: "Fortune" },
+  { key: "axios", label: "Axios" },
+  // Technology
+  { key: "techcrunch", label: "TechCrunch" },
+  { key: "the verge", label: "The Verge" },
+  { key: "wired", label: "Wired" },
+  { key: "ars technica", label: "Ars Technica" },
+  // Science & health
+  { key: "nature", label: "Nature" },
+  { key: "new scientist", label: "New Scientist" },
+  { key: "stat news", label: "STAT News" },
+  // Energy & climate
+  { key: "canary media", label: "Canary Media" },
+  { key: "inside climate news", label: "Inside Climate" },
+  // World affairs
+  { key: "foreign policy", label: "Foreign Policy" },
+  { key: "south china morning post", label: "SCMP" },
 ] as const;
 
-export const DEFAULT_COMPARE_SOURCES = ["reuters", "bbc", "associated press"];
+// Category-aware defaults: top 5 most relevant sources per category
+export const CATEGORY_COMPARE_DEFAULTS: Record<CategoryId, string[]> = {
+  top:            ["reuters", "bbc", "npr", "the guardian", "axios"],
+  technology:     ["techcrunch", "the verge", "wired", "ars technica", "cnbc"],
+  business:       ["bloomberg", "financial times", "cnbc", "fortune", "reuters"],
+  science:        ["nature", "new scientist", "reuters", "bbc", "the guardian"],
+  energy:         ["canary media", "inside climate news", "bloomberg", "reuters", "the economist"],
+  world:          ["al jazeera", "bbc", "france 24", "the guardian", "foreign policy"],
+  health:         ["stat news", "npr", "reuters", "bbc", "the guardian"],
+  politics:       ["politico", "the hill", "axios", "npr", "the washington post"],
+  sports:         ["bbc", "reuters", "cnn", "the guardian", "france 24"],
+  entertainment:  ["the verge", "bbc", "the guardian", "wired", "cnn"],
+};
+
+export const DEFAULT_COMPARE_SOURCES = CATEGORY_COMPARE_DEFAULTS.top;
 
 // ─── Timing ─────────────────────────────────────────────
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -127,7 +127,7 @@ export interface ArticleCardProps {
   onBookmark: (id: string) => void;
   isBookmarked: boolean;
   index: number;
-  onCompare?: (topic: string) => void;
+  onCompare?: (topic: string, sourceName?: string) => void;
 }
 
 export interface StoryCardProps {
@@ -136,7 +136,7 @@ export interface StoryCardProps {
   onBookmark: (id: string) => void;
   bookmarks: Set<string>;
   index: number;
-  onCompare?: (topic: string) => void;
+  onCompare?: (topic: string, sourceName?: string) => void;
 }
 
 export interface CardImageProps {


### PR DESCRIPTION
## Summary
- Expand compare source list from 12 to 31 outlets (wire, print, tech, science, health, energy, world)
- Category-aware defaults: 5 sources per category based on actual DB coverage (e.g., Technology defaults to TechCrunch/Verge/Wired/Ars/CNBC)
- Auto-include article's originating source in comparisons — any outlet works, not just curated list
- Article source passed through `onCompare(topic, sourceName)` from both ArticleCard and StoryCard

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] 41 tests pass
- [ ] Compare from Technology article defaults to tech outlets
- [ ] Compare from World article defaults to international outlets
- [ ] Non-curated source (e.g., Electrek) auto-included in comparison

