### PR TITLE
Add personalized custom topics (Feature 1)

### DIFF
--- a/__tests__/copy.test.ts
+++ b/__tests__/copy.test.ts
@@ -1,0 +1,72 @@
+import { COPY } from "@/lib/copy";
+
+describe("COPY strings", () => {
+  describe("search.resultsFor", () => {
+    it("wraps query in curly quotes", () => {
+      expect(COPY.search.resultsFor("AI")).toBe("Results for \u201cAI\u201d");
+    });
+  });
+
+  describe("stories.sourcesBadge", () => {
+    it("returns singular for 1 source", () => {
+      expect(COPY.stories.sourcesBadge(1)).toBe("1 source");
+    });
+
+    it("returns plural for multiple sources", () => {
+      expect(COPY.stories.sourcesBadge(3)).toBe("3 sources");
+    });
+  });
+
+  describe("stories.expand", () => {
+    it("returns singular for 1 article", () => {
+      expect(COPY.stories.expand(1)).toBe("View 1 article");
+    });
+
+    it("returns plural for multiple articles", () => {
+      expect(COPY.stories.expand(5)).toBe("View 5 articles");
+    });
+  });
+
+  describe("static strings", () => {
+    it("has header tagline", () => {
+      expect(COPY.header.tagline).toBeTruthy();
+    });
+
+    it("has footer text", () => {
+      expect(COPY.footer.main).toBeTruthy();
+    });
+
+    it("has error strings", () => {
+      expect(COPY.error.title).toBeTruthy();
+      expect(COPY.error.body).toBeTruthy();
+      expect(COPY.error.button).toBeTruthy();
+    });
+
+    it("has loading strings", () => {
+      expect(COPY.loading.slow).toBeTruthy();
+      expect(COPY.loading.slowTopic).toBeTruthy();
+      expect(COPY.loading.refresh).toBeTruthy();
+    });
+
+    it("has topic modal strings", () => {
+      expect(COPY.topics.modalTitle).toBeTruthy();
+      expect(COPY.topics.modalPlaceholder).toBeTruthy();
+      expect(COPY.topics.generating).toBeTruthy();
+      expect(COPY.topics.previewTitle).toBeTruthy();
+      expect(COPY.topics.confirm).toBeTruthy();
+      expect(COPY.topics.cancel).toBeTruthy();
+      expect(COPY.topics.edit).toBeTruthy();
+      expect(COPY.topics.maxReached).toBeTruthy();
+    });
+
+    it("has compare strings", () => {
+      expect(COPY.compare.button).toBeTruthy();
+      expect(COPY.compare.placeholder).toBeTruthy();
+    });
+
+    it("has bookmark strings", () => {
+      expect(COPY.bookmarks.title).toBeTruthy();
+      expect(COPY.bookmarks.emptyTitle).toBeTruthy();
+    });
+  });
+});

--- a/app/api/topics/generate/route.ts
+++ b/app/api/topics/generate/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import type { TopicGenerateResponse } from "@/lib/types";
+
+export async function POST(request: NextRequest) {
+  let body: { rawTopic?: string; existingTopics?: string[] };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const rawTopic = body.rawTopic?.trim();
+  if (!rawTopic || rawTopic.length < 2 || rawTopic.length > 200) {
+    return NextResponse.json(
+      { error: "Topic must be 2-200 characters" },
+      { status: 400 }
+    );
+  }
+
+  const existingTopics = body.existingTopics || [];
+
+  try {
+    const anthropic = new Anthropic();
+
+    const existingClause =
+      existingTopics.length > 0
+        ? `\nThe user already tracks these topics (avoid duplicates): ${existingTopics.join(", ")}`
+        : "";
+
+    const response = await anthropic.messages.create({
+      model: "claude-haiku-4-5",
+      max_tokens: 512,
+      messages: [
+        {
+          role: "user",
+          content: `You are helping a user create a personalized news topic for a news aggregator.
+They described their interest as: "${rawTopic}"
+${existingClause}
+
+Generate a topic configuration:
+1. shortLabel: A concise label (12 characters max) for a navigation pill. Be creative but clear.
+2. icon: A single emoji that represents this topic.
+3. searchQueries: 3-5 specific search queries that would find relevant current news. Be specific — include company names, policy names, geographic areas, and industry terms. Think like a research analyst.
+4. description: One sentence explaining what this topic covers.
+
+Respond with ONLY valid JSON, no explanation:
+{"shortLabel": "...", "icon": "...", "searchQueries": ["...", "..."], "description": "..."}`,
+        },
+      ],
+    });
+
+    const textBlock = response.content.find((b) => b.type === "text");
+    if (!textBlock || textBlock.type !== "text") {
+      return NextResponse.json(
+        { error: "No response from AI" },
+        { status: 502 }
+      );
+    }
+
+    const jsonStr = textBlock.text
+      .replace(/```json\n?/g, "")
+      .replace(/```\n?/g, "")
+      .trim();
+
+    let parsed: TopicGenerateResponse;
+    try {
+      parsed = JSON.parse(jsonStr);
+    } catch {
+      return NextResponse.json(
+        { error: "Failed to parse AI response" },
+        { status: 502 }
+      );
+    }
+
+    // Validate and sanitize
+    if (!parsed.shortLabel || !parsed.searchQueries || !Array.isArray(parsed.searchQueries)) {
+      return NextResponse.json(
+        { error: "Invalid AI response structure" },
+        { status: 502 }
+      );
+    }
+
+    // Enforce constraints
+    parsed.shortLabel = parsed.shortLabel.slice(0, 12);
+    parsed.searchQueries = parsed.searchQueries.slice(0, 5);
+    if (parsed.searchQueries.length < 1) {
+      parsed.searchQueries = [rawTopic];
+    }
+    if (!parsed.icon) parsed.icon = "\u2b50";
+    if (!parsed.description) parsed.description = rawTopic;
+
+    return NextResponse.json(parsed);
+  } catch (err) {
+    console.error("Topic generation error:", err);
+    return NextResponse.json(
+      { error: "Failed to generate topic", details: String(err) },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/topics/route.ts
+++ b/app/api/topics/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { getCustomTopics, saveCustomTopic, deleteCustomTopic } from "@/lib/db";
+import type { CustomTopic } from "@/lib/types";
+import { MAX_CUSTOM_TOPICS } from "@/lib/constants";
+
+function unauthorized() {
+  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+// GET /api/topics — returns user's custom topics
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) return unauthorized();
+
+  try {
+    const rows = await getCustomTopics(userId);
+    const topics: CustomTopic[] = rows.map((row) => {
+      try {
+        return JSON.parse(row.query) as CustomTopic;
+      } catch {
+        return {
+          id: row.id,
+          rawInput: row.name,
+          shortLabel: row.name.slice(0, 12),
+          icon: "\u2b50",
+          searchQueries: [row.name],
+          description: row.name,
+          createdAt: row.created_at.toISOString(),
+          colorIndex: 0,
+        };
+      }
+    });
+    return NextResponse.json({ topics });
+  } catch (err) {
+    console.error("Topics GET error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// POST /api/topics — body { topic: CustomTopic }
+export async function POST(request: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) return unauthorized();
+
+  try {
+    const { topic } = (await request.json()) as { topic: CustomTopic };
+    if (!topic || !topic.id || !topic.shortLabel) {
+      return NextResponse.json({ error: "Invalid topic" }, { status: 400 });
+    }
+
+    // Check limit
+    const existing = await getCustomTopics(userId);
+    if (existing.length >= MAX_CUSTOM_TOPICS) {
+      return NextResponse.json(
+        { error: "Maximum custom topics reached" },
+        { status: 400 }
+      );
+    }
+
+    await saveCustomTopic(topic.id, userId, topic.shortLabel, JSON.stringify(topic));
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("Topics POST error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// DELETE /api/topics — body { id }
+export async function DELETE(request: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) return unauthorized();
+
+  try {
+    const { id } = (await request.json()) as { id: string };
+    if (!id) {
+      return NextResponse.json({ error: "id required" }, { status: 400 });
+    }
+    await deleteCustomTopic(id, userId);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("Topics DELETE error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -2,20 +2,21 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
-import { CATEGORIES, COMPARE_SOURCES, CATEGORY_COMPARE_DEFAULTS, DEFAULT_COMPARE_SOURCES } from "@/lib/constants";
+import { CATEGORIES, COMPARE_SOURCES, CATEGORY_COMPARE_DEFAULTS, DEFAULT_COMPARE_SOURCES, CUSTOM_TOPIC_COLORS } from "@/lib/constants";
 import { COPY } from "@/lib/copy";
 import { timeAgo } from "@/lib/utils";
-import { useNewsLoader, useBookmarks, useTheme, useTopicSearch, useCompare } from "@/lib/hooks";
+import { useNewsLoader, useBookmarks, useTheme, useTopicSearch, useCompare, useCustomTopics } from "@/lib/hooks";
 import ArticleCard from "./ArticleCard";
 import StoryCard from "./StoryCard";
 import SkeletonCard from "./SkeletonCard";
 import EmptyState from "./EmptyState";
 import ErrorState from "./ErrorState";
 import TopicSearch from "./TopicSearch";
+import TopicModal from "./TopicModal";
 import CompareView from "./CompareView";
 import SiftLogo from "./SiftLogo";
 import AuthButtons, { clerkEnabled } from "./AuthButtons";
-import type { Article, FeedItem, CategoryId } from "@/lib/types";
+import type { Article, CustomTopic, FeedItem, CategoryId } from "@/lib/types";
 
 // ─── Clerk user ID (safe when ClerkProvider absent) ─────
 
@@ -37,6 +38,9 @@ export default function NewsAggregator() {
   const [selectedSources, setSelectedSources] = useState<string[]>([...DEFAULT_COMPARE_SOURCES]);
   const [sourcesExpanded, setSourcesExpanded] = useState(false);
 
+  const [activeCustomTopic, setActiveCustomTopic] = useState<CustomTopic | null>(null);
+  const [showTopicModal, setShowTopicModal] = useState(false);
+
   const [categoryFading, setCategoryFading] = useState(false);
   const [refreshed, setRefreshed] = useState(false);
   const pillContainerRef = useRef<HTMLDivElement>(null);
@@ -48,6 +52,7 @@ export default function NewsAggregator() {
 
   const { articles, stories, loading, error, slow, lastUpdated, loadCategory } = useNewsLoader();
   const { bookmarks, toggle: toggleBookmark, count: bookmarkCount } = useBookmarks(userId);
+  const { topics: customTopics, add: addCustomTopic, remove: removeCustomTopic, canAdd: canAddTopic } = useCustomTopics(userId);
   const { dark: darkMode, toggle: toggleDark, mounted } = useTheme();
   const {
     articles: topicArticles,
@@ -80,14 +85,27 @@ export default function NewsAggregator() {
 
   // Category switch with fade-out/fade-in
   const switchCategory = useCallback((catId: CategoryId) => {
-    if (catId === activeCategory) return;
+    if (catId === activeCategory && !activeCustomTopic) return;
     setCategoryFading(true);
-    // Brief fade-out, then switch & fade-in
     setTimeout(() => {
       setActiveCategory(catId);
+      setActiveCustomTopic(null);
+      clearTopicSearch();
       setCategoryFading(false);
     }, 120);
-  }, [activeCategory]);
+  }, [activeCategory, activeCustomTopic, clearTopicSearch]);
+
+  // Switch to a custom topic
+  const switchToCustomTopic = useCallback((topic: CustomTopic) => {
+    if (activeCustomTopic?.id === topic.id) return;
+    setCategoryFading(true);
+    setTimeout(() => {
+      setActiveCustomTopic(topic);
+      setCategoryFading(false);
+      // Search using the first query (most specific)
+      searchTopic(topic.searchQueries[0]);
+    }, 120);
+  }, [activeCustomTopic, searchTopic]);
 
   // Position the sliding indicator under the active pill
   const updateIndicator = useCallback(() => {
@@ -105,7 +123,7 @@ export default function NewsAggregator() {
 
   useEffect(() => {
     updateIndicator();
-  }, [activeCategory, showBookmarks, searchMode, compareMode, updateIndicator]);
+  }, [activeCategory, activeCustomTopic, showBookmarks, searchMode, compareMode, updateIndicator]);
 
   // Fetch full bookmarked articles from DB when viewing bookmarks (signed in)
   useEffect(() => {
@@ -126,7 +144,11 @@ export default function NewsAggregator() {
   }, [showBookmarks, userId, bookmarks]);
 
   const handleRefresh = async () => {
-    await loadCategory(activeCategory, true);
+    if (activeCustomTopic) {
+      searchTopic(activeCustomTopic.searchQueries[0]);
+    } else {
+      await loadCategory(activeCategory, true);
+    }
     setRefreshed(true);
     setTimeout(() => setRefreshed(false), 2000);
   };
@@ -182,8 +204,10 @@ export default function NewsAggregator() {
     clearCompare();
   };
 
+  const customTopicMode = !!activeCustomTopic;
+
   const currentArticles = useMemo((): Article[] => {
-    if (searchMode) {
+    if (searchMode || customTopicMode) {
       return topicArticles;
     }
     if (showBookmarks) {
@@ -193,12 +217,12 @@ export default function NewsAggregator() {
       return Object.values(articles).flat().filter((a) => bookmarks.has(a.id));
     }
     return articles[activeCategory] || [];
-  }, [articles, activeCategory, showBookmarks, bookmarks, userId, bookmarkedArticles, searchMode, topicArticles]);
+  }, [articles, activeCategory, showBookmarks, bookmarks, userId, bookmarkedArticles, searchMode, customTopicMode, topicArticles]);
 
   // Build feed items: stories + standalone articles, sorted by date
   const feedItems = useMemo((): FeedItem[] => {
-    // Stories only apply to category view (not bookmarks/search)
-    if (searchMode || showBookmarks) {
+    // Stories only apply to category view (not bookmarks/search/custom topics)
+    if (searchMode || showBookmarks || customTopicMode) {
       return currentArticles.map((a) => ({ type: "article" as const, data: a }));
     }
 
@@ -219,7 +243,7 @@ export default function NewsAggregator() {
     });
 
     return items;
-  }, [currentArticles, stories, activeCategory, searchMode, showBookmarks]);
+  }, [currentArticles, stories, activeCategory, searchMode, showBookmarks, customTopicMode]);
 
   const hasData = feedItems.length > 0;
   const activeCatLabel = CATEGORIES.find((c) => c.id === activeCategory)?.label;
@@ -244,7 +268,7 @@ export default function NewsAggregator() {
         <div className="max-w-[1200px] mx-auto px-6 py-3.5 flex items-center justify-between">
           <div
             className="flex items-baseline gap-3 cursor-pointer"
-            onClick={() => { setShowBookmarks(false); setSearchMode(false); clearTopicSearch(); exitCompareMode(); setActiveCategory("top"); }}
+            onClick={() => { setShowBookmarks(false); setSearchMode(false); clearTopicSearch(); exitCompareMode(); setActiveCustomTopic(null); setActiveCategory("top"); }}
           >
             <SiftLogo variant="full" size={28} />
             <span className="text-[10px] font-bold tracking-widest uppercase text-[var(--accent)] opacity-80">
@@ -341,7 +365,7 @@ export default function NewsAggregator() {
         {!showBookmarks && !searchMode && !compareMode && (
           <div ref={pillContainerRef} className="max-w-[1200px] mx-auto px-6 pb-3 flex gap-1.5 overflow-x-auto relative">
             {CATEGORIES.map((cat) => {
-              const active = activeCategory === cat.id;
+              const active = activeCategory === cat.id && !activeCustomTopic;
               return (
                 <button
                   key={cat.id}
@@ -360,6 +384,60 @@ export default function NewsAggregator() {
                 </button>
               );
             })}
+
+            {/* Custom topic pills */}
+            {customTopics.map((topic) => {
+              const active = activeCustomTopic?.id === topic.id;
+              const color = CUSTOM_TOPIC_COLORS[topic.colorIndex % CUSTOM_TOPIC_COLORS.length];
+              return (
+                <button
+                  key={`custom-${topic.id}`}
+                  data-active={active}
+                  onClick={() => switchToCustomTopic(topic)}
+                  className="flex items-center gap-1.5 px-4 py-1.5 rounded-full text-[13px] whitespace-nowrap cursor-pointer transition-all duration-200 font-body group relative"
+                  style={{
+                    background: active ? color.hex : "transparent",
+                    color: active ? "#fff" : "var(--text-muted)",
+                    border: active ? `1px solid ${color.hex}` : `1px solid rgba(${color.rgb}, 0.25)`,
+                    fontWeight: active ? 700 : 500,
+                  }}
+                >
+                  <span className="text-[10px]">{topic.icon}</span>
+                  {topic.shortLabel}
+                  <span
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (activeCustomTopic?.id === topic.id) {
+                        setActiveCustomTopic(null);
+                        clearTopicSearch();
+                      }
+                      removeCustomTopic(topic.id);
+                    }}
+                    className="text-[10px] opacity-0 group-hover:opacity-60 transition-opacity duration-150 ml-0.5 cursor-pointer"
+                    style={{ color: active ? "#fff" : "var(--text-muted)" }}
+                  >
+                    &times;
+                  </span>
+                </button>
+              );
+            })}
+
+            {/* Add topic button */}
+            {canAddTopic && (
+              <button
+                onClick={() => setShowTopicModal(true)}
+                className="flex items-center justify-center w-8 h-8 rounded-full text-sm cursor-pointer transition-all duration-200 shrink-0"
+                style={{
+                  background: "transparent",
+                  border: "1px dashed var(--border)",
+                  color: "var(--text-muted)",
+                }}
+                aria-label="Add custom topic"
+              >
+                +
+              </button>
+            )}
+
             {/* Sliding indicator under active pill */}
             {indicatorStyle && (
               <div
@@ -367,7 +445,9 @@ export default function NewsAggregator() {
                 style={{
                   left: indicatorStyle.left,
                   width: indicatorStyle.width,
-                  background: "var(--accent)",
+                  background: activeCustomTopic
+                    ? CUSTOM_TOPIC_COLORS[activeCustomTopic.colorIndex % CUSTOM_TOPIC_COLORS.length].hex
+                    : "var(--accent)",
                   transition: "left 0.3s cubic-bezier(0.16,1,0.3,1), width 0.3s cubic-bezier(0.16,1,0.3,1)",
                 }}
               />
@@ -539,9 +619,16 @@ export default function NewsAggregator() {
                     ? (topicQuery ? COPY.search.resultsFor(topicQuery) : COPY.articles.searchTopics)
                     : showBookmarks
                       ? COPY.bookmarks.title
-                      : activeCatLabel}
+                      : activeCustomTopic
+                        ? `${activeCustomTopic.icon} ${activeCustomTopic.shortLabel}`
+                        : activeCatLabel}
                 </h2>
-                {lastUpdated && !showBookmarks && !searchMode && (
+                {activeCustomTopic && (
+                  <p className="text-xs mt-1 text-[var(--text-muted)]">
+                    {activeCustomTopic.description}
+                  </p>
+                )}
+                {lastUpdated && !showBookmarks && !searchMode && !customTopicMode && (
                   <p className="text-xs mt-1" style={{ color: refreshed ? "var(--accent)" : "var(--text-muted)" }}>
                     {refreshed ? COPY.articles.updated : `Updated ${timeAgo(lastUpdated.toISOString())}`}
                   </p>
@@ -555,7 +642,7 @@ export default function NewsAggregator() {
             </div>
 
             {/* Loading skeleton */}
-            {((searchMode ? topicLoading : loading) && !hasData && !(searchMode ? topicError : error)) && (
+            {(((searchMode || customTopicMode) ? topicLoading : loading) && !hasData && !((searchMode || customTopicMode) ? topicError : error)) && (
               <div>
                 <div className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-5">
                   <SkeletonCard featured />
@@ -563,9 +650,9 @@ export default function NewsAggregator() {
                     <SkeletonCard key={i} />
                   ))}
                 </div>
-                {(searchMode ? topicSlow : slow) && (
+                {((searchMode || customTopicMode) ? topicSlow : slow) && (
                   <p className="text-center mt-6 text-sm text-[var(--text-muted)] animate-fade-slide-in">
-                    {searchMode
+                    {(searchMode || customTopicMode)
                       ? COPY.loading.slowTopic
                       : COPY.loading.slow}
                   </p>
@@ -574,13 +661,15 @@ export default function NewsAggregator() {
             )}
 
             {/* Error */}
-            {(searchMode ? topicError : error) && !(searchMode ? topicLoading : loading) && !hasData && (
+            {((searchMode || customTopicMode) ? topicError : error) && !((searchMode || customTopicMode) ? topicLoading : loading) && !hasData && (
               <ErrorState
-                message={(searchMode ? topicError : error) || COPY.error.body}
+                message={((searchMode || customTopicMode) ? topicError : error) || COPY.error.body}
                 onRetry={() =>
-                  searchMode && topicQuery
-                    ? searchTopic(topicQuery)
-                    : loadCategory(activeCategory, true)
+                  activeCustomTopic
+                    ? searchTopic(activeCustomTopic.searchQueries[0])
+                    : searchMode && topicQuery
+                      ? searchTopic(topicQuery)
+                      : loadCategory(activeCategory, true)
                 }
               />
             )}
@@ -593,8 +682,16 @@ export default function NewsAggregator() {
               />
             )}
 
+            {/* Empty custom topic results */}
+            {customTopicMode && !topicLoading && !topicError && !hasData && (
+              <EmptyState
+                title={COPY.articles.emptyTitle}
+                body={COPY.articles.emptyBody}
+              />
+            )}
+
             {/* Empty search results */}
-            {searchMode && !topicLoading && !topicError && !hasData && topicQuery && (
+            {searchMode && !customTopicMode && !topicLoading && !topicError && !hasData && topicQuery && (
               <EmptyState
                 title={COPY.searchEmpty.title}
                 body={COPY.searchEmpty.body}
@@ -617,7 +714,7 @@ export default function NewsAggregator() {
                     <StoryCard
                       key={`story-${item.data.id}`}
                       story={item.data}
-                      featured={i === 0 && !showBookmarks && !searchMode}
+                      featured={i === 0 && !showBookmarks && !searchMode && !customTopicMode}
                       onBookmark={toggleBookmark}
                       bookmarks={bookmarks}
                       index={i}
@@ -627,7 +724,7 @@ export default function NewsAggregator() {
                     <ArticleCard
                       key={item.data.id}
                       article={item.data}
-                      featured={i === 0 && !showBookmarks && !searchMode}
+                      featured={i === 0 && !showBookmarks && !searchMode && !customTopicMode}
                       onBookmark={toggleBookmark}
                       isBookmarked={bookmarks.has(item.data.id)}
                       index={i}
@@ -648,6 +745,21 @@ export default function NewsAggregator() {
           </>
         )}
       </main>
+
+      {/* ── Topic Modal ─────────────────────────────── */}
+      {showTopicModal && (
+        <TopicModal
+          onClose={() => setShowTopicModal(false)}
+          onAdd={(topic) => {
+            addCustomTopic(topic);
+            setShowTopicModal(false);
+            // Switch to the new topic immediately
+            setTimeout(() => switchToCustomTopic(topic), 150);
+          }}
+          existingTopics={customTopics}
+          colorIndex={customTopics.length}
+        />
+      )}
 
       {/* ── Footer ──────────────────────────────────── */}
       <footer className="border-t border-[var(--border)] py-6 px-6 text-center text-xs text-[var(--text-muted)] max-w-[1200px] mx-auto">

--- a/components/TopicModal.tsx
+++ b/components/TopicModal.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { COPY } from "@/lib/copy";
+import { CUSTOM_TOPIC_COLORS } from "@/lib/constants";
+import type { CustomTopic, TopicGenerateResponse } from "@/lib/types";
+
+interface TopicModalProps {
+  onClose: () => void;
+  onAdd: (topic: CustomTopic) => void;
+  existingTopics: CustomTopic[];
+  colorIndex: number;
+}
+
+type ModalStep = "input" | "generating" | "preview";
+
+export default function TopicModal({ onClose, onAdd, existingTopics, colorIndex }: TopicModalProps) {
+  const [step, setStep] = useState<ModalStep>("input");
+  const [inputValue, setInputValue] = useState("");
+  const [preview, setPreview] = useState<TopicGenerateResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const color = CUSTOM_TOPIC_COLORS[colorIndex % CUSTOM_TOPIC_COLORS.length];
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  const generate = async () => {
+    const trimmed = inputValue.trim();
+    if (trimmed.length < 2) return;
+
+    setStep("generating");
+    setError(null);
+
+    try {
+      const res = await fetch("/api/topics/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          rawTopic: trimmed,
+          existingTopics: existingTopics.map((t) => t.shortLabel),
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+
+      const data: TopicGenerateResponse = await res.json();
+      setPreview(data);
+      setStep("preview");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to generate topic");
+      setStep("input");
+    }
+  };
+
+  const confirm = () => {
+    if (!preview) return;
+
+    const topic: CustomTopic = {
+      id: crypto.randomUUID(),
+      rawInput: inputValue.trim(),
+      shortLabel: preview.shortLabel,
+      icon: preview.icon,
+      searchQueries: preview.searchQueries,
+      description: preview.description,
+      createdAt: new Date().toISOString(),
+      colorIndex,
+    };
+
+    onAdd(topic);
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center p-4"
+      style={{ background: "rgba(0,0,0,0.6)", backdropFilter: "blur(8px)" }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        className="w-full max-w-[460px] rounded-2xl border border-[var(--border)] overflow-hidden animate-fade-slide-in"
+        style={{ background: "var(--card-bg)" }}
+      >
+        {/* Header */}
+        <div className="px-6 pt-6 pb-4 flex items-center justify-between">
+          <h2 className="font-heading text-lg font-bold text-[var(--text)]">
+            {step === "preview" ? COPY.topics.previewTitle : COPY.topics.modalTitle}
+          </h2>
+          <button
+            onClick={onClose}
+            className="bg-transparent border-none text-[var(--text-muted)] text-xl cursor-pointer p-1 transition-colors duration-200"
+            aria-label="Close"
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="px-6 pb-6">
+          {/* Input step */}
+          {(step === "input" || step === "generating") && (
+            <form
+              onSubmit={(e) => { e.preventDefault(); generate(); }}
+            >
+              <input
+                ref={inputRef}
+                type="text"
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                placeholder={COPY.topics.modalPlaceholder}
+                maxLength={200}
+                disabled={step === "generating"}
+                className="w-full px-4 py-3 rounded-xl text-sm font-body transition-all duration-200 outline-none"
+                style={{
+                  background: "var(--bg)",
+                  border: "1px solid var(--border)",
+                  color: "var(--text)",
+                  opacity: step === "generating" ? 0.6 : 1,
+                }}
+              />
+              {error && (
+                <p className="text-xs text-red-500 mt-2">{error}</p>
+              )}
+              {step === "generating" && (
+                <div className="flex items-center gap-2 mt-3">
+                  <span className="animate-sift-refresh inline-block text-sm" style={{ color: color.hex }}>
+                    &#x25C6;
+                  </span>
+                  <span className="text-xs text-[var(--text-muted)]">
+                    {COPY.topics.generating}
+                  </span>
+                </div>
+              )}
+              {step === "input" && (
+                <button
+                  type="submit"
+                  disabled={inputValue.trim().length < 2}
+                  className="mt-3 w-full py-2.5 rounded-xl text-sm font-semibold cursor-pointer transition-all duration-200 border-none"
+                  style={{
+                    background: inputValue.trim().length >= 2 ? color.hex : "var(--border)",
+                    color: inputValue.trim().length >= 2 ? "#fff" : "var(--text-muted)",
+                    cursor: inputValue.trim().length >= 2 ? "pointer" : "not-allowed",
+                  }}
+                >
+                  Generate preview
+                </button>
+              )}
+            </form>
+          )}
+
+          {/* Preview step */}
+          {step === "preview" && preview && (
+            <div className="space-y-4">
+              {/* Label + icon */}
+              <div className="flex items-center gap-3">
+                <span
+                  className="flex items-center justify-center w-10 h-10 rounded-full text-lg"
+                  style={{ background: `rgba(${color.rgb}, 0.12)` }}
+                >
+                  {preview.icon}
+                </span>
+                <div>
+                  <p className="font-bold text-[var(--text)]">{preview.shortLabel}</p>
+                  <p className="text-xs text-[var(--text-muted)]">{preview.description}</p>
+                </div>
+              </div>
+
+              {/* Search queries */}
+              <div>
+                <p className="text-[10px] font-bold uppercase tracking-widest text-[var(--text-muted)] mb-2">
+                  {COPY.topics.previewQueries}
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {preview.searchQueries.map((q) => (
+                    <span
+                      key={q}
+                      className="px-2.5 py-1 rounded-full text-[11px] font-medium"
+                      style={{
+                        background: `rgba(${color.rgb}, 0.08)`,
+                        color: color.hex,
+                        border: `1px solid rgba(${color.rgb}, 0.15)`,
+                      }}
+                    >
+                      {q}
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              {/* Actions */}
+              <div className="flex gap-2 pt-1">
+                <button
+                  onClick={() => { setStep("input"); setPreview(null); }}
+                  className="flex-1 py-2.5 rounded-xl text-sm font-semibold cursor-pointer transition-all duration-200"
+                  style={{
+                    background: "transparent",
+                    border: "1px solid var(--border)",
+                    color: "var(--text-secondary)",
+                  }}
+                >
+                  {COPY.topics.edit}
+                </button>
+                <button
+                  onClick={confirm}
+                  className="flex-1 py-2.5 rounded-xl text-sm font-semibold cursor-pointer transition-all duration-200 border-none"
+                  style={{ background: color.hex, color: "#fff" }}
+                >
+                  {COPY.topics.confirm}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -131,4 +131,18 @@ export const SLOW_THRESHOLD_MS = 3_000;
 export const STORAGE_KEYS = {
   bookmarks: "sift-bookmarks",
   theme: "sift-theme",
+  customTopics: "sift-custom-topics",
 } as const;
+
+// ─── Custom Topic Colors ────────────────────────────────
+// Distinct from category colors. One per max custom topic slot.
+
+export const CUSTOM_TOPIC_COLORS: { hex: string; rgb: string }[] = [
+  { hex: "#8b5cf6", rgb: "139,92,246" },   // violet
+  { hex: "#06b6d4", rgb: "6,182,212" },     // cyan
+  { hex: "#f59e0b", rgb: "245,158,11" },    // amber
+  { hex: "#ec4899", rgb: "236,72,153" },    // pink
+  { hex: "#10b981", rgb: "16,185,129" },    // emerald
+];
+
+export const MAX_CUSTOM_TOPICS = 5;

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -60,6 +60,17 @@ export const COPY = {
     body: "We looked everywhere \u2014 even had the AI search for it. Let\u2019s get you back to the stories.",
     button: "Back to Sift",
   },
+  topics: {
+    modalTitle: "What do you want to track?",
+    modalPlaceholder: "e.g. Florida utilities, AI in healthcare, Series A funding",
+    generating: "Interpreting your topic\u2026",
+    previewTitle: "Here\u2019s what I\u2019ll track",
+    previewQueries: "Search queries",
+    confirm: "Add topic",
+    cancel: "Cancel",
+    edit: "Edit",
+    maxReached: "You\u2019ve hit the 5-topic limit. Remove one to add another.",
+  },
   searchEmpty: {
     title: "Nothing matched that search",
     body: "Try different words \u2014 or let the AI surprise you.",

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -210,4 +210,43 @@ export async function insertArticle(article: {
   );
 }
 
+// ─── Custom Topics ────────────────────────────────────
+
+export interface DbCustomTopic {
+  id: string;
+  user_id: string;
+  name: string;
+  query: string; // JSON-encoded CustomTopic data
+  created_at: Date;
+}
+
+export async function getCustomTopics(userId: string): Promise<DbCustomTopic[]> {
+  const result = await pool.query<DbCustomTopic>(
+    "SELECT id, user_id, name, query, created_at FROM custom_topics WHERE user_id = $1 ORDER BY created_at ASC",
+    [userId]
+  );
+  return result.rows;
+}
+
+export async function saveCustomTopic(
+  id: string,
+  userId: string,
+  name: string,
+  topicJson: string
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO custom_topics (id, user_id, name, query)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (user_id, name) DO UPDATE SET query = $4`,
+    [id, userId, name, topicJson]
+  );
+}
+
+export async function deleteCustomTopic(id: string, userId: string): Promise<void> {
+  await pool.query(
+    "DELETE FROM custom_topics WHERE id = $1 AND user_id = $2",
+    [id, userId]
+  );
+}
+
 export default pool;

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
-import { STORAGE_KEYS, SLOW_THRESHOLD_MS, API_TIMEOUT_MS } from "./constants";
-import type { Article, Story, ArticleCache, StoryCache, CategoryId, NewsApiResponse, CompareResponse, CompareClaim, SSEResultsEvent, SSEDoneEvent, SSEErrorEvent } from "./types";
+import { STORAGE_KEYS, SLOW_THRESHOLD_MS, API_TIMEOUT_MS, MAX_CUSTOM_TOPICS } from "./constants";
+import type { Article, Story, ArticleCache, StoryCache, CategoryId, CustomTopic, NewsApiResponse, CompareResponse, CompareClaim, SSEResultsEvent, SSEDoneEvent, SSEErrorEvent } from "./types";
 import { readSSE } from "./sse";
 
 // ─── useLocalStorage ────────────────────────────────────
@@ -393,6 +393,81 @@ export function useTopicSearch() {
   }, []);
 
   return { ...state, search, clear };
+}
+
+// ─── useCustomTopics ────────────────────────────────────
+
+export function useCustomTopics(userId?: string | null) {
+  const [localTopics, setLocalTopics] = useLocalStorage<CustomTopic[]>(
+    STORAGE_KEYS.customTopics,
+    []
+  );
+  const [serverTopics, setServerTopics] = useState<CustomTopic[]>([]);
+  const [synced, setSynced] = useState(false);
+
+  const isSignedIn = !!userId;
+
+  // Fetch from server on mount when signed in
+  useEffect(() => {
+    if (!isSignedIn) {
+      setSynced(false);
+      return;
+    }
+    let cancelled = false;
+    fetch("/api/topics")
+      .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then((data: { topics: CustomTopic[] }) => {
+        if (!cancelled) {
+          setServerTopics(data.topics);
+          setSynced(true);
+        }
+      })
+      .catch((err) => console.error("Failed to fetch custom topics:", err));
+    return () => { cancelled = true; };
+  }, [isSignedIn]);
+
+  const topics = isSignedIn && synced ? serverTopics : localTopics;
+
+  const add = useCallback(
+    (topic: CustomTopic) => {
+      if (topics.length >= MAX_CUSTOM_TOPICS) return;
+
+      if (isSignedIn) {
+        setServerTopics((prev) => [...prev, topic]);
+        fetch("/api/topics", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ topic }),
+        }).catch((err) => console.error("Topic save error:", err));
+      } else {
+        setLocalTopics((prev) => [...prev, topic]);
+      }
+    },
+    [isSignedIn, topics.length, setLocalTopics]
+  );
+
+  const remove = useCallback(
+    (id: string) => {
+      if (isSignedIn) {
+        setServerTopics((prev) => prev.filter((t) => t.id !== id));
+        fetch("/api/topics", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id }),
+        }).catch((err) => console.error("Topic delete error:", err));
+      } else {
+        setLocalTopics((prev) => prev.filter((t) => t.id !== id));
+      }
+    },
+    [isSignedIn, setLocalTopics]
+  );
+
+  return {
+    topics,
+    add,
+    remove,
+    canAdd: topics.length < MAX_CUSTOM_TOPICS,
+  };
 }
 
 // ─── useCompare ─────────────────────────────────────────

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -162,6 +162,26 @@ export interface CompareSource {
   label: string;
 }
 
+// ─── Custom Topic Types ────────────────────────────────
+
+export interface CustomTopic {
+  id: string;
+  rawInput: string;
+  shortLabel: string;
+  icon: string;
+  searchQueries: string[];
+  description: string;
+  createdAt: string;
+  colorIndex: number;
+}
+
+export interface TopicGenerateResponse {
+  shortLabel: string;
+  icon: string;
+  searchQueries: string[];
+  description: string;
+}
+
 // ─── State Types ────────────────────────────────────────
 
 export interface ArticleCache {


### PR DESCRIPTION
## Summary
- Users define freeform topics via a modal; Claude Haiku interprets input into smart search queries, a short label, and an emoji icon
- Custom topic pills appear in the category nav with per-topic colors and a delete button
- Articles load via existing topic search infrastructure (Voyage AI + pgvector + Claude web fallback)
- Dual storage: localStorage for signed-out users, `custom_topics` DB table for signed-in users (Clerk auth)
- Max 5 custom topics per user

## Test plan
- [ ] Click "+" in category nav, type "Florida utilities and clean energy", confirm preview
- [ ] Verify new pill appears with AI-generated label and articles load via SSE
- [ ] Refresh page and confirm topic persists (localStorage)
- [ ] Click "×" on pill to remove topic
- [ ] Add 5 topics and verify "+" button disappears
- [ ] Sign in with Clerk and verify topics sync to server
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run build` clean
- [ ] `npm test` — 41 tests pass

