### PR TITLE
Add Content-Security-Policy header

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,24 @@ const nextConfig = {
     remotePatterns: [{ protocol: "https", hostname: "**" }],
   },
   async headers() {
+    const csp = [
+      "default-src 'self'",
+      // 'unsafe-inline' required for: theme init script (layout.tsx), Tailwind styles, Clerk UI
+      "script-src 'self' 'unsafe-inline' https://*.clerk.accounts.dev https://challenges.cloudflare.com",
+      "style-src 'self' 'unsafe-inline'",
+      // img-src: self + any HTTPS (news article images from 100+ sources)
+      "img-src 'self' https: data:",
+      // connect-src: API calls to self, Clerk, and server-side proxied services
+      "connect-src 'self' https://*.clerk.accounts.dev",
+      // Clerk auth iframes
+      "frame-src https://*.clerk.accounts.dev https://challenges.cloudflare.com",
+      "frame-ancestors 'none'",
+      "form-action 'self'",
+      "base-uri 'self'",
+      // Clerk uses web workers for session management
+      "worker-src 'self' blob:",
+    ].join("; ");
+
     return [
       {
         source: "/(.*)",
@@ -22,6 +40,10 @@ const nextConfig = {
           {
             key: "Permissions-Policy",
             value: "camera=(), microphone=(), geolocation=()",
+          },
+          {
+            key: "Content-Security-Policy",
+            value: csp,
           },
         ],
       },


### PR DESCRIPTION
## Summary

Adds Content-Security-Policy header — the last remaining security hardening item identified across 5 audit rounds.

### CSP Directives
- `default-src 'self'` — restrict all resources to same origin by default
- `script-src 'self' 'unsafe-inline'` — needed for theme init script in layout.tsx; Clerk auth domains whitelisted
- `style-src 'self' 'unsafe-inline'` — Tailwind CSS injects styles inline
- `img-src 'self' https: data:` — news article images from 100+ RSS sources
- `connect-src 'self'` — API calls to own backend; Clerk auth domains whitelisted
- `frame-src` — scoped to Clerk auth iframes and Cloudflare challenges
- `frame-ancestors 'none'` — prevents clickjacking (supplements X-Frame-Options: DENY)
- `form-action 'self'` — prevents form submissions to external domains
- `base-uri 'self'` — prevents base tag injection
- `worker-src 'self' blob:` — Clerk uses web workers for session management

### Note on `'unsafe-inline'`
Required because:
1. Theme initialization script uses `dangerouslySetInnerHTML` (hardcoded, not user-controlled)
2. Tailwind CSS generates inline styles
3. Clerk UI components inject inline styles

This is acceptable — all inline scripts/styles are application-controlled, never user-controlled. The XSS attack surface is already mitigated by `stripHtml()` sanitization on all external data.

## Test plan
- [x] All 73 tests pass
- [x] Coverage thresholds met
- [ ] Verify Clerk sign-in/sign-up flows work with CSP enabled
- [ ] Verify news article images load correctly
- [ ] Check browser console for CSP violation reports

