### PR TITLE
Cut mobile LCP and JS shipped on first paint

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -60,7 +60,7 @@ html {
 }
 
 body {
-  font-family: "Source Sans 3", "Segoe UI", sans-serif;
+  font-family: var(--font-body), "Segoe UI", sans-serif;
   background: var(--bg);
   color: var(--text);
   -webkit-font-smoothing: antialiased;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,26 @@
 import type { Metadata } from "next";
 import { ClerkProvider } from "@clerk/nextjs";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import { Playfair_Display, Source_Sans_3 } from "next/font/google";
 import "./globals.css";
+
+// Self-hosted via next/font: Next downloads the woff2s at build time, serves
+// them from /_next/static/media (same-origin, cacheable, no CSP changes), and
+// auto-injects <link rel="preload"> for the primary weights. CSS variables
+// are wired into Tailwind (font-heading, font-body) and globals.css.
+const fontHeading = Playfair_Display({
+  subsets: ["latin"],
+  weight: ["400", "600", "700", "800", "900"],
+  display: "swap",
+  variable: "--font-heading",
+});
+
+const fontBody = Source_Sans_3({
+  subsets: ["latin"],
+  weight: ["300", "400", "500", "600", "700"],
+  display: "swap",
+  variable: "--font-body",
+});
 
 export const metadata: Metadata = {
   title: {
@@ -44,26 +63,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   const inner = (
-    <html lang="en" data-theme="dark" suppressHydrationWarning>
+    <html
+      lang="en"
+      data-theme="dark"
+      className={`${fontHeading.variable} ${fontBody.variable}`}
+      suppressHydrationWarning
+    >
       <head>
-        <link
-          rel="preconnect"
-          href="https://fonts.googleapis.com"
-        />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
-        <link
-          rel="preload"
-          as="style"
-          href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700;800;900&family=Source+Sans+3:wght@300;400;500;600;700&display=swap"
-        />
-        <link
-          rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700;800;900&family=Source+Sans+3:wght@300;400;500;600;700&display=swap"
-        />
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body>

--- a/components/CardImage.tsx
+++ b/components/CardImage.tsx
@@ -29,6 +29,9 @@ export default function CardImage({ src, alt, featured }: CardImageProps) {
         alt={alt || ""}
         fill
         sizes={featured ? "(max-width: 768px) 100vw, 50vw" : "(max-width: 640px) 100vw, 340px"}
+        // The featured (index-0) card image is the LCP element on /news.
+        // priority adds fetchpriority="high", loading="eager", and a <link rel="preload">.
+        priority={featured}
         referrerPolicy="no-referrer"
         onLoad={() => setStatus("loaded")}
         onError={() => setStatus("error")}

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useAuth } from "@clerk/nextjs";
+import dynamic from "next/dynamic";
 import { CATEGORIES, VALID_CATEGORIES, COMPARE_SOURCES, CATEGORY_COMPARE_DEFAULTS, DEFAULT_COMPARE_SOURCES, CUSTOM_TOPIC_COLORS } from "@/lib/constants";
 import { COPY } from "@/lib/copy";
 import { timeAgo } from "@/lib/utils";
@@ -12,12 +13,16 @@ import StoryCard from "./StoryCard";
 import SkeletonCard from "./SkeletonCard";
 import EmptyState from "./EmptyState";
 import ErrorState from "./ErrorState";
-import TopicSearch from "./TopicSearch";
-import TopicModal from "./TopicModal";
-import CompareView from "./CompareView";
 import SiftLogo from "./SiftLogo";
 import AuthButtons, { clerkEnabled } from "./AuthButtons";
 import type { Article, CustomTopic, FeedItem, CategoryId } from "@/lib/types";
+
+// Code-split: these surfaces only render on user intent (Cmd+K search,
+// "+" topic-create, async compare response). Deferring their JS shaves
+// ~240 KiB of unused-on-first-paint bundle from Lighthouse.
+const TopicSearch = dynamic(() => import("./TopicSearch"), { ssr: false });
+const TopicModal = dynamic(() => import("./TopicModal"), { ssr: false });
+const CompareView = dynamic(() => import("./CompareView"), { ssr: false });
 
 // ─── Clerk user ID (safe when ClerkProvider absent) ─────
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,8 +10,9 @@ const config: Config = {
   theme: {
     extend: {
       fontFamily: {
-        heading: ["Playfair Display", "Georgia", "Times New Roman", "serif"],
-        body: ["Source Sans 3", "Segoe UI", "sans-serif"],
+        // CSS variables are injected by next/font in app/layout.tsx.
+        heading: ["var(--font-heading)", "Georgia", "Times New Roman", "serif"],
+        body: ["var(--font-body)", "Segoe UI", "sans-serif"],
       },
       colors: {
         sift: {


### PR DESCRIPTION
## Summary

Three perf-only changes targeting the items 1, 15, and 16 of the Track-B audit findings. No visual or behavioral changes; same fonts, same layout, same modals — just shipped differently.

## Baseline (Lighthouse, 2026-04)

| Run            | Perf  | LCP   | TBT  | CLS | Unused JS |
| -------------- | ----- | ----- | ---- | --- | --------- |
| /news mobile   | **69** | **5.8s** | 50ms | 0   | **239 KiB** |
| /news desktop  | 95    | 1.3s  | 0ms  | 0   | 238 KiB   |
| / mobile       | **75** | **5.3s** | 10ms | 0   | 240 KiB   |

CLS=0 confirms the pre-hydration theme script is fine. The mobile LCP problem is the ask.

## Changes

### 1. Featured story image: \`priority={featured}\`
Lighthouse called the index-0 Top Story \`<img>\` the LCP element on /news and flagged \`loading="lazy"\` (Next.js default for \`fill\` without \`priority\`). The \`featured\` prop already encodes "first card and not in bookmarks/search/topic mode" via \`NewsAggregator.tsx\`, so passing it straight to \`priority\` is the minimal fix — no new prop, no index threading.

\`priority\` adds \`fetchpriority="high"\`, \`loading="eager"\`, and a \`<link rel="preload">\` for the resource.

### 2. Modal code-split via \`next/dynamic\`
\`TopicSearch\`, \`TopicModal\`, and \`CompareView\` only render on user intent (Cmd+K, "+" button, async compare response). Static imports were shipping all three on first paint. Deferring them via \`dynamic(..., { ssr: false })\` trims the unused-JS surface Lighthouse called out.

### 3. \`next/font/google\` for Playfair Display + Source Sans 3
Previously loaded via Google Fonts CDN \`<link>\` tags. \`next/font\` self-hosts the woff2s at build time under \`/_next/static/media\` — same-origin, cacheable, no extra DNS/handshake — auto-injects \`<link rel="preload">\` for the primary weights, and generates size-adjust fallback metrics that keep CLS at 0. Wired through CSS variables (\`--font-heading\`, \`--font-body\`) into Tailwind and \`globals.css\` so existing \`font-heading\` utility classes keep working unchanged.

CSP unchanged — self-hosted fonts already covered by \`font-src 'self'\`. The \`fonts.googleapis.com\` / \`fonts.gstatic.com\` allowlist entries are now dead but harmless; they can be removed in a follow-up cleanup.

## Files

- \`app/layout.tsx\` — next/font setup, removed Google Fonts \`<link>\` tags
- \`tailwind.config.ts\` — \`fontFamily.heading\`/\`body\` → CSS variables
- \`app/globals.css\` — \`body\` font-family → CSS variable
- \`components/CardImage.tsx\` — \`priority={featured}\` on the \`Image\`
- \`components/NewsAggregator.tsx\` — three static imports → \`dynamic\`

## Test plan

- [x] \`npm run build\` clean (existing \`ml-[calc(...)]\` tailwind warning is preexisting, unrelated)
- [x] \`npm test\` — 73/73 pass
- [ ] After Vercel deploys this branch, re-run Lighthouse against the preview URL for /news mobile + / mobile
- [ ] Confirm /news mobile Perf ≥ 90, LCP ≤ 2.5s
- [ ] Smoke-test all three deferred modals: Cmd+K search, "+" topic creation, "Compare coverage" on a story card
- [ ] Visual parity: typography should look identical — same family, same weights

## Out of scope (later PRs in the audit plan)

- PR 2: mobile/responsive correctness (header overflow on 390, bookmark badge, category pill scroll)
- PR 3: a11y baseline (skip-link target, aria-labels, modal focus trap)
- PR 4: design-system seed (Button/IconButton/Badge primitives)
- PR 5: craft polish (hero text-wrap balance, card-grid normalization, theme transition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)