### PR TITLE
feat(StoryCard): craft polish on expanded multi-source moment

### DIFF
--- a/__tests__/copy.test.ts
+++ b/__tests__/copy.test.ts
@@ -27,6 +27,46 @@ describe("COPY strings", () => {
     });
   });
 
+  describe("stories.framing", () => {
+    it("returns singular phrasing for 1 outlet", () => {
+      expect(COPY.stories.framing(1)).toBe("How one outlet framed it");
+    });
+
+    it("uses 'framed it' phrasing for small groups (≤3)", () => {
+      expect(COPY.stories.framing(2)).toBe("How 2 outlets framed it");
+      expect(COPY.stories.framing(3)).toBe("How 3 outlets framed it");
+    });
+
+    it("uses 'covered this' phrasing for larger groups (>3)", () => {
+      expect(COPY.stories.framing(4)).toBe("How 4 outlets covered this");
+      expect(COPY.stories.framing(14)).toBe("How 14 outlets covered this");
+    });
+  });
+
+  describe("stories.expandedMeta", () => {
+    it("returns singular for 1 source", () => {
+      expect(COPY.stories.expandedMeta("12 min ago", 1)).toBe(
+        "Updated 12 min ago · 1 source"
+      );
+    });
+
+    it("returns plural for multiple sources", () => {
+      expect(COPY.stories.expandedMeta("just now", 14)).toBe(
+        "Updated just now · 14 sources"
+      );
+    });
+  });
+
+  describe("stories.toneLabels", () => {
+    it("provides editorial labels for every framing tone", () => {
+      expect(COPY.stories.toneLabels.neutral).toBe("Straight");
+      expect(COPY.stories.toneLabels.urgent).toBe("Pressing");
+      expect(COPY.stories.toneLabels.analytical).toBe("Deep read");
+      expect(COPY.stories.toneLabels.critical).toBe("Skeptical");
+      expect(COPY.stories.toneLabels.optimistic).toBe("Hopeful");
+    });
+  });
+
   describe("static strings", () => {
     it("has header tagline", () => {
       expect(COPY.header.tagline).toBeTruthy();

--- a/app/globals.css
+++ b/app/globals.css
@@ -20,13 +20,28 @@ html[data-theme="dark"] {
   --text-secondary: #a8a29e;
   --text-muted: #78716c;
   --border: #292524;
-  --shadow: rgba(0, 0, 0, 0.4);
-  --shadow-hover: rgba(0, 0, 0, 0.6);
+  --border-subtle: rgba(41, 37, 36, 0.4);
+  --shadow-low: rgba(0, 0, 0, 0.18);
+  --shadow-mid: rgba(0, 0, 0, 0.4);
+  --shadow-high: rgba(0, 0, 0, 0.62);
+  --shadow: var(--shadow-mid);
+  --shadow-hover: var(--shadow-high);
+  --well-bg: linear-gradient(180deg, rgba(0, 0, 0, 0.18) 0%, transparent 8px), var(--bg);
+  --highlight-color: rgba(255, 255, 255, 0.025);
+  --highlight-blend: screen;
   --skeleton: #292524;
   --accent: #818cf8;
   --nav-bg: rgba(12, 10, 9, 0.92);
   --pill-active: #818cf8;
   --pill-text: #f5f5f4;
+
+  /* Motion tokens — used across rows, badges, disclosures */
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-snap: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --dur-fast: 120ms;
+  --dur-base: 240ms;
+  --dur-slow: 400ms;
 }
 
 /* Newsprint */
@@ -37,8 +52,15 @@ html[data-theme="light"] {
   --text-secondary: #57534e;
   --text-muted: #8a8380;
   --border: #e7e5e4;
-  --shadow: rgba(0, 0, 0, 0.06);
-  --shadow-hover: rgba(0, 0, 0, 0.12);
+  --border-subtle: rgba(231, 229, 228, 0.6);
+  --shadow-low: rgba(0, 0, 0, 0.04);
+  --shadow-mid: rgba(0, 0, 0, 0.06);
+  --shadow-high: rgba(0, 0, 0, 0.14);
+  --shadow: var(--shadow-mid);
+  --shadow-hover: var(--shadow-high);
+  --well-bg: linear-gradient(180deg, rgba(0, 0, 0, 0.04) 0%, transparent 8px), var(--bg);
+  --highlight-color: rgba(0, 0, 0, 0.025);
+  --highlight-blend: multiply;
   --skeleton: #e7e5e4;
   --accent: #4338ca;
   --nav-bg: rgba(245, 242, 237, 0.92);
@@ -157,10 +179,117 @@ article,
   100% { transform: rotate(360deg) scale(1); opacity: 0.5; }
 }
 
-/* ─── Story Expand Animation ──────────────────────────── */
-@keyframes story-expand {
-  from { max-height: 0; opacity: 0; transform: translateY(-8px); }
-  to   { max-height: 500px; opacity: 1; transform: translateY(0); }
+/* ─── Story Disclosure Animations ─────────────────────── */
+/* Per-row reveal used inside the grid-template-rows disclosure.
+   Capped stagger keeps long lists (16+ rows) from dragging. */
+@keyframes row-reveal {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* One-shot tone-badge breathe, runs once on initial reveal. */
+@keyframes tone-breathe {
+  0%   { transform: scale(1); }
+  30%  { transform: scale(1.04); }
+  100% { transform: scale(1); }
+}
+
+/* ─── Story Row Affordances ───────────────────────────── */
+/* Used by both framing rows and article rows in the expanded
+   StoryCard. Hover/focus reveals an accent rail, shifts the
+   source-name 2px right, and fades in the trailing CTA. */
+.story-row {
+  position: relative;
+  padding-left: 14px;
+}
+.story-row__rail {
+  position: absolute;
+  left: 0;
+  top: 8px;
+  bottom: 8px;
+  width: 1px;
+  background: var(--accent);
+  opacity: 0;
+  transform: scaleY(0.4);
+  transform-origin: center;
+  transition:
+    opacity var(--dur-base) var(--ease-out-expo),
+    width var(--dur-base) var(--ease-out-expo),
+    transform var(--dur-base) var(--ease-out-expo);
+  pointer-events: none;
+}
+.story-row:hover .story-row__rail,
+.story-row:focus-within .story-row__rail {
+  opacity: 0.9;
+  width: 2px;
+  transform: scaleY(1);
+}
+.story-row__source {
+  transition: transform var(--dur-base) var(--ease-out-expo);
+}
+.story-row:hover .story-row__source,
+.story-row:focus-within .story-row__source {
+  transform: translateX(2px);
+}
+.story-row__cta {
+  opacity: 0;
+  transform: translateX(-4px);
+  transition:
+    opacity var(--dur-base) var(--ease-out-expo) 40ms,
+    transform var(--dur-base) var(--ease-out-expo) 40ms;
+}
+.story-row:hover .story-row__cta,
+.story-row:focus-within .story-row__cta {
+  opacity: 1;
+  transform: translateX(0);
+}
+.story-row:active {
+  transform: scale(0.99);
+  transition: transform 80ms var(--ease-snap);
+}
+/* Tone-color gutter — lives at row left edge, semantic content. */
+.story-row__tone-gutter {
+  position: absolute;
+  left: 0;
+  top: 6px;
+  bottom: 6px;
+  width: 2px;
+  opacity: 0.7;
+  pointer-events: none;
+  border-radius: 1px;
+}
+
+/* ─── Story Light-Source Highlight ────────────────────── */
+/* 2.5% radial — sits well below banding threshold. Inverts under
+   Newsprint via the theme override below. */
+.story-highlight {
+  background: radial-gradient(
+    ellipse 60% 100% at 50% 0%,
+    rgba(255, 255, 255, 0.025) 0%,
+    transparent 70%
+  );
+  mix-blend-mode: screen;
+}
+html[data-theme="light"] .story-highlight {
+  background: radial-gradient(
+    ellipse 60% 100% at 50% 0%,
+    rgba(0, 0, 0, 0.025) 0%,
+    transparent 70%
+  );
+  mix-blend-mode: multiply;
+}
+
+/* ─── Story Expand Button + Chevron ───────────────────── */
+.story-expand-btn:active {
+  transform: scale(0.99);
+  transition: transform 80ms var(--ease-snap);
+}
+.story-chevron {
+  display: inline-block;
+  transition: transform var(--dur-base) var(--ease-out-expo);
+}
+.story-chevron[data-expanded="true"] {
+  transform: rotate(180deg);
 }
 
 /* ─── Category Fade Transition ────────────────────────── */

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -57,7 +57,8 @@ export default function ArticleCard({
       `}
       style={{
         position: "relative",
-        transition: "transform 0.4s cubic-bezier(0.16,1,0.3,1), box-shadow 0.4s cubic-bezier(0.16,1,0.3,1), background-color 0.3s ease, border-color 0.3s ease",
+        transition:
+          "transform var(--dur-slow) var(--ease-out-expo), box-shadow var(--dur-slow) var(--ease-out-expo), background-color 0.3s ease, border-color 0.3s ease",
         transform: hovered ? "translateY(-4px)" : "translateY(0)",
         boxShadow: hovered
           ? "0 20px 60px var(--shadow-hover)"

--- a/components/CardImage.tsx
+++ b/components/CardImage.tsx
@@ -2,9 +2,11 @@
 
 import { useState, useEffect } from "react";
 import Image from "next/image";
+import { CATEGORY_COLORS } from "@/lib/constants";
 import type { CardImageProps } from "@/lib/types";
 
-export default function CardImage({ src, alt, featured }: CardImageProps) {
+export default function CardImage({ src, alt, featured, category }: CardImageProps) {
+  const color = CATEGORY_COLORS[category] || CATEGORY_COLORS.top;
   const [status, setStatus] = useState<"loading" | "loaded" | "error">(
     src ? "loading" : "error"
   );
@@ -50,6 +52,19 @@ export default function CardImage({ src, alt, featured }: CardImageProps) {
           className="absolute inset-0 pointer-events-none"
           style={{
             background: "linear-gradient(to top, rgba(0,0,0,0.3) 0%, transparent 40%)",
+          }}
+        />
+      )}
+
+      {/* Category-color hairline ties image to card body */}
+      {status === "loaded" && (
+        <div
+          aria-hidden
+          className="absolute bottom-0 left-0 right-0 pointer-events-none"
+          style={{
+            height: 1,
+            background: `linear-gradient(90deg, ${color.hex} 0%, ${color.hex}80 30%, transparent 100%)`,
+            opacity: 0.85,
           }}
         />
       )}

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -15,6 +15,28 @@ const TONE_COLORS: Record<StoryFraming["tone"], string> = {
   optimistic: "#059669",
 };
 
+function Chevron({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      className="story-chevron"
+      data-expanded={expanded}
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      fill="none"
+      aria-hidden
+    >
+      <path
+        d="M2 3.5 L5 6.5 L8 3.5"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 export default function StoryCard({
   story,
   featured,
@@ -56,11 +78,16 @@ export default function StoryCard({
       `}
       style={{
         position: "relative",
-        transition: "transform 0.4s cubic-bezier(0.16,1,0.3,1), box-shadow 0.4s cubic-bezier(0.16,1,0.3,1)",
+        transition:
+          "transform var(--dur-slow) var(--ease-out-expo), box-shadow var(--dur-slow) var(--ease-out-expo)",
         transform: hovered ? "translateY(-4px)" : "translateY(0)",
         boxShadow: hovered
-          ? "0 20px 60px var(--shadow-hover)"
-          : "0 2px 16px var(--shadow)",
+          ? featured && expanded
+            ? "0 24px 80px var(--shadow-high)"
+            : "0 20px 60px var(--shadow-hover)"
+          : featured && expanded
+            ? "0 4px 24px var(--shadow-mid)"
+            : "0 2px 16px var(--shadow)",
         borderTop: !hasImage ? `3px solid ${color.hex}` : undefined,
         animation: index <= 2 ? `card-enter-left 0.5s ease-out both` : undefined,
         animationDelay: index <= 2 ? `${index * 60}ms` : undefined,
@@ -71,6 +98,14 @@ export default function StoryCard({
         className="absolute top-0 left-0 right-0 h-[2px] transition-opacity duration-300 pointer-events-none"
         style={{ background: color.hex, opacity: hovered ? 0.6 : 0, zIndex: 1 }}
       />
+
+      {/* Light-source radial highlight — only on the signature expanded card */}
+      {featured && expanded && (
+        <div
+          aria-hidden
+          className="story-highlight absolute top-0 left-0 right-0 h-[120px] pointer-events-none"
+        />
+      )}
 
       {/* Image */}
       {hasImage && (
@@ -108,17 +143,17 @@ export default function StoryCard({
 
         {/* Headline */}
         <h3
-          className="font-heading font-bold leading-snug text-[var(--text)] tracking-tight"
-          style={{ fontSize: featured ? 24 : 19 }}
+          className={`font-heading font-bold text-[var(--text)] ${
+            featured ? "text-headline-lg" : "text-headline"
+          }`}
         >
           {story.headline}
         </h3>
 
         {/* Summary */}
         <p
-          className="text-[var(--text-secondary)] leading-relaxed"
+          className={`text-[var(--text-secondary)] ${featured ? "text-body-lg" : "text-body"}`}
           style={{
-            fontSize: featured ? 15 : 14,
             display: "-webkit-box",
             WebkitLineClamp: featured ? 4 : 3,
             WebkitBoxOrient: "vertical",
@@ -155,29 +190,60 @@ export default function StoryCard({
         {/* Framings section */}
         {story.framings.length > 0 && (
           <div className="mt-1">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-[var(--text-muted)] mb-2">
-              {COPY.stories.framing}
-            </p>
-            <div className="flex flex-col gap-1.5">
-              {story.framings.map((f) => (
-                <div key={f.sourceName} className="flex items-start gap-2 text-xs">
-                  <span className="font-bold text-[var(--text-secondary)] shrink-0 min-w-[80px]">
-                    {f.sourceName}
-                  </span>
-                  <span className="text-[var(--text-muted)] flex-1">{f.framing}</span>
-                  <span
-                    className="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase shrink-0"
-                    style={{
-                      color: TONE_COLORS[f.tone] || TONE_COLORS.neutral,
-                      background: `${TONE_COLORS[f.tone] || TONE_COLORS.neutral}15`,
-                    }}
+            <div className="flex items-center gap-3 mb-3">
+              <p className="text-kicker font-bold uppercase text-[var(--text-muted)] shrink-0">
+                {COPY.stories.framing(story.framings.length)}
+              </p>
+              <span
+                aria-hidden
+                className="flex-1 h-px bg-gradient-to-r from-[var(--border)] to-transparent"
+              />
+            </div>
+            <div className="flex flex-col">
+              {story.framings.map((f, i) => {
+                const toneHex = TONE_COLORS[f.tone] || TONE_COLORS.neutral;
+                return (
+                  <div
+                    key={f.sourceName}
+                    className="story-row flex items-start gap-4 py-2.5 border-b border-[color:var(--border-subtle)] last:border-b-0"
                   >
-                    {f.tone}
-                  </span>
-                </div>
-              ))}
+                    <span
+                      aria-hidden
+                      className="story-row__tone-gutter"
+                      style={{ background: toneHex }}
+                    />
+                    <span className="story-row__source text-outlet font-semibold uppercase text-[var(--text)] shrink-0 min-w-[88px]">
+                      {f.sourceName}
+                    </span>
+                    <span className="text-body text-[var(--text-secondary)] flex-1">
+                      {f.framing}
+                    </span>
+                    <span
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-[var(--border)] text-[10px] font-medium tracking-[0.04em] text-[var(--text-secondary)] shrink-0"
+                      style={{
+                        animation: "tone-breathe 600ms var(--ease-spring) both",
+                        animationDelay: `${300 + i * 24}ms`,
+                      }}
+                    >
+                      <span
+                        aria-hidden
+                        className="inline-block rounded-full"
+                        style={{ width: 6, height: 6, background: toneHex }}
+                      />
+                      {COPY.stories.toneLabels[f.tone]}
+                    </span>
+                  </div>
+                );
+              })}
             </div>
           </div>
+        )}
+
+        {/* Empty-framings fallback — articles exist but framings still pending */}
+        {story.framings.length === 0 && story.articles.length > 0 && (
+          <p className="text-body text-[var(--text-muted)] italic">
+            {COPY.stories.analyzingFallback}
+          </p>
         )}
 
         {/* Expand/collapse toggle */}
@@ -186,61 +252,87 @@ export default function StoryCard({
             e.stopPropagation();
             setExpanded(!expanded);
           }}
-          className="self-start bg-transparent border-none p-0 cursor-pointer text-xs font-semibold transition-colors duration-200 mt-1"
+          className="story-expand-btn self-start bg-transparent border-none p-0 cursor-pointer text-xs font-semibold transition-colors duration-200 mt-1 inline-flex items-center gap-1.5"
           style={{ color: "var(--accent)" }}
+          aria-expanded={expanded}
         >
           {expanded ? COPY.stories.collapse : COPY.stories.expand(story.articles.length)}
+          <Chevron expanded={expanded} />
         </button>
 
-        {/* Expanded child articles */}
-        {expanded && (
-          <div
-            className="flex flex-col gap-2 mt-1 pt-3 border-t border-[var(--border)]"
-            style={{ animation: "story-expand 0.35s ease-out both" }}
-          >
-            {story.articles.map((article) => (
-              <a
-                key={article.id}
-                href={article.sourceUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200 no-underline hover:bg-[var(--card-bg)]"
-                style={{ background: "var(--bg)" }}
-              >
-                <span className="text-xs font-bold text-[var(--text-secondary)] min-w-[70px] shrink-0">
-                  {article.sourceName}
-                </span>
-                <span
-                  className="text-xs text-[var(--text)] flex-1"
+        {/* Expanded child articles — grid-template-rows disclosure (no max-height) */}
+        <div
+          style={{
+            display: "grid",
+            gridTemplateRows: expanded ? "1fr" : "0fr",
+            transition: "grid-template-rows var(--dur-base) var(--ease-out-expo)",
+          }}
+        >
+          <div style={{ overflow: "hidden", minHeight: 0 }}>
+            {expanded && (
+              <div className="mt-3 pt-4 border-t border-[var(--border)]">
+                <p className="text-meta text-[var(--text-muted)] mb-3">
+                  {COPY.stories.expandedMeta(timeAgo(story.publishedDate), story.articles.length)}
+                </p>
+                <div
+                  className="rounded-[10px] px-2"
                   style={{
-                    display: "-webkit-box",
-                    WebkitLineClamp: 1,
-                    WebkitBoxOrient: "vertical",
-                    overflow: "hidden",
+                    background: "var(--well-bg)",
+                    boxShadow: "inset 0 1px 0 var(--border)",
                   }}
                 >
-                  {article.title}
-                </span>
-                <span className="text-[10px] text-[var(--text-muted)] shrink-0">
-                  {timeAgo(article.publishedDate)}
-                </span>
-                {onCompare && (
-                  <button
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      onCompare(article.title, article.sourceName);
-                    }}
-                    className="bg-transparent border-none p-0 cursor-pointer text-[10px] font-medium shrink-0 transition-colors duration-200"
-                    style={{ color: "var(--accent)" }}
-                  >
-                    Compare
-                  </button>
-                )}
-              </a>
-            ))}
+                  <div className="flex flex-col">
+                    {story.articles.map((article, i) => (
+                      <a
+                        key={article.id}
+                        href={article.sourceUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="story-row flex items-center gap-4 py-3 no-underline border-b border-[color:var(--border-subtle)] last:border-b-0"
+                        style={{
+                          animation: "row-reveal 320ms var(--ease-out-expo) both",
+                          animationDelay: `${(story.framings.length + Math.min(i, 11)) * 24}ms`,
+                        }}
+                      >
+                        <span aria-hidden className="story-row__rail" />
+                        <span className="story-row__source text-outlet font-semibold uppercase text-[var(--text)] shrink-0 min-w-[88px]">
+                          {article.sourceName}
+                        </span>
+                        <span
+                          className="text-body text-[var(--text)] flex-1"
+                          style={{
+                            display: "-webkit-box",
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: "vertical",
+                            overflow: "hidden",
+                          }}
+                        >
+                          {article.title}
+                        </span>
+                        <span className="text-meta text-[var(--text-muted)] shrink-0">
+                          {timeAgo(article.publishedDate)}
+                        </span>
+                        {onCompare && (
+                          <button
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              onCompare(article.title, article.sourceName);
+                            }}
+                            className="story-row__cta bg-transparent border-none p-0 cursor-pointer text-meta font-medium shrink-0"
+                            style={{ color: "var(--accent)" }}
+                          >
+                            {COPY.stories.compareRow}
+                          </button>
+                        )}
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
-        )}
+        </div>
 
         {/* Meta row */}
         <div className="flex items-center gap-3 mt-auto pt-2 text-xs text-[var(--text-muted)] font-medium">

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -4,6 +4,8 @@
 // Voice: Bloomberg meets a smart friend. Conversational authority.
 // Rules: contractions always, active voice, no jargon, no exclamation marks.
 
+import type { StoryFraming } from "./types";
+
 export const COPY = {
   header: {
     tagline: "Intelligence, distilled",
@@ -52,8 +54,24 @@ export const COPY = {
   stories: {
     sourcesBadge: (count: number) => `${count} source${count !== 1 ? "s" : ""}`,
     expand: (count: number) => `View ${count} article${count !== 1 ? "s" : ""}`,
-    collapse: "Collapse",
-    framing: "How sources covered this",
+    collapse: "Hide sources",
+    framing: (count: number) =>
+      count === 1
+        ? "How one outlet framed it"
+        : count <= 3
+          ? `How ${count} outlets framed it`
+          : `How ${count} outlets covered this`,
+    compareRow: "See angles",
+    expandedMeta: (when: string, count: number) =>
+      `Updated ${when} · ${count} ${count === 1 ? "source" : "sources"}`,
+    analyzingFallback: "Sources are still being analyzed — articles below.",
+    toneLabels: {
+      neutral: "Straight",
+      urgent: "Pressing",
+      analytical: "Deep read",
+      critical: "Skeptical",
+      optimistic: "Hopeful",
+    } as Record<StoryFraming["tone"], string>,
   },
   notFound: {
     title: "This page wandered off",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,6 +14,16 @@ const config: Config = {
         heading: ["var(--font-heading)", "Georgia", "Times New Roman", "serif"],
         body: ["var(--font-body)", "Segoe UI", "sans-serif"],
       },
+      fontSize: {
+        kicker:        ["11px",   { lineHeight: "1.2",  letterSpacing: "0.12em" }],
+        meta:          ["11px",   { lineHeight: "1.3",  letterSpacing: "0.02em" }],
+        outlet:        ["11px",   { lineHeight: "1.2",  letterSpacing: "0.08em" }],
+        body:          ["13.5px", { lineHeight: "1.5",  letterSpacing: "0" }],
+        "body-lg":     ["15px",   { lineHeight: "1.55", letterSpacing: "-0.005em" }],
+        headline:      ["19px",   { lineHeight: "1.25", letterSpacing: "-0.015em" }],
+        "headline-lg": ["24px",   { lineHeight: "1.2",  letterSpacing: "-0.02em" }],
+        display:       ["32px",   { lineHeight: "1.1",  letterSpacing: "-0.025em" }],
+      },
       colors: {
         sift: {
           bg: "var(--bg)",


### PR DESCRIPTION
## Summary
- Reworks the expanded `StoryCard` (the moment when a featured story has 10+ sources covering it) across motion, type, color/depth, and microcopy — targeting a Linear/Vercel/Pitch level of craft while staying vanilla CSS.
- Replaces `@keyframes story-expand` (max-height, jank, 500px cap) with a `grid-template-rows: 0fr → 1fr` disclosure plus per-row `row-reveal` stagger (capped at row 12 → ~290ms settle even on 18-source stories).
- Introduces motion + duration + shadow tier tokens and a modular `fontSize` scale (`kicker / meta / outlet / body / body-lg / headline / headline-lg / display`) so future work doesn't drift back into inline `style={{ fontSize: 24 }}`.
- Framing rows: tone-color left gutter (semantic), outline + dot tone badge replacing the sticker pill, editorial verdict labels (`Straight / Pressing / Deep read / Skeptical / Hopeful`), kicker section header with newspaper rule.
- Article rows (under "View N articles"): hover/focus rail grows from 1px to 2px, source-name nudges 2px right, "See angles" CTA fades in from -4px, all on `var(--ease-out-expo)` over `var(--dur-base)`.
- Featured + expanded card sits one shadow tier higher (`--shadow-mid` → `--shadow-high`), gets a 2.5% radial light-source highlight (theme-aware: `screen` on dark, `multiply` on light), and a CSS image-to-body category-color hairline at the bottom of the image.
- Microcopy: `framing` becomes `framing(count)` ("How 14 outlets covered this"), `Compare` → `See angles`, `Collapse` → `Hide sources`, plus an `expandedMeta` line ("Updated 12 min ago · 14 sources") and an `analyzingFallback` for the empty-framings/articles-present edge case.
- A11y: framing-snippet contrast lifts from `--text-muted` (~3.4:1, fails AA) to `--text-secondary` (~6.8:1, passes AA). All new motion respected by the existing `prefers-reduced-motion` block in `globals.css`.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 73 tests pass across 5 suites (no copy-test regressions even after `framing` became a function and `collapse` changed)
- [x] `npm run build` — production build succeeds; `/news` 15.4 kB / 126 kB First Load (no JS bundle change — vanilla CSS only)
- [x] Compiled CSS bundle includes all new tokens, keyframes, and utility classes; old `@keyframes story-expand` removed
- [ ] Pull up `localhost:3000/news` in a real browser and walk through plan steps 2–11: resting state shadow tier, image-bottom hairline, click expand → grid disclosure cascade, hover row 5 (rail/source-shift/CTA reveal), tab through (`:focus-within` parity), tone-label readout, theme toggle (Newsprint inversion), `prefers-reduced-motion` reduce → instant rows, axe contrast pass, edge cases (`framings.length === 0/1/18`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)