### PR TITLE
Strip leaked cite tags from summaries

### DIFF
--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -7,7 +7,8 @@ const BAD_SUMMARIES = ["unable to provide summary"];
 function cleanSummary(raw: string | null): string {
   if (!raw) return "";
   if (BAD_SUMMARIES.some((b) => raw.toLowerCase().startsWith(b))) return "";
-  return raw;
+  // Strip <cite> tags leaked from Claude web_search responses
+  return raw.replace(/<cite[^>]*>|<\/cite>/g, "");
 }
 
 // ─── Valid Categories ───────────────────────────────────


### PR DESCRIPTION
## Summary
- Strip `<cite>` tags from Claude web_search responses that were leaking into article summaries
- Regex cleanup in `cleanSummary()` at API layer

## Test plan
- [ ] Verify no raw HTML tags appear in article summaries
- [ ] Build + tests pass

