### PR TITLE
Show sign-in prompt for unauthenticated Compare

### DIFF
--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -661,10 +661,17 @@ export default function NewsAggregator() {
 
             {/* Compare error */}
             {compareError && !compareLoading && (
-              <ErrorState
-                message={compareError}
-                onRetry={() => compareTopic && runCompare(compareTopic)}
-              />
+              compareError === "Unauthorized" ? (
+                <EmptyState
+                  title="Sign in to compare"
+                  body="Source comparison uses AI to cross-reference multiple outlets. Sign in to access this feature."
+                />
+              ) : (
+                <ErrorState
+                  message={compareError}
+                  onRetry={() => compareTopic && runCompare(compareTopic)}
+                />
+              )
             )}
 
             {/* Compare results */}


### PR DESCRIPTION
## Summary
- Compare requires authentication (rate-limited to 5/min per user)
- Previously showed generic "We hit a snag" error for unsigned users
- Now shows a clear "Sign in to compare" message explaining the feature requires auth

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] 73/73 tests pass

