### PR TITLE
Security audit round 2: fix remaining vulnerabilities

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -59,9 +59,11 @@ export async function POST(request: NextRequest) {
 
       if (!res.ok) {
         const errorBody = await res.json().catch(() => ({}));
+        console.error("Compare service error:", res.status, errorBody.detail);
+        const status = res.status >= 400 && res.status < 500 ? 400 : 502;
         return NextResponse.json(
-          { error: errorBody.detail || `Comparison service error (${res.status})` },
-          { status: res.status }
+          { error: "Comparison service unavailable" },
+          { status }
         );
       }
 

--- a/app/api/cron/refresh/route.ts
+++ b/app/api/cron/refresh/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
+import { timingSafeEqual } from "crypto";
 
 const SIFT_API_URL = process.env.SIFT_API_URL || "http://localhost:8000";
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
 
 export async function GET(request: NextRequest) {
   // Verify cron secret — always required
@@ -9,8 +15,9 @@ export async function GET(request: NextRequest) {
     console.error("CRON_SECRET environment variable is not set");
     return NextResponse.json({ error: "Server misconfigured" }, { status: 500 });
   }
-  const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${cronSecret}`) {
+  const authHeader = request.headers.get("authorization") || "";
+  const expected = `Bearer ${cronSecret}`;
+  if (!constantTimeEqual(authHeader, expected)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getStoriesWithArticles, getLastRefreshed } from "@/lib/db";
+import { stripHtml, sanitizeUrl } from "@/lib/sanitize";
 import type { CategoryId, Article, Story, StoryFraming, EntitySet, NewsApiResponse, NewsApiError } from "@/lib/types";
 
 const BAD_SUMMARIES = ["unable to provide summary"];
@@ -7,23 +8,24 @@ const BAD_SUMMARIES = ["unable to provide summary"];
 function cleanSummary(raw: string | null): string {
   if (!raw) return "";
   if (BAD_SUMMARIES.some((b) => raw.toLowerCase().startsWith(b))) return "";
-  // Strip <cite> tags leaked from Claude web_search responses
-  return raw.replace(/<cite[^>]*>|<\/cite>/g, "");
+  return stripHtml(raw);
 }
 
 function cleanImageUrl(raw: string | null): string | null {
   if (!raw) return null;
+  const safe = sanitizeUrl(raw);
+  if (!safe) return null;
   try {
-    const url = new URL(raw);
+    const url = new URL(safe);
     // Contentful CDN (VentureBeat etc): upgrade tiny thumbnails to usable size
     if (url.hostname.includes("ctfassets.net")) {
       url.searchParams.set("w", "800");
       url.searchParams.set("q", "80");
       return url.toString();
     }
-    return raw;
+    return safe;
   } catch {
-    return raw;
+    return null;
   }
 }
 

--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
 import { searchArticlesByEmbedding, insertArticle } from "@/lib/db";
 import { stableHash, estimateReadTime } from "@/lib/utils";
+import { stripHtml, sanitizeUrl } from "@/lib/sanitize";
 import type { Article, CategoryId } from "@/lib/types";
 import { rateLimit } from "@/lib/rate-limit";
 
@@ -130,13 +131,18 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // Rate limit by IP: 20 searches per minute
-  const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
-  const rl = rateLimit(`topic-search:${ip}`, { maxRequests: 20, windowMs: 60_000 });
-  if (!rl.allowed) {
+  // Rate limit by IP + global fallback to prevent abuse
+  // Use x-real-ip (set by reverse proxy) over x-forwarded-for (user-spoofable)
+  const ip = request.headers.get("x-real-ip")
+    || request.headers.get("x-forwarded-for")?.split(",")[0]?.trim()
+    || "unknown";
+  const perIp = rateLimit(`topic-search:${ip}`, { maxRequests: 20, windowMs: 60_000 });
+  const global = rateLimit("topic-search:global", { maxRequests: 200, windowMs: 60_000 });
+  if (!perIp.allowed || !global.allowed) {
+    const retryMs = Math.max(perIp.retryAfterMs, global.retryAfterMs);
     return NextResponse.json(
       { error: "Too many requests" },
-      { status: 429, headers: { "Retry-After": String(Math.ceil(rl.retryAfterMs / 1000)) } }
+      { status: 429, headers: { "Retry-After": String(Math.ceil(retryMs / 1000)) } }
     );
   }
 
@@ -383,32 +389,39 @@ If you truly cannot find any articles, respond with an empty array: []`,
     const a = parsed[i];
     if (!a.title || !a.source_url) continue;
 
+    // Sanitize external data before storage and display
+    const safeTitle = stripHtml(a.title);
+    const safeSummary = stripHtml(a.summary || "");
+    const safeSourceUrl = sanitizeUrl(a.source_url);
+    const safeSourceName = stripHtml(a.source_name || "Web");
+    if (!safeTitle || !safeSourceUrl) continue;
+
     const category: CategoryId =
       catData && embeddings[i]
         ? classifyCategory(embeddings[i], catData.embeddings, catData.categories)
         : ("top" as CategoryId);
 
-    const id = stableHash(a.source_url + a.title);
+    const id = stableHash(safeSourceUrl + safeTitle);
     articles.push({
       id,
-      title: a.title,
-      summary: a.summary || "",
-      sourceUrl: a.source_url,
-      sourceName: a.source_name || "Web",
+      title: safeTitle,
+      summary: safeSummary,
+      sourceUrl: safeSourceUrl,
+      sourceName: safeSourceName,
       publishedDate: new Date().toISOString(),
       imageUrl: null,
       category,
-      readTime: estimateReadTime(a.summary),
+      readTime: estimateReadTime(safeSummary),
     });
 
     // Store in Postgres (fire and forget)
     if (embeddings[i]) {
       insertArticle({
         id,
-        title: a.title,
-        summary: a.summary || "",
-        source_url: a.source_url,
-        source_name: a.source_name || "Web",
+        title: safeTitle,
+        summary: safeSummary,
+        source_url: safeSourceUrl,
+        source_name: safeSourceName,
         category,
         embedding: embeddings[i],
         published_date: new Date(),

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -4,9 +4,14 @@ if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL environment variable is not set");
 }
 
+const isLocalhost = process.env.DATABASE_URL.includes("localhost") || process.env.DATABASE_URL.includes("127.0.0.1");
+
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   max: 5,
+  ...(!isLocalhost && {
+    ssl: { rejectUnauthorized: true },
+  }),
 });
 
 export interface DbArticle {

--- a/lib/sanitize.ts
+++ b/lib/sanitize.ts
@@ -1,0 +1,32 @@
+/**
+ * Sanitize untrusted text content (article titles, summaries, source names)
+ * by stripping all HTML tags. This prevents stored XSS from external sources
+ * like RSS feeds and Claude web search results.
+ */
+export function stripHtml(text: string): string {
+  return text
+    .replace(/<[^>]*>/g, "") // Remove all HTML tags
+    .replace(/&lt;/g, "<")   // Decode common entities for readability
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/g, "'")
+    .replace(/&#x2F;/g, "/")
+    .trim();
+}
+
+/**
+ * Validate that a string is a safe HTTP(S) URL.
+ * Rejects javascript:, data:, and other dangerous schemes.
+ */
+export function sanitizeUrl(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      return null;
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -2,13 +2,24 @@ import { NextRequest, NextResponse } from "next/server";
 
 /**
  * Validates that mutation requests (POST, PUT, DELETE, PATCH) originate
- * from the same site by checking the Origin or Referer header.
+ * from the same site by checking Origin, Referer, and Sec-Fetch-Site headers.
  * Returns null if valid, or a 403 response if the check fails.
  */
 export function checkCsrf(request: NextRequest): NextResponse | null {
   const method = request.method.toUpperCase();
   if (method === "GET" || method === "HEAD" || method === "OPTIONS") {
     return null;
+  }
+
+  // Sec-Fetch-Site is set by browsers and cannot be spoofed by JS.
+  // If present, use it as the primary CSRF check.
+  const secFetchSite = request.headers.get("sec-fetch-site");
+  if (secFetchSite) {
+    if (secFetchSite === "same-origin" || secFetchSite === "same-site" || secFetchSite === "none") {
+      return null;
+    }
+    // "cross-site" — block
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const origin = request.headers.get("origin");
@@ -19,7 +30,7 @@ export function checkCsrf(request: NextRequest): NextResponse | null {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  // Check Origin header first (most reliable)
+  // Check Origin header (most reliable after Sec-Fetch-Site)
   if (origin) {
     try {
       const originHost = new URL(origin).host;
@@ -41,7 +52,9 @@ export function checkCsrf(request: NextRequest): NextResponse | null {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  // No Origin or Referer — allow for non-browser clients (cURL, cron, etc.)
-  // Browsers always send Origin on cross-origin requests
+  // No Sec-Fetch-Site, no Origin, no Referer.
+  // Non-browser clients (cURL, cron) don't send these headers — allow.
+  // Browsers always send at least one of Sec-Fetch-Site or Origin on
+  // cross-origin requests, so this path is safe.
   return null;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,8 +7,19 @@ const clerkEnabled = !!clerkPk && clerkPk.startsWith("pk_");
 
 const clerk = clerkEnabled ? clerkMiddleware() : undefined;
 
+// Paths that require auth — fail-closed if Clerk is misconfigured
+const PROTECTED_PREFIXES = ["/api/bookmarks", "/api/topics", "/api/compare"];
+
 export default function middleware(request: NextRequest) {
   if (clerk) return clerk(request, {} as any);
+
+  // Fail-closed: block protected API routes when Clerk is not configured
+  const path = request.nextUrl.pathname;
+  if (PROTECTED_PREFIXES.some((p) => path.startsWith(p))) {
+    console.error("Clerk is not configured — blocking protected route:", path);
+    return NextResponse.json({ error: "Server misconfigured" }, { status: 500 });
+  }
+
   return NextResponse.next();
 }
 


### PR DESCRIPTION
## Summary

Second security audit found and fixed 8 additional vulnerabilities across API routes, middleware, and database configuration.

### High severity fixes
- **Timing-safe cron secret comparison** — replaced `!==` with `crypto.timingSafeEqual()` to prevent timing attacks on `CRON_SECRET`
- **Rate limit bypass prevention** — prefer `x-real-ip` over spoofable `x-forwarded-for`, added global 200/min ceiling regardless of IP
- **Stored XSS prevention** — new `lib/sanitize.ts` with `stripHtml()` and `sanitizeUrl()`, applied to Claude web search results before DB insertion
- **Full HTML sanitization on output** — `cleanSummary()` now strips all HTML tags (was only stripping `<cite>`), `cleanImageUrl()` validates URL scheme

### Medium severity fixes
- **CSRF hardening** — `Sec-Fetch-Site` header used as primary defense (browser-set, not JS-spoofable)
- **SSL/TLS enforcement** — `ssl: { rejectUnauthorized: true }` on non-localhost DB connections
- **Compare error sanitization** — no longer leaks backend `errorBody.detail` to client
- **Fail-closed middleware** — protected API routes (`/api/bookmarks`, `/api/topics`, `/api/compare`) return 500 when Clerk is unconfigured

### New files
- `lib/sanitize.ts` — HTML stripping and URL scheme validation utilities

## Test plan
- [x] All 55 tests pass (`npm test`)
- [x] No new TypeScript errors
- [ ] Verify cron endpoint rejects invalid Bearer tokens
- [ ] Verify `Sec-Fetch-Site: cross-site` requests are blocked on mutation endpoints
- [ ] Verify non-HTTPS image URLs return null from `cleanImageUrl()`
- [ ] Verify middleware blocks `/api/topics` when Clerk key is unset

Closes #34

