### PR TITLE
Fix: add missing API key header to compare route

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -11,6 +11,7 @@ try {
 } catch {
   throw new Error(`Invalid SIFT_API_URL: ${SIFT_API_URL}`);
 }
+const SIFT_API_KEY = process.env.SIFT_API_KEY || "";
 const COMPARE_TIMEOUT_MS = 60_000;
 
 const compareSchema = z.object({
@@ -53,7 +54,10 @@ export async function POST(request: NextRequest) {
     try {
       const res = await fetch(`${SIFT_API_URL}/analyze/compare`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "X-Pipeline-Key": SIFT_API_KEY,
+        },
         body: JSON.stringify({
           topic: body.topic.trim(),
           sources: body.sources || undefined,


### PR DESCRIPTION
## Summary
- Compare route was calling sift-api `/analyze/compare` without the required `X-Pipeline-Key` header
- sift-api returned 422 ("Field required"), which the frontend showed as "Comparison service unavailable"
- Added `SIFT_API_KEY` env var and `X-Pipeline-Key` header to the fetch call

## Test plan
- [x] Verified compare endpoint works with the correct API key against production sift-api
- [x] `npx tsc --noEmit` clean
- [x] 73/73 tests pass

