### PR TITLE
Add smart feed ranking, why-it-matters context, and importance scoring

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -38,6 +38,8 @@ const MOCK_DB_ROWS: DbArticle[] = [
     category: "technology",
     published_date: new Date("2026-03-28T10:00:00Z"),
     read_time: 2,
+    why_it_matters: null,
+    importance_score: null,
     created_at: new Date("2026-03-28T10:00:00Z"),
   },
   {
@@ -50,6 +52,8 @@ const MOCK_DB_ROWS: DbArticle[] = [
     category: "technology",
     published_date: new Date("2026-03-28T08:00:00Z"),
     read_time: 3,
+    why_it_matters: null,
+    importance_score: null,
     created_at: new Date("2026-03-28T08:00:00Z"),
   },
 ];

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -2,6 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { getStoriesWithArticles, getLastRefreshed } from "@/lib/db";
 import type { CategoryId, Article, Story, StoryFraming, EntitySet, NewsApiResponse, NewsApiError } from "@/lib/types";
 
+const BAD_SUMMARIES = ["unable to provide summary"];
+
+function cleanSummary(raw: string | null): string {
+  if (!raw) return "";
+  if (BAD_SUMMARIES.some((b) => raw.toLowerCase().startsWith(b))) return "";
+  return raw;
+}
+
 // ─── Valid Categories ───────────────────────────────────
 
 const VALID_CATEGORIES = new Set<string>([
@@ -33,13 +41,15 @@ export async function GET(request: NextRequest) {
     const articles: Article[] = standaloneArticles.map((row) => ({
       id: row.id,
       title: row.title,
-      summary: row.summary || "",
+      summary: cleanSummary(row.summary),
       sourceUrl: row.source_url,
       sourceName: row.source_name,
       publishedDate: row.published_date ? row.published_date.toISOString() : null,
       imageUrl: row.image_url,
       category: row.category as CategoryId,
       readTime: row.read_time || 1,
+      ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
+      ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
     }));
 
     // Map stories with nested articles
@@ -48,13 +58,15 @@ export async function GET(request: NextRequest) {
       const childArticles: Article[] = childRows.map((row) => ({
         id: row.id,
         title: row.title,
-        summary: row.summary || "",
+        summary: cleanSummary(row.summary),
         sourceUrl: row.source_url,
         sourceName: row.source_name,
         publishedDate: row.published_date ? row.published_date.toISOString() : null,
         imageUrl: row.image_url,
         category: row.category as CategoryId,
         readTime: row.read_time || 1,
+        ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
+        ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
       }));
 
       // Parse JSONB framings

--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -162,6 +162,8 @@ export async function GET(request: NextRequest) {
           imageUrl: row.image_url,
           category: row.category as CategoryId,
           readTime: row.read_time || 1,
+          ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
+          ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
         }));
 
         // 4. Stream vector results immediately

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -155,15 +155,21 @@ export default function ArticleCard({
           className="text-[var(--text-secondary)] leading-relaxed"
           style={{
             fontSize: featured ? 15 : 13.5,
-            display: "-webkit-box",
-            WebkitLineClamp: featured ? 4 : 3,
-            WebkitBoxOrient: "vertical",
-            overflow: "hidden",
             flex: 1,
           }}
         >
           {article.summary}
         </p>
+
+        {/* Why it matters */}
+        {article.whyItMatters && (
+          <p
+            className="text-[13px] italic leading-snug"
+            style={{ color: color.hex, opacity: 0.75 }}
+          >
+            {article.whyItMatters}
+          </p>
+        )}
 
         {/* Meta */}
         <div className="flex items-center gap-3 mt-auto pt-2 text-xs text-[var(--text-muted)] font-medium flex-wrap">

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -219,7 +219,7 @@ export default function NewsAggregator() {
     return articles[activeCategory] || [];
   }, [articles, activeCategory, showBookmarks, bookmarks, userId, bookmarkedArticles, searchMode, customTopicMode, topicArticles]);
 
-  // Build feed items: stories + standalone articles, sorted by date
+  // Build feed items: stories + standalone articles, ranked by importance * recency
   const feedItems = useMemo((): FeedItem[] => {
     // Stories only apply to category view (not bookmarks/search/custom topics)
     if (searchMode || showBookmarks || customTopicMode) {
@@ -232,15 +232,22 @@ export default function NewsAggregator() {
       ...currentArticles.map((a) => ({ type: "article" as const, data: a })),
     ];
 
-    // Sort by published date descending
-    items.sort((a, b) => {
-      const dateA = a.type === "story" ? a.data.publishedDate : a.data.publishedDate;
-      const dateB = b.type === "story" ? b.data.publishedDate : b.data.publishedDate;
-      if (!dateA && !dateB) return 0;
-      if (!dateA) return 1;
-      if (!dateB) return -1;
-      return new Date(dateB).getTime() - new Date(dateA).getTime();
-    });
+    // Rank by composite score: (importance + source_boost) * recency_decay
+    const now = Date.now();
+    function rankScore(item: FeedItem): number {
+      const pubDate = item.data.publishedDate;
+      const ageHours = pubDate ? (now - new Date(pubDate).getTime()) / 3_600_000 : 48;
+      const decay = Math.exp(-ageHours / 24);
+
+      if (item.type === "story") {
+        const sourceBoost = Math.min((item.data.articleCount - 1), 4) * 0.5;
+        return (3 + sourceBoost) * decay;
+      }
+      const importance = item.data.importanceScore ?? 3;
+      return importance * decay;
+    }
+
+    items.sort((a, b) => rankScore(b) - rankScore(a));
 
     return items;
   }, [currentArticles, stories, activeCategory, searchMode, showBookmarks, customTopicMode]);

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -15,6 +15,8 @@ export interface DbArticle {
   category: string;
   published_date: Date | null;
   read_time: number;
+  why_it_matters: string | null;
+  importance_score: number | null;
   created_at: Date;
 }
 
@@ -24,10 +26,15 @@ export async function getArticlesByCategory(
 ): Promise<DbArticle[]> {
   const result = await pool.query<DbArticle>(
     `SELECT id, title, summary, source_url, source_name, image_url,
-            category, published_date, read_time, created_at
+            category, published_date, read_time, why_it_matters, importance_score, created_at
      FROM articles
      WHERE category = $1 AND from_search = false
-     ORDER BY published_date DESC NULLS LAST
+       AND summary IS NOT NULL AND summary != ''
+       AND LOWER(summary) NOT LIKE 'unable to provide%'
+     ORDER BY
+       COALESCE(importance_score, 3)::float *
+       EXP(-EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))) / 86400.0)
+     DESC NULLS LAST
      LIMIT $2`,
     [category, limit]
   );
@@ -64,7 +71,10 @@ export async function getStoriesWithArticles(
               article_count, representative_image_url, published_date, synthesis_status
        FROM stories
        WHERE category = $1 AND synthesis_status = 'complete'
-       ORDER BY published_date DESC NULLS LAST
+       ORDER BY
+         COALESCE(article_count, 1)::float *
+         EXP(-EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))) / 86400.0)
+       DESC NULLS LAST
        LIMIT 20`,
       [category]
     );
@@ -82,10 +92,15 @@ export async function getStoriesWithArticles(
   try {
     const articlesResult = await pool.query<DbStoryArticle>(
       `SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, created_at, story_id
+              category, published_date, read_time, why_it_matters, importance_score, created_at, story_id
        FROM articles
        WHERE category = $1 AND from_search = false
-       ORDER BY published_date DESC NULLS LAST
+         AND summary IS NOT NULL AND summary != ''
+         AND LOWER(summary) NOT LIKE 'unable to provide%'
+       ORDER BY
+         COALESCE(importance_score, 3)::float *
+         EXP(-EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))) / 86400.0)
+       DESC NULLS LAST
        LIMIT 50`,
       [category]
     );
@@ -96,10 +111,15 @@ export async function getStoriesWithArticles(
     if (!msg.includes("story_id")) throw err;
     const fallback = await pool.query<DbArticle>(
       `SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, created_at
+              category, published_date, read_time, why_it_matters, importance_score, created_at
        FROM articles
        WHERE category = $1 AND from_search = false
-       ORDER BY published_date DESC NULLS LAST
+         AND summary IS NOT NULL AND summary != ''
+         AND LOWER(summary) NOT LIKE 'unable to provide%'
+       ORDER BY
+         COALESCE(importance_score, 3)::float *
+         EXP(-EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))) / 86400.0)
+       DESC NULLS LAST
        LIMIT 50`,
       [category]
     );
@@ -167,7 +187,7 @@ export async function removeBookmark(userId: string, articleId: string): Promise
 export async function getBookmarkedArticles(userId: string): Promise<DbArticle[]> {
   const result = await pool.query<DbArticle>(
     `SELECT a.id, a.title, a.summary, a.source_url, a.source_name, a.image_url,
-            a.category, a.published_date, a.read_time, a.created_at
+            a.category, a.published_date, a.read_time, a.why_it_matters, a.importance_score, a.created_at
      FROM articles a
      JOIN bookmarks b ON b.article_id = a.id
      WHERE b.user_id = $1
@@ -191,7 +211,7 @@ export async function searchArticlesByEmbedding(
   const vectorStr = `[${embedding.join(",")}]`;
   const result = await pool.query<DbArticle & { similarity: number }>(
     `SELECT id, title, summary, source_url, source_name, image_url,
-            category, published_date, read_time, created_at,
+            category, published_date, read_time, why_it_matters, importance_score, created_at,
             1 - (embedding <=> $1::vector) AS similarity
      FROM articles
      WHERE embedding IS NOT NULL

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,6 +28,8 @@ export interface Article {
   imageUrl: string | null;
   category: CategoryId;
   readTime: number;
+  whyItMatters?: string;
+  importanceScore?: number;
 }
 
 // ─── Story Types ────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Smart ranking**: Feed now uses `(importance + source_boost) * recency_decay` instead of pure chronological order. Breaking news surfaces above routine updates.
- **AI importance scores (1-5)**: Claude Haiku rates each article during pipeline. Scores stored in DB, used for ranking.
- **"Why it matters" context lines**: One-liner below each article summary explaining real-world impact. Natural voice, no templated prefix.
- **Source-count boost**: Stories covered by multiple outlets rank higher via `article_count` weighting.
- **Quality filter**: Articles with empty/bad summaries excluded at DB query level. Summary line clamp removed so full text shows.

## Test plan
- [ ] Verify feed order reflects importance (breaking news at top, routine at bottom)
- [ ] Confirm context lines display below summaries in accent-colored italic
- [ ] Check articles without scores gracefully default to importance 3
- [ ] Verify topic search and bookmarks still work correctly
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run build` clean
- [ ] `npm test` passes (53 tests)

