### PR TITLE
a11y: skip-link target + TopicModal focus trap

### DIFF
--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -20,7 +20,7 @@ function NewsLoading() {
       >
         <div className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-10 py-3.5 h-14" />
       </header>
-      <main className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-10 pt-7 pb-20">
+      <main id="main-content" className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-10 pt-7 pb-20">
         <div className="grid grid-cols-1 sm:grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4 sm:gap-5">
           {[0, 1, 2, 3, 4].map((i) => (
             <div

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -8,7 +8,8 @@ export const metadata: Metadata = {
 
 export default function NotFound() {
   return (
-    <div
+    <main
+      id="main-content"
       className="min-h-screen flex items-center justify-center px-5"
       style={{ background: "var(--bg)", color: "var(--text)" }}
     >
@@ -32,6 +33,6 @@ export default function NotFound() {
           {COPY.notFound.button}
         </Link>
       </div>
-    </div>
+    </main>
   );
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -7,7 +7,8 @@ export const metadata: Metadata = {
 
 export default function PrivacyPage() {
   return (
-    <div
+    <main
+      id="main-content"
       className="min-h-screen px-6 py-16"
       style={{ background: "var(--bg)", color: "var(--text)" }}
     >
@@ -61,6 +62,6 @@ export default function PrivacyPage() {
           Last updated: April 2026
         </p>
       </div>
-    </div>
+    </main>
   );
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -7,7 +7,8 @@ export const metadata: Metadata = {
 
 export default function TermsPage() {
   return (
-    <div
+    <main
+      id="main-content"
       className="min-h-screen px-6 py-16"
       style={{ background: "var(--bg)", color: "var(--text)" }}
     >
@@ -61,6 +62,6 @@ export default function TermsPage() {
           Last updated: April 2026
         </p>
       </div>
-    </div>
+    </main>
   );
 }

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -99,7 +99,6 @@ export default function LandingPage() {
 
   return (
     <div
-      id="main-content"
       style={{
         background: "var(--bg)",
         color: "var(--text)",
@@ -150,6 +149,7 @@ export default function LandingPage() {
         </div>
       </nav>
 
+      <main id="main-content">
       {/* ── Hero ──────────────────────────────────── */}
       <section className="max-w-[1200px] mx-auto px-6 pt-24 pb-20 text-center">
         <h1 className="font-heading text-[clamp(36px,6vw,60px)] font-bold leading-[1.1] tracking-tight text-[var(--text)] mb-6">
@@ -340,6 +340,7 @@ export default function LandingPage() {
           Start Reading &rarr;
         </Link>
       </section>
+      </main>
 
       {/* ── Footer ────────────────────────────────── */}
       <footer className="border-t border-[var(--border)] py-10 px-6 max-w-[1200px] mx-auto">

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -648,7 +648,7 @@ export default function NewsAggregator() {
       </div>
 
       {/* ── Main ────────────────────────────────────── */}
-      <main className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-10 pt-7 pb-20">
+      <main id="main-content" className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-10 pt-7 pb-20">
         {/* Compare mode */}
         {compareMode ? (
           <>

--- a/components/TopicModal.tsx
+++ b/components/TopicModal.tsx
@@ -20,6 +20,7 @@ export default function TopicModal({ onClose, onAdd, existingTopics, colorIndex 
   const [preview, setPreview] = useState<TopicGenerateResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   const color = CUSTOM_TOPIC_COLORS[colorIndex % CUSTOM_TOPIC_COLORS.length];
 
@@ -27,10 +28,39 @@ export default function TopicModal({ onClose, onAdd, existingTopics, colorIndex 
     inputRef.current?.focus();
   }, []);
 
-  // Close on Escape
+  // Restore focus to whoever opened the modal when it unmounts.
+  useEffect(() => {
+    const opener = document.activeElement as HTMLElement | null;
+    return () => {
+      // Guard against the opener being unmounted (e.g. the "+" button hides
+      // when the topic limit is reached after the new topic is added).
+      if (opener && document.contains(opener)) opener.focus();
+    };
+  }, []);
+
+  // Escape closes; Tab/Shift+Tab cycles within the dialog so focus can't leak
+  // into the muted background page.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab" || !dialogRef.current) return;
+      const focusables = dialogRef.current.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
@@ -95,6 +125,7 @@ export default function TopicModal({ onClose, onAdd, existingTopics, colorIndex 
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
       <div
+        ref={dialogRef}
         className="w-full max-w-[460px] rounded-2xl border border-[var(--border)] overflow-hidden animate-fade-slide-in"
         style={{ background: "var(--card-bg)" }}
       >


### PR DESCRIPTION
## Summary
- **Skip-link target (#58 item 3)**: the "Skip to content" link in `app/layout.tsx` pointed at `#main-content` but the anchor only existed on the landing page — and there it wrapped the nav, so the skip didn't actually skip. Added `id="main-content"` to news (`<main>` + SSR skeleton), privacy, terms, and 404; rewrapped landing-page content sections inside `<main id="main-content">` so the skip now bypasses the nav.
- **Focus trap on TopicModal (#58 item 14)**: dialog already had `role`/`aria-modal`/`aria-labelledby`/Escape-close. Added Tab/Shift+Tab cycling within the dialog, and focus restoration to the opener on unmount (guarded against the opener being removed — the "+" pill hides at the topic limit after a successful add).
- **Aria-labels (#58 item 4)**: audit was a no-op. Every icon-only button in the header, modals, search, and compare view already has an aria-label. TopicSearch is an inline form (not a modal), so no focus trap needed.

Closes #58.

## Test plan
- [x] `npm run build` clean (no new warnings; bundle delta on /news is 0)
- [x] `npm test` — 73/73 passing
- [ ] Manual: keyboard-tab from address bar reveals "Skip to content" → activates → focus lands inside `<main>` past the header on `/`, `/news`, `/privacy`, `/terms`, and the 404
- [ ] Manual: open the "+" topic modal, Tab cycles through close/input/submit and wraps; Shift+Tab wraps backward; Escape closes; focus returns to the "+" button (or to body if "+" was hidden by hitting the topic limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)