### PR TITLE
Fix: upgrade blurry Contentful CDN images

### DIFF
--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -11,6 +11,22 @@ function cleanSummary(raw: string | null): string {
   return raw.replace(/<cite[^>]*>|<\/cite>/g, "");
 }
 
+function cleanImageUrl(raw: string | null): string | null {
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    // Contentful CDN (VentureBeat etc): upgrade tiny thumbnails to usable size
+    if (url.hostname.includes("ctfassets.net")) {
+      url.searchParams.set("w", "800");
+      url.searchParams.set("q", "80");
+      return url.toString();
+    }
+    return raw;
+  } catch {
+    return raw;
+  }
+}
+
 // ─── Valid Categories ───────────────────────────────────
 
 const VALID_CATEGORIES = new Set<string>([
@@ -46,7 +62,7 @@ export async function GET(request: NextRequest) {
       sourceUrl: row.source_url,
       sourceName: row.source_name,
       publishedDate: row.published_date ? row.published_date.toISOString() : null,
-      imageUrl: row.image_url,
+      imageUrl: cleanImageUrl(row.image_url),
       category: row.category as CategoryId,
       readTime: row.read_time || 1,
       ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
@@ -63,7 +79,7 @@ export async function GET(request: NextRequest) {
         sourceUrl: row.source_url,
         sourceName: row.source_name,
         publishedDate: row.published_date ? row.published_date.toISOString() : null,
-        imageUrl: row.image_url,
+        imageUrl: cleanImageUrl(row.image_url),
         category: row.category as CategoryId,
         readTime: row.read_time || 1,
         ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
@@ -95,7 +111,7 @@ export async function GET(request: NextRequest) {
         framings,
         entities,
         articleCount: s.article_count,
-        imageUrl: s.representative_image_url,
+        imageUrl: cleanImageUrl(s.representative_image_url),
         publishedDate: s.published_date ? s.published_date.toISOString() : null,
         articles: childArticles,
       };


### PR DESCRIPTION
## Summary
- VentureBeat articles had blurry images because their RSS feed serves Contentful CDN URLs at `w=300&q=30` (300px wide, 30% JPEG quality)
- Added `cleanImageUrl()` in the API route to detect `ctfassets.net` URLs and upgrade to `w=800&q=80`
- Applied to all 3 image mapping points (standalone articles, story child articles, story representative image)

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] 53/53 tests pass
- [x] Verified the CrowdStrike/RSAC article image URL would be rewritten correctly

