### PR TITLE
Fix mobile/responsive correctness on /news (Track-B PR 2)

### DIFF
--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -18,10 +18,10 @@ function NewsLoading() {
         className="sticky top-0 z-50 border-b border-[var(--border)]"
         style={{ background: "var(--nav-bg)", backdropFilter: "blur(20px)", WebkitBackdropFilter: "blur(20px)" }}
       >
-        <div className="max-w-[1200px] mx-auto px-6 py-3.5 h-14" />
+        <div className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-10 py-3.5 h-14" />
       </header>
-      <main className="max-w-[1200px] mx-auto px-6 pt-7 pb-20">
-        <div className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-5">
+      <main className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-10 pt-7 pb-20">
+        <div className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4 sm:gap-5">
           {[0, 1, 2, 3, 4].map((i) => (
             <div
               key={i}

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -169,12 +169,17 @@ export default function ArticleCard({
           )}
         </h3>
 
-        {/* Summary */}
+        {/* Summary — clamp to fixed line count so card heights converge across
+            the auto-fill grid (StoryCard.tsx already does the same). */}
         <p
           className="text-[var(--text-secondary)] leading-relaxed"
           style={{
             fontSize: featured ? 15 : 13.5,
             flex: 1,
+            display: "-webkit-box",
+            WebkitLineClamp: featured ? 5 : 4,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
           }}
         >
           {article.summary}

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -324,29 +324,30 @@ export default function NewsAggregator() {
           WebkitBackdropFilter: "blur(20px) saturate(180%)",
         }}
       >
-        <div className="max-w-[1200px] mx-auto px-6 py-3.5 flex items-center justify-between">
+        <div className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-10 py-3.5 flex items-center justify-between">
           <div
             className="flex items-baseline gap-3 cursor-pointer"
             onClick={() => { setShowBookmarks(false); setSearchMode(false); clearTopicSearch(); exitCompareMode(); setActiveCustomTopic(null); setActiveCategory("top"); }}
           >
             <SiftLogo variant="full" size={28} />
-            <span className="text-[10px] font-bold tracking-widest uppercase text-[var(--accent)] opacity-80">
+            {/* Tagline hides under sm — at 390px the right cluster needs the space. */}
+            <span className="hidden sm:inline text-[10px] font-bold tracking-widest uppercase text-[var(--accent)] opacity-80">
               {COPY.header.tagline}
             </span>
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5 sm:gap-2">
             <button
               onClick={() => { setShowBookmarks(!showBookmarks); setSearchMode(false); clearTopicSearch(); exitCompareMode(); }}
-              aria-label="Bookmarks"
-              className="flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-sm font-semibold cursor-pointer transition-all duration-200 font-body"
+              aria-label={bookmarkCount > 0 ? `Bookmarks (${bookmarkCount})` : "Bookmarks"}
+              className="flex items-center gap-1.5 h-9 px-2.5 sm:px-3.5 rounded-full text-sm font-semibold cursor-pointer transition-all duration-200 font-body"
               style={{
                 background: showBookmarks ? "var(--accent)" : "transparent",
                 border: `1px solid ${showBookmarks ? "var(--accent)" : "var(--border)"}`,
                 color: showBookmarks ? "#fff" : "var(--text-secondary)",
               }}
             >
-              ★ {bookmarkCount}
+              {bookmarkCount > 0 ? `★ ${bookmarkCount}` : "★"}
             </button>
 
             <button
@@ -423,10 +424,12 @@ export default function NewsAggregator() {
         {/* Category pills with sliding indicator */}
         {!showBookmarks && !searchMode && !compareMode && (
           <div className="max-w-[1200px] mx-auto relative">
-            {/* Scroll fade indicators for mobile */}
-            <div className="absolute left-0 top-0 bottom-0 w-6 z-10 pointer-events-none bg-gradient-to-r from-[var(--nav-bg)] to-transparent md:hidden" />
-            <div className="absolute right-0 top-0 bottom-0 w-6 z-10 pointer-events-none bg-gradient-to-l from-[var(--nav-bg)] to-transparent md:hidden" />
-          <div ref={pillContainerRef} className="px-6 pb-3 flex gap-1.5 overflow-x-auto relative scrollbar-none" style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}>
+            {/* Scroll fade indicators for mobile. --nav-bg is rgba(...,0.92) so a
+                gradient from that color is barely visible over the pills. Use the
+                solid --bg color so the fade is unmistakable. */}
+            <div className="absolute left-0 top-0 bottom-0 w-8 z-10 pointer-events-none bg-gradient-to-r from-[var(--bg)] to-transparent md:hidden" />
+            <div className="absolute right-0 top-0 bottom-0 w-8 z-10 pointer-events-none bg-gradient-to-l from-[var(--bg)] to-transparent md:hidden" />
+          <div ref={pillContainerRef} className="px-4 sm:px-6 lg:px-10 pb-3 flex gap-1.5 overflow-x-auto relative scrollbar-none" style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}>
             {CATEGORIES.map((cat) => {
               const active = activeCategory === cat.id && !activeCustomTopic;
               return (
@@ -542,7 +545,7 @@ export default function NewsAggregator() {
 
         {/* Compare input bar */}
         {compareMode && !compareComparison && !compareLoading && (
-          <div className="max-w-[1200px] mx-auto px-6 pb-3">
+          <div className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-10 pb-3">
             <form
               onSubmit={(e) => {
                 e.preventDefault();
@@ -645,7 +648,7 @@ export default function NewsAggregator() {
       </div>
 
       {/* ── Main ────────────────────────────────────── */}
-      <main className="max-w-[1200px] mx-auto px-6 pt-7 pb-20">
+      <main className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-10 pt-7 pb-20">
         {/* Compare mode */}
         {compareMode ? (
           <>
@@ -737,7 +740,7 @@ export default function NewsAggregator() {
             {/* Loading skeleton */}
             {(((searchMode || customTopicMode) ? topicLoading : loading) && !hasData && !((searchMode || customTopicMode) ? topicError : error)) && (
               <div>
-                <div className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-5">
+                <div className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4 sm:gap-5">
                   <SkeletonCard featured />
                   {[1, 2, 3, 4].map((i) => (
                     <SkeletonCard key={i} hasImage={i % 2 === 0} />
@@ -769,7 +772,7 @@ export default function NewsAggregator() {
 
             {/* Bookmarks loading */}
             {showBookmarks && loadingBookmarks && !hasData && (
-              <div className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-5">
+              <div className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4 sm:gap-5">
                 {[1, 2, 3].map((i) => (
                   <SkeletonCard key={i} />
                 ))}
@@ -804,7 +807,7 @@ export default function NewsAggregator() {
             {/* Feed grid — fades on category switch */}
             {hasData && (
               <div
-                className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-5"
+                className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4 sm:gap-5"
                 style={{
                   transition: "opacity 0.12s ease-out, transform 0.12s ease-out",
                   opacity: categoryFading ? 0 : 1,


### PR DESCRIPTION
## Summary

Five narrow audit fixes, all in existing components — no architecture change. Diff is +27 / -19 across 3 files.

| Item | Fix |
| --- | --- |
| 22 — gutter | \`px-6\` → \`px-4 sm:px-6 lg:px-10\` (16/24/40 px). Header, pill row, compare bar, main, SSR skeleton. |
| 2 — header overflow | Tagline hides under \`sm\`; right cluster gap goes \`gap-1.5 sm:gap-2\`. Right cluster now fits at 390 px. |
| 5 — bookmark badge | Add \`h-9\` (matches sibling icon buttons), drop padding to \`px-2.5\` on mobile, hide count when zero. \`aria-label\` reflects count. |
| 7 — pill scroll fade | Gradients used \`--nav-bg\` (rgba 0.92) — invisible over pills. Switch to solid \`--bg\`, widen \`w-6\` → \`w-8\`. |
| 9 — grid jitter + bonus | \`ArticleCard\` summary now has \`WebkitLineClamp\` 4/5 (matching StoryCard). Mobile grid gap goes \`gap-4 sm:gap-5\`. |

## Why these specific fixes

- **Audit screenshots** showed the right cluster clipping on 390 px (\`dark_390_02-news-fold0\`) and the pill row's \"more pills exist\" cue being invisible because the fade was the same translucent color as the nav.
- **Bookmark tap target** was \`py-1.5\` (~33 px tall) — below the 36 px floor the sibling icon buttons hold. Adding \`h-9\` makes the cluster visually consistent and bumps tap target.
- **Grid jitter** root cause was a missing line-clamp on ArticleCard's summary (StoryCard already had one). Auto-fill grid rows align to the tallest item; capping summary at 4 lines gets card heights to converge without restructuring.

## Test plan

- [x] \`npm run build\` clean. /news bundle: 14.0 kB → 14.1 kB (+0.1 kB, just className strings).
- [x] 73/73 tests pass.
- [ ] After deploy, visual checks at 390 / 768 / 1440:
  - Header right cluster fits on 390 with no clipping
  - Bookmark pill aligns with adjacent icon buttons (same height)
  - Pill row left/right fades visibly indicate scrollability on mobile
  - Feed grid: card heights converge, no row-height jitter on /news
  - Gutters: ~16 px on mobile, ~24 px tablet, ~40 px desktop
- [ ] iOS Safari + Android Chrome smoke: Cmd+K opens search, ★ toggles bookmark, theme toggle, refresh, compare — all still work.

## Out of scope (deferred to PR 3/4/5)

- A11y attributes on icon-only buttons (#58)
- Scroll-snap on the pill row (would conflict with the existing sliding indicator animation)
- Featured-card visual tightening (#60 item 8)

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)