### PR TITLE
Add Anthropic API token usage + cost logging

### DIFF
--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -5,6 +5,7 @@ import { stableHash, estimateReadTime } from "@/lib/utils";
 import { stripHtml, sanitizeUrl } from "@/lib/sanitize";
 import type { Article, CategoryId } from "@/lib/types";
 import { rateLimit } from "@/lib/rate-limit";
+import { logUsage } from "@/lib/usage-tracker";
 
 const BAD_SUMMARIES = ["unable to provide summary"];
 
@@ -331,6 +332,7 @@ If you truly cannot find any articles, respond with an empty array: []`,
       },
     ],
   });
+  logUsage("news.topic.webSearchFallback", response, "claude-haiku-4-5");
 
   // Extract JSON from response — Claude may return multiple text blocks
   const textBlocks = response.content

--- a/app/api/topics/generate/route.ts
+++ b/app/api/topics/generate/route.ts
@@ -5,6 +5,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import type { TopicGenerateResponse } from "@/lib/types";
 import { rateLimit } from "@/lib/rate-limit";
 import { checkCsrf } from "@/lib/security";
+import { logUsage } from "@/lib/usage-tracker";
 
 const generateSchema = z.object({
   rawTopic: z.string().min(2).max(200),
@@ -72,6 +73,7 @@ Respond with ONLY valid JSON, no explanation:
         },
       ],
     });
+    logUsage("topics.generate", response, "claude-haiku-4-5");
 
     const textBlock = response.content.find((b) => b.type === "text");
     if (!textBlock || textBlock.type !== "text") {

--- a/lib/usage-tracker.ts
+++ b/lib/usage-tracker.ts
@@ -1,0 +1,97 @@
+// Token usage + cost logging for Anthropic API calls.
+// Emits a single structured JSON log line per call so costs can be
+// aggregated from server logs (Vercel log drains / console).
+
+// Claude Haiku 4.5 pricing (USD per 1M tokens)
+// Source: https://docs.anthropic.com/en/docs/about-claude/pricing
+const PRICE_INPUT_PER_M = 1.0;
+const PRICE_OUTPUT_PER_M = 5.0;
+const PRICE_CACHE_WRITE_5M_PER_M = 1.25;
+const PRICE_CACHE_READ_PER_M = 0.1;
+
+// Web search tool: $10 per 1,000 searches
+const PRICE_WEB_SEARCH_PER_CALL = 0.01;
+
+type MaybeUsage = {
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  cache_read_input_tokens?: number | null;
+  cache_creation_input_tokens?: number | null;
+} | null
+  | undefined;
+
+type MaybeMessage = {
+  usage?: MaybeUsage;
+  content?: Array<{ type: string; name?: string }>;
+};
+
+export interface UsageLog {
+  event: "api_usage";
+  operation: string;
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+  web_searches: number;
+  cost_usd: number;
+}
+
+/**
+ * Log token usage + estimated cost for an Anthropic Messages response.
+ * Swallows all errors so telemetry never breaks the request path.
+ */
+export function logUsage(
+  operation: string,
+  response: MaybeMessage,
+  model: string = "claude-haiku-4-5",
+  webSearches?: number,
+): UsageLog | null {
+  try {
+    const usage = response?.usage ?? null;
+    const inputTokens = usage?.input_tokens ?? 0;
+    const outputTokens = usage?.output_tokens ?? 0;
+    const cacheRead = usage?.cache_read_input_tokens ?? 0;
+    const cacheCreation = usage?.cache_creation_input_tokens ?? 0;
+    const searches = webSearches ?? countWebSearches(response);
+
+    const costUsd =
+      (inputTokens * PRICE_INPUT_PER_M) / 1_000_000 +
+      (outputTokens * PRICE_OUTPUT_PER_M) / 1_000_000 +
+      (cacheCreation * PRICE_CACHE_WRITE_5M_PER_M) / 1_000_000 +
+      (cacheRead * PRICE_CACHE_READ_PER_M) / 1_000_000 +
+      searches * PRICE_WEB_SEARCH_PER_CALL;
+
+    const payload: UsageLog = {
+      event: "api_usage",
+      operation,
+      model,
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      cache_read_input_tokens: cacheRead,
+      cache_creation_input_tokens: cacheCreation,
+      web_searches: searches,
+      cost_usd: Math.round(costUsd * 1_000_000) / 1_000_000,
+    };
+    console.log(JSON.stringify(payload));
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+/** Count `server_tool_use` blocks with name="web_search" in a Messages response. */
+export function countWebSearches(response: MaybeMessage): number {
+  try {
+    const content = response?.content ?? [];
+    let count = 0;
+    for (const block of content) {
+      if (block?.type === "server_tool_use" && block?.name === "web_search") {
+        count += 1;
+      }
+    }
+    return count;
+  } catch {
+    return 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `lib/usage-tracker.ts` utility that emits a structured JSON log line per Claude call with input/output/cache tokens, web-search count, and estimated cost (Haiku 4.5 pricing).
- Wires `logUsage(...)` into the two frontend Claude call sites: `topics.generate` and `news.topic.webSearchFallback`.
- Phase 1 of the cost-reduction plan — establishes a measurable baseline so upcoming changes (prompt caching, Batch API, terser outputs, dedup) can be validated from logs.
- No behavior change. Purely additive logging.

## Test plan
- [ ] Visual confirm TypeScript compiles (no new errors vs pre-existing `@vercel/speed-insights` type issue)
- [ ] After merge/deploy, hit `/api/topics/generate` once and confirm a JSON log line with `"event":"api_usage","operation":"topics.generate"` appears in Vercel logs
- [ ] Trigger a custom-topic web-search fallback and confirm `"operation":"news.topic.webSearchFallback"` line appears with `web_searches >= 1`
- [ ] Compare summed `cost_usd` from logs (24h) vs Anthropic console — should match within a few percent

🤖 Generated with [Claude Code](https://claude.com/claude-code)