### PR TITLE
Fix theme-color so light-theme users get matching browser chrome

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { ClerkProvider } from "@clerk/nextjs";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Playfair_Display, Source_Sans_3 } from "next/font/google";
@@ -44,10 +44,18 @@ export const metadata: Metadata = {
     description:
       "AI-curated news summaries from 100+ sources. Get the key points in 60 seconds.",
   },
-  other: {
-    "theme-color": "#0c0a09",
-    "color-scheme": "dark light",
-  },
+};
+
+// Browser chrome (iOS Safari address bar, Android task switcher) follows the OS
+// color-scheme preference, not the user's in-app theme toggle. Late Edition
+// background for dark; Newsprint background for light. Matches the CSS
+// variables in app/globals.css.
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#f5f2ed" },
+    { media: "(prefers-color-scheme: dark)", color: "#0c0a09" },
+  ],
+  colorScheme: "dark light",
 };
 
 const clerkPk = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;


### PR DESCRIPTION
## Summary

- Replace dark-only `theme-color` meta tag with two media-scoped values via Next 15's `viewport` export.
- Light: `#f5f2ed` (Newsprint `--bg`). Dark: `#0c0a09` (Late Edition `--bg`).
- `color-scheme` moves from `metadata.other` to `viewport.colorScheme`.

## Why

iOS Safari address bar, Android task-switcher chrome, and any UA reading `<meta name=\"theme-color\">` was hardcoded dark — visually inconsistent with the page for any user on the light palette (whether by OS preference or in-app toggle).

The page palette follows the user's in-app toggle (`localStorage[\"sift-theme\"]`); browser chrome follows OS `prefers-color-scheme`. These are distinct contexts and the meta tag governs the latter, so OS preference is the right signal.

## Test plan
- [x] `npm run build` clean
- [x] 73/73 tests pass
- [ ] After deploy: view-source on `/` shows two `<meta name=\"theme-color\">` tags with `media` attributes
- [ ] iOS Safari light-mode device: address bar matches `#f5f2ed`
- [ ] iOS Safari dark-mode device: address bar matches `#0c0a09`
- [ ] Android Chrome task-switcher snapshot follows OS preference

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)