### PR TITLE
Fix custom topics auth errors and add optimistic rollback

### DIFF
--- a/app/api/topics/generate/route.ts
+++ b/app/api/topics/generate/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: NextRequest) {
 
   const { userId } = await auth();
   if (!userId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json({ error: "Sign in to create custom topics" }, { status: 401 });
   }
 
   // Rate limit: 10 requests per minute per user

--- a/app/api/topics/route.ts
+++ b/app/api/topics/route.ts
@@ -24,7 +24,7 @@ const deleteTopicSchema = z.object({
 });
 
 function unauthorized() {
-  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  return NextResponse.json({ error: "Sign in to manage custom topics" }, { status: 401 });
 }
 
 // GET /api/topics — returns user's custom topics

--- a/components/TopicModal.tsx
+++ b/components/TopicModal.tsx
@@ -55,7 +55,10 @@ export default function TopicModal({ onClose, onAdd, existingTopics, colorIndex 
 
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || `HTTP ${res.status}`);
+        if (res.status === 401) {
+          throw new Error("Please sign in to create custom topics");
+        }
+        throw new Error(body.error || `Something went wrong (${res.status})`);
       }
 
       const data: TopicGenerateResponse = await res.json();

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -461,7 +461,16 @@ export function useCustomTopics(userId?: string | null) {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ topic }),
-        }).catch((err) => console.error("Topic save error:", err));
+        }).then((res) => {
+          if (!res.ok) {
+            // Rollback optimistic update on failure
+            setServerTopics((prev) => prev.filter((t) => t.id !== topic.id));
+            console.error("Topic save failed:", res.status);
+          }
+        }).catch((err) => {
+          setServerTopics((prev) => prev.filter((t) => t.id !== topic.id));
+          console.error("Topic save error:", err);
+        });
       } else {
         setLocalTopics((prev) => [...prev, topic]);
       }
@@ -472,17 +481,27 @@ export function useCustomTopics(userId?: string | null) {
   const remove = useCallback(
     (id: string) => {
       if (isSignedIn) {
+        const snapshot = serverTopics;
         setServerTopics((prev) => prev.filter((t) => t.id !== id));
         fetch("/api/topics", {
           method: "DELETE",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ id }),
-        }).catch((err) => console.error("Topic delete error:", err));
+        }).then((res) => {
+          if (!res.ok) {
+            // Rollback: restore the removed topic
+            setServerTopics(snapshot);
+            console.error("Topic delete failed:", res.status);
+          }
+        }).catch((err) => {
+          setServerTopics(snapshot);
+          console.error("Topic delete error:", err);
+        });
       } else {
         setLocalTopics((prev) => prev.filter((t) => t.id !== id));
       }
     },
-    [isSignedIn, setLocalTopics]
+    [isSignedIn, serverTopics, setLocalTopics]
   );
 
   return {


### PR DESCRIPTION
## Summary

- Replace cryptic "Unauthorized" API responses with actionable messages like "Sign in to create custom topics"
- Add optimistic update rollback in `useCustomTopics` hook — if the API call fails (401, network error, etc.), the UI reverts instead of silently keeping an unpersisted topic
- Add explicit 401 handling in `TopicModal` so users see a helpful message instead of the raw error string

## Test plan

- [ ] Sign out and attempt to create a custom topic — verify the error message says "Please sign in to create custom topics"
- [ ] Sign in with a valid session and create a custom topic — verify it persists across refresh
- [ ] Simulate a network failure (e.g. DevTools offline mode) while adding a topic — verify the topic disappears from the UI after the request fails
- [ ] Simulate a network failure while removing a topic — verify the topic reappears after the request fails

