### PR TITLE
Fix Suspense fallback and stabilize URL state sync

### DIFF
--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -8,9 +8,42 @@ export const metadata: Metadata = {
     "AI-curated news summaries across technology, business, science, energy, world, and health.",
 };
 
+function NewsLoading() {
+  return (
+    <div
+      className="min-h-screen font-body"
+      style={{ background: "var(--bg)", color: "var(--text)" }}
+    >
+      <header
+        className="sticky top-0 z-50 border-b border-[var(--border)]"
+        style={{ background: "var(--nav-bg)", backdropFilter: "blur(20px)", WebkitBackdropFilter: "blur(20px)" }}
+      >
+        <div className="max-w-[1200px] mx-auto px-6 py-3.5 h-14" />
+      </header>
+      <main className="max-w-[1200px] mx-auto px-6 pt-7 pb-20">
+        <div className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-5">
+          {[0, 1, 2, 3, 4].map((i) => (
+            <div
+              key={i}
+              className={`bg-[var(--card-bg)] rounded-[14px] overflow-hidden border border-[var(--border)] ${i === 0 ? "col-span-full" : ""}`}
+            >
+              <div className={`bg-[var(--skeleton)] animate-shimmer ${i === 0 ? "h-[200px]" : "h-[140px]"}`} />
+              <div className="p-5 space-y-3">
+                <div className="h-3 w-[30%] bg-[var(--skeleton)] rounded-md animate-shimmer" />
+                <div className="h-4 w-[90%] bg-[var(--skeleton)] rounded-md animate-shimmer" />
+                <div className="h-4 w-[70%] bg-[var(--skeleton)] rounded-md animate-shimmer" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}
+
 export default function NewsPage() {
   return (
-    <Suspense>
+    <Suspense fallback={<NewsLoading />}>
       <NewsAggregator />
     </Suspense>
   );

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useSearchParams, useRouter } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useAuth } from "@clerk/nextjs";
 import { CATEGORIES, VALID_CATEGORIES, COMPARE_SOURCES, CATEGORY_COMPARE_DEFAULTS, DEFAULT_COMPARE_SOURCES, CUSTOM_TOPIC_COLORS } from "@/lib/constants";
 import { COPY } from "@/lib/copy";
@@ -30,19 +30,24 @@ function useClerkUserId(): string | null {
 
 // ─── Component ──────────────────────────────────────────
 
-export default function NewsAggregator() {
+// Read URL params once on mount (avoids re-reading on every render)
+function useInitialParams() {
   const searchParams = useSearchParams();
-  const router = useRouter();
+  const [initial] = useState(() => ({
+    category: (() => {
+      const param = searchParams.get("category");
+      return param && VALID_CATEGORIES.has(param as CategoryId) ? param as CategoryId : "top";
+    })(),
+    view: searchParams.get("view"),
+  }));
+  return initial;
+}
 
-  // Initialize state from URL params
-  const initialCategory = (() => {
-    const param = searchParams.get("category");
-    return param && VALID_CATEGORIES.has(param as CategoryId) ? param as CategoryId : "top";
-  })();
-  const initialView = searchParams.get("view");
+export default function NewsAggregator() {
+  const initialParams = useInitialParams();
 
-  const [activeCategory, setActiveCategory] = useState<CategoryId>(initialCategory);
-  const [showBookmarks, setShowBookmarks] = useState(initialView === "bookmarks");
+  const [activeCategory, setActiveCategory] = useState<CategoryId>(initialParams.category);
+  const [showBookmarks, setShowBookmarks] = useState(initialParams.view === "bookmarks");
   const [searchMode, setSearchMode] = useState(false);
   const [compareMode, setCompareMode] = useState(false);
   const [compareInputValue, setCompareInputValue] = useState("");
@@ -95,7 +100,7 @@ export default function NewsAggregator() {
     loadCategory(activeCategory);
   }, [activeCategory, loadCategory]);
 
-  // Sync state to URL
+  // Sync state to URL (shallow replace, no scroll)
   useEffect(() => {
     const params = new URLSearchParams();
     if (showBookmarks) {
@@ -103,9 +108,10 @@ export default function NewsAggregator() {
     } else if (activeCategory !== "top") {
       params.set("category", activeCategory);
     }
-    const newUrl = params.toString() ? `?${params.toString()}` : "/news";
-    router.replace(newUrl, { scroll: false });
-  }, [activeCategory, showBookmarks, router]);
+    const newUrl = params.toString() ? `/news?${params.toString()}` : "/news";
+    // Use history API directly to avoid triggering re-renders from router
+    window.history.replaceState(null, "", newUrl);
+  }, [activeCategory, showBookmarks]);
 
   // Category switch with fade-out/fade-in
   const switchCategory = useCallback((catId: CategoryId) => {


### PR DESCRIPTION
## Summary

Follow-up fix to PR #42. The Suspense boundary added for `useSearchParams` was missing a fallback, and the URL state sync could cause render loops.

- **Add skeleton fallback to Suspense** — Without a `fallback` prop, the page fails to render while `useSearchParams` resolves, causing "We hit a snag" error
- **Read URL params once on mount** — Wrap `searchParams.get()` in a `useState` initializer so initial state isn't re-computed on every render
- **Replace `router.replace()` with `history.replaceState()`** — Next.js `useRouter()` returns unstable references that trigger re-renders; direct History API avoids this
- **Remove unused `useRouter` import**

## Test plan
- [x] TypeScript compilation passes
- [x] All 73 tests pass (5/5 suites)
- [ ] Verify `/news` loads without "We hit a snag" error
- [ ] Verify `/news?category=technology` opens to Technology tab
- [ ] Verify `/news?view=bookmarks` opens bookmarks view
- [ ] Verify category switching updates URL without page reload

