### PR TITLE
Security hardening: fix critical and medium vulnerabilities

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -266,7 +266,7 @@ describe("GET /api/news", () => {
 
       expect(res.status).toBe(500);
       expect(body.error).toBe("Internal server error");
-      expect(body.details).toContain("connection refused");
+      expect(body.details).toBeUndefined();
     });
   });
 

--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
+import { z } from "zod";
 import {
   getBookmarks,
   addBookmark,
@@ -7,6 +8,11 @@ import {
   getBookmarkedArticles,
 } from "@/lib/db";
 import type { Article, CategoryId } from "@/lib/types";
+import { checkCsrf } from "@/lib/security";
+
+const bookmarkSchema = z.object({
+  articleId: z.string().min(1).max(200),
+});
 
 function unauthorized() {
   return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -46,15 +52,20 @@ export async function GET(request: NextRequest) {
 
 // POST /api/bookmarks — body { articleId }
 export async function POST(request: NextRequest) {
+  const csrfError = checkCsrf(request);
+  if (csrfError) return csrfError;
+
   const { userId } = await auth();
   if (!userId) return unauthorized();
 
   try {
-    const { articleId } = await request.json();
-    if (!articleId || typeof articleId !== "string") {
+    let body: z.infer<typeof bookmarkSchema>;
+    try {
+      body = bookmarkSchema.parse(await request.json());
+    } catch {
       return NextResponse.json({ error: "articleId required" }, { status: 400 });
     }
-    await addBookmark(userId, articleId);
+    await addBookmark(userId, body.articleId);
     return NextResponse.json({ ok: true });
   } catch (err) {
     console.error("Bookmarks POST error:", err);
@@ -64,15 +75,20 @@ export async function POST(request: NextRequest) {
 
 // DELETE /api/bookmarks — body { articleId }
 export async function DELETE(request: NextRequest) {
+  const csrfError = checkCsrf(request);
+  if (csrfError) return csrfError;
+
   const { userId } = await auth();
   if (!userId) return unauthorized();
 
   try {
-    const { articleId } = await request.json();
-    if (!articleId || typeof articleId !== "string") {
+    let body: z.infer<typeof bookmarkSchema>;
+    try {
+      body = bookmarkSchema.parse(await request.json());
+    } catch {
       return NextResponse.json({ error: "articleId required" }, { status: 400 });
     }
-    await removeBookmark(userId, articleId);
+    await removeBookmark(userId, body.articleId);
     return NextResponse.json({ ok: true });
   } catch (err) {
     console.error("Bookmarks DELETE error:", err);

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -1,21 +1,42 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
+import { z } from "zod";
+import { rateLimit } from "@/lib/rate-limit";
+import { checkCsrf } from "@/lib/security";
 
 const SIFT_API_URL = process.env.SIFT_API_URL || "http://localhost:8000";
 const COMPARE_TIMEOUT_MS = 60_000;
 
+const compareSchema = z.object({
+  topic: z.string().min(3).max(500),
+  sources: z.array(z.string().max(200)).max(10).optional(),
+});
+
 export async function POST(request: NextRequest) {
+  const csrfError = checkCsrf(request);
+  if (csrfError) return csrfError;
+
   const { userId } = await auth();
   if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  try {
-    const body = await request.json();
+  // Rate limit: 5 comparisons per minute per user
+  const rl = rateLimit(`compare:${userId}`, { maxRequests: 5, windowMs: 60_000 });
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": String(Math.ceil(rl.retryAfterMs / 1000)) } }
+    );
+  }
 
-    if (!body.topic || typeof body.topic !== "string" || body.topic.trim().length < 3) {
+  try {
+    let body: z.infer<typeof compareSchema>;
+    try {
+      body = compareSchema.parse(await request.json());
+    } catch {
       return NextResponse.json(
-        { error: "Topic must be at least 3 characters" },
+        { error: "Topic must be 3-500 characters" },
         { status: 400 }
       );
     }

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -1,9 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
 
 const SIFT_API_URL = process.env.SIFT_API_URL || "http://localhost:8000";
 const COMPARE_TIMEOUT_MS = 60_000;
 
 export async function POST(request: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const body = await request.json();
 

--- a/app/api/cron/refresh/route.ts
+++ b/app/api/cron/refresh/route.ts
@@ -1,16 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
 
 const SIFT_API_URL = process.env.SIFT_API_URL || "http://localhost:8000";
-const SIFT_API_KEY = process.env.SIFT_API_KEY || "dev-key";
 
 export async function GET(request: NextRequest) {
-  // Verify cron secret in production
+  // Verify cron secret — always required
   const cronSecret = process.env.CRON_SECRET;
-  if (cronSecret) {
-    const auth = request.headers.get("authorization");
-    if (auth !== `Bearer ${cronSecret}`) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+  if (!cronSecret) {
+    console.error("CRON_SECRET environment variable is not set");
+    return NextResponse.json({ error: "Server misconfigured" }, { status: 500 });
+  }
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const siftApiKey = process.env.SIFT_API_KEY;
+  if (!siftApiKey) {
+    console.error("SIFT_API_KEY environment variable is not set");
+    return NextResponse.json({ error: "Server misconfigured" }, { status: 500 });
   }
 
   try {
@@ -18,7 +25,7 @@ export async function GET(request: NextRequest) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Pipeline-Key": SIFT_API_KEY,
+        "X-Pipeline-Key": siftApiKey,
       },
       body: JSON.stringify({}),
       signal: AbortSignal.timeout(300_000), // 5 min timeout for full pipeline
@@ -35,7 +42,7 @@ export async function GET(request: NextRequest) {
   } catch (err) {
     console.error("Pipeline trigger failed:", err);
     return NextResponse.json(
-      { triggered: false, error: String(err) },
+      { triggered: false, error: "Pipeline trigger failed" },
       { status: 502 }
     );
   }

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -126,7 +126,7 @@ export async function GET(request: NextRequest) {
   } catch (err) {
     console.error("Database query error:", err);
     return NextResponse.json<NewsApiError>(
-      { error: "Internal server error", details: String(err) },
+      { error: "Internal server error" },
       { status: 500 }
     );
   }

--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -3,6 +3,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { searchArticlesByEmbedding, insertArticle } from "@/lib/db";
 import { stableHash, estimateReadTime } from "@/lib/utils";
 import type { Article, CategoryId } from "@/lib/types";
+import { rateLimit } from "@/lib/rate-limit";
 
 const SIMILARITY_THRESHOLD = 0.35;
 const MIN_STRONG_RESULTS = 3;
@@ -126,6 +127,16 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(
       { error: "Query must be 2-200 characters" },
       { status: 400 }
+    );
+  }
+
+  // Rate limit by IP: 20 searches per minute
+  const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
+  const rl = rateLimit(`topic-search:${ip}`, { maxRequests: 20, windowMs: 60_000 });
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": String(Math.ceil(rl.retryAfterMs / 1000)) } }
     );
   }
 
@@ -271,7 +282,8 @@ async function webSearchFallback(query: string): Promise<Article[]> {
     messages: [
       {
         role: "user",
-        content: `Search the web for recent news articles related to: "${query}"
+        content: `Search the web for recent news articles related to:
+<user_query>${query}</user_query>
 
 If the query is vague or broad (like a single word), interpret it generously — find interesting recent news stories that relate to the theme.
 

--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -211,7 +211,7 @@ export async function GET(request: NextRequest) {
       } catch (err) {
         console.error("Topic search error:", err);
         controller.enqueue(
-          sseEvent("error", { message: String(err) })
+          sseEvent("error", { message: "Topic search failed" })
         );
       } finally {
         controller.close();

--- a/app/api/topics/generate/route.ts
+++ b/app/api/topics/generate/route.ts
@@ -1,30 +1,46 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
+import { z } from "zod";
 import Anthropic from "@anthropic-ai/sdk";
 import type { TopicGenerateResponse } from "@/lib/types";
+import { rateLimit } from "@/lib/rate-limit";
+import { checkCsrf } from "@/lib/security";
+
+const generateSchema = z.object({
+  rawTopic: z.string().min(2).max(200),
+  existingTopics: z.array(z.string().max(200)).max(20).optional().default([]),
+});
 
 export async function POST(request: NextRequest) {
+  const csrfError = checkCsrf(request);
+  if (csrfError) return csrfError;
+
   const { userId } = await auth();
   if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  let body: { rawTopic?: string; existingTopics?: string[] };
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  // Rate limit: 10 requests per minute per user
+  const rl = rateLimit(`generate:${userId}`, { maxRequests: 10, windowMs: 60_000 });
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": String(Math.ceil(rl.retryAfterMs / 1000)) } }
+    );
   }
 
-  const rawTopic = body.rawTopic?.trim();
-  if (!rawTopic || rawTopic.length < 2 || rawTopic.length > 200) {
+  let body: z.infer<typeof generateSchema>;
+  try {
+    body = generateSchema.parse(await request.json());
+  } catch {
     return NextResponse.json(
-      { error: "Topic must be 2-200 characters" },
+      { error: "Invalid input: rawTopic (2-200 chars) is required" },
       { status: 400 }
     );
   }
 
-  const existingTopics = body.existingTopics || [];
+  const rawTopic = body.rawTopic.trim();
+  const existingTopics = body.existingTopics;
 
   try {
     const anthropic = new Anthropic();
@@ -41,7 +57,8 @@ export async function POST(request: NextRequest) {
         {
           role: "user",
           content: `You are helping a user create a personalized news topic for a news aggregator.
-They described their interest as: "${rawTopic}"
+They described their interest as:
+<user_input>${rawTopic}</user_input>
 ${existingClause}
 
 Generate a topic configuration:

--- a/app/api/topics/generate/route.ts
+++ b/app/api/topics/generate/route.ts
@@ -1,8 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
 import Anthropic from "@anthropic-ai/sdk";
 import type { TopicGenerateResponse } from "@/lib/types";
 
 export async function POST(request: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   let body: { rawTopic?: string; existingTopics?: string[] };
   try {
     body = await request.json();
@@ -94,7 +100,7 @@ Respond with ONLY valid JSON, no explanation:
   } catch (err) {
     console.error("Topic generation error:", err);
     return NextResponse.json(
-      { error: "Failed to generate topic", details: String(err) },
+      { error: "Failed to generate topic" },
       { status: 500 }
     );
   }

--- a/app/api/topics/route.ts
+++ b/app/api/topics/route.ts
@@ -1,8 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
+import { z } from "zod";
 import { getCustomTopics, saveCustomTopic, deleteCustomTopic } from "@/lib/db";
 import type { CustomTopic } from "@/lib/types";
 import { MAX_CUSTOM_TOPICS } from "@/lib/constants";
+import { checkCsrf } from "@/lib/security";
+
+const topicSchema = z.object({
+  topic: z.object({
+    id: z.string().min(1).max(200),
+    shortLabel: z.string().min(1).max(12),
+    icon: z.string().max(10).optional(),
+    searchQueries: z.array(z.string().max(500)).min(1).max(5),
+    description: z.string().max(500).optional(),
+    rawInput: z.string().max(200).optional(),
+    createdAt: z.string().optional(),
+    colorIndex: z.number().int().min(0).max(100).optional(),
+  }),
+});
+
+const deleteTopicSchema = z.object({
+  id: z.string().min(1).max(200),
+});
 
 function unauthorized() {
   return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -40,14 +59,20 @@ export async function GET() {
 
 // POST /api/topics — body { topic: CustomTopic }
 export async function POST(request: NextRequest) {
+  const csrfError = checkCsrf(request);
+  if (csrfError) return csrfError;
+
   const { userId } = await auth();
   if (!userId) return unauthorized();
 
   try {
-    const { topic } = (await request.json()) as { topic: CustomTopic };
-    if (!topic || !topic.id || !topic.shortLabel) {
+    let parsed: z.infer<typeof topicSchema>;
+    try {
+      parsed = topicSchema.parse(await request.json());
+    } catch {
       return NextResponse.json({ error: "Invalid topic" }, { status: 400 });
     }
+    const topic = parsed.topic as CustomTopic;
 
     // Check limit
     const existing = await getCustomTopics(userId);
@@ -68,14 +93,20 @@ export async function POST(request: NextRequest) {
 
 // DELETE /api/topics — body { id }
 export async function DELETE(request: NextRequest) {
+  const csrfError = checkCsrf(request);
+  if (csrfError) return csrfError;
+
   const { userId } = await auth();
   if (!userId) return unauthorized();
 
   try {
-    const { id } = (await request.json()) as { id: string };
-    if (!id) {
+    let body: z.infer<typeof deleteTopicSchema>;
+    try {
+      body = deleteTopicSchema.parse(await request.json());
+    } catch {
       return NextResponse.json({ error: "id required" }, { status: 400 });
     }
+    const { id } = body;
     await deleteCustomTopic(id, userId);
     return NextResponse.json({ ok: true });
   } catch (err) {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,7 +1,11 @@
 import { Pool } from "pg";
 
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL environment variable is not set");
+}
+
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL || "postgresql://sift:sift@localhost:5432/siftdb",
+  connectionString: process.env.DATABASE_URL,
   max: 5,
 });
 

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,58 @@
+/**
+ * Simple in-memory rate limiter using a sliding window.
+ * Suitable for single-instance deployments (Vercel serverless resets per cold start).
+ * For multi-instance deployments, replace with Redis-backed solution.
+ */
+
+interface RateLimitEntry {
+  timestamps: number[];
+}
+
+const store = new Map<string, RateLimitEntry>();
+
+// Periodically clean up expired entries to prevent memory leaks
+const CLEANUP_INTERVAL_MS = 60_000;
+let lastCleanup = Date.now();
+
+function cleanup(windowMs: number) {
+  const now = Date.now();
+  if (now - lastCleanup < CLEANUP_INTERVAL_MS) return;
+  lastCleanup = now;
+  const cutoff = now - windowMs;
+  for (const [key, entry] of store) {
+    entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+    if (entry.timestamps.length === 0) store.delete(key);
+  }
+}
+
+export function rateLimit(
+  key: string,
+  { maxRequests, windowMs }: { maxRequests: number; windowMs: number }
+): { allowed: boolean; remaining: number; retryAfterMs: number } {
+  cleanup(windowMs);
+
+  const now = Date.now();
+  const cutoff = now - windowMs;
+  const entry = store.get(key) || { timestamps: [] };
+
+  // Remove expired timestamps
+  entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+
+  if (entry.timestamps.length >= maxRequests) {
+    const oldest = entry.timestamps[0];
+    return {
+      allowed: false,
+      remaining: 0,
+      retryAfterMs: oldest + windowMs - now,
+    };
+  }
+
+  entry.timestamps.push(now);
+  store.set(key, entry);
+
+  return {
+    allowed: true,
+    remaining: maxRequests - entry.timestamps.length,
+    retryAfterMs: 0,
+  };
+}

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Validates that mutation requests (POST, PUT, DELETE, PATCH) originate
+ * from the same site by checking the Origin or Referer header.
+ * Returns null if valid, or a 403 response if the check fails.
+ */
+export function checkCsrf(request: NextRequest): NextResponse | null {
+  const method = request.method.toUpperCase();
+  if (method === "GET" || method === "HEAD" || method === "OPTIONS") {
+    return null;
+  }
+
+  const origin = request.headers.get("origin");
+  const referer = request.headers.get("referer");
+  const host = request.headers.get("host");
+
+  if (!host) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Check Origin header first (most reliable)
+  if (origin) {
+    try {
+      const originHost = new URL(origin).host;
+      if (originHost === host) return null;
+    } catch {
+      // invalid origin
+    }
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Fall back to Referer header
+  if (referer) {
+    try {
+      const refererHost = new URL(referer).host;
+      if (refererHost === host) return null;
+    } catch {
+      // invalid referer
+    }
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // No Origin or Referer — allow for non-browser clients (cURL, cron, etc.)
+  // Browsers always send Origin on cross-origin requests
+  return null;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,26 @@ const nextConfig = {
     // Allow news article images from any domain
     remotePatterns: [{ protocol: "https", hostname: "**" }],
   },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000; includeSubDomains",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    // Allow news article images from any domain
+    // Allow news article images from any HTTPS domain.
+    // Sift aggregates from 100+ RSS sources with diverse CDN domains,
+    // making a strict allowlist impractical. Images are only loaded from
+    // URLs stored in the database via trusted RSS feed ingestion.
     remotePatterns: [{ protocol: "https", hostname: "**" }],
   },
   async headers() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "next": "^15.1.0",
         "pg": "^8.20.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -10990,6 +10991,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "next": "^15.1.0",
     "pg": "^8.20.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
## Summary

Security audit of the Sift codebase identified critical and medium-severity vulnerabilities across API routes and configuration. This PR fixes all of them.

### Critical/High fixes (#31)
- **Removed hardcoded `"dev-key"` fallback** for `SIFT_API_KEY` — now fails fast if unset
- **Removed hardcoded DB credentials** (`sift:sift@localhost`) fallback in `lib/db.ts`
- **Made `CRON_SECRET` mandatory** — cron endpoint was fully open if env var was unset
- **Added Clerk auth** to `/api/topics/generate` and `/api/compare` (were completely unprotected)
- **Sanitized error responses** — stopped leaking `String(err)` internals to clients
- **Added security headers** (HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy)

### Medium fixes (#32)
- **Rate limiting** on expensive endpoints: `topics/generate` (10/min), `compare` (5/min), `news/topic` (20/min)
- **Zod schema validation** on all POST/DELETE endpoints, replacing ad-hoc `typeof` checks
- **CSRF protection** via Origin/Referer header checking on all mutation endpoints
- **Prompt injection mitigation** — user input wrapped in XML tags in Claude prompts
- **Documented wildcard image domain** rationale (100+ RSS sources make strict allowlist impractical)

### New files
- `lib/rate-limit.ts` — in-memory sliding window rate limiter
- `lib/security.ts` — CSRF origin checking utility

## Test plan
- [x] All 55 tests pass (`npm test`)
- [x] No new TypeScript errors (`npx tsc --noEmit`)
- [x] Updated test for sanitized error response (removed `details` field assertion)
- [ ] Verify protected endpoints return 401 without auth
- [ ] Verify rate limiting returns 429 after threshold
- [ ] Verify cron endpoint returns 500 if `CRON_SECRET` is unset

Closes #31, closes #32

