### PR TITLE
Fix articles disappearing after exiting compare mode

### DIFF
--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -113,6 +113,19 @@ export default function NewsAggregator() {
     window.history.replaceState(null, "", newUrl);
   }, [activeCategory, showBookmarks]);
 
+  // Push a history entry when entering compare mode so browser back exits it
+  useEffect(() => {
+    if (!compareMode) return;
+    window.history.pushState({ compareMode: true }, "");
+    const handlePopState = (e: PopStateEvent) => {
+      if (compareMode) {
+        exitCompareMode();
+      }
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, [compareMode]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Category switch with fade-out/fade-in
   const switchCategory = useCallback((catId: CategoryId) => {
     if (catId === activeCategory && !activeCustomTopic) return;
@@ -216,7 +229,6 @@ export default function NewsAggregator() {
     setCompareMode(true);
     setShowBookmarks(false);
     setSearchMode(false);
-    clearTopicSearch();
     runCompare(topic, sources);
   };
 


### PR DESCRIPTION
## Summary
- **Preserved topic articles when entering compare mode**: `startCompare()` was calling `clearTopicSearch()`, which wiped `topicArticles` while `activeCustomTopic` remained set. Exiting compare then showed an empty "No stories yet" state. Removed the unnecessary clear since `setSearchMode(false)` already hides the search UI.
- **Added browser history support for compare mode**: Compare mode had no history entry, so pressing the browser back button navigated away from `/news` entirely. Added `pushState` on enter and a `popstate` listener that exits compare mode on back.

## Test plan
- [ ] Navigate to a custom topic tab, click "Compare coverage" on an article, then exit compare — verify articles are still visible
- [ ] Enter compare mode from a regular category tab, press browser back — verify it exits compare and shows articles instead of navigating away
- [ ] Verify compare mode still works end-to-end (enter topic, view results, close)
- [ ] Verify search mode and bookmarks still work after entering/exiting compare

