### PR TITLE
Sift civic-literacy pivot — Phase 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Sift
 
-AI-curated news aggregator. 100+ RSS sources, 10 categories, Claude Haiku summaries, Voyage AI embeddings, multi-source comparison. Updated every 10 minutes.
+A civic-literacy news app for the American public. Sift reads hundreds of vetted sources, surfaces the civic context the news assumes you already know, compares how outlets across the political spectrum frame the same story, and shows the financial and political ties behind every entity — all linked to public records.
 
 **Live:** [siftnews.kristenmartino.ai](https://siftnews.kristenmartino.ai)
+
+> **Direction:** Sift is mid-pivot from a general-audience news aggregator to a civic-literacy news app. See [`plans/sift-civic-literacy.md`](../../.claude/plans/sift-civic-literacy.md) for the active plan. The pre-pivot product is preserved at git tag `v1-general-audience`. A possible future "Sift Pro" tier (paid power-user / professional intelligence) is documented but deferred — see [`plans/sift-ib-pivot.md`](../../.claude/plans/sift-ib-pivot.md).
 
 ## Architecture
 
@@ -17,7 +19,7 @@ Browser --> Vercel (Next.js) --reads--> Neon Postgres (pgvector)
 - **sift-api**: Python FastAPI + LangGraph on Railway — background pipeline + comparison workflow
 - **Database**: Neon Postgres (pgvector) — shared source of truth
 
-## Features
+## Features (current)
 
 - **10 categories**: Top, Technology, Business, Science, Energy, World, Health, Politics, Sports, Entertainment
 - **AI summaries**: Every article summarized by Claude Haiku 4.5
@@ -26,8 +28,15 @@ Browser --> Vercel (Next.js) --reads--> Neon Postgres (pgvector)
 - **Bookmarks**: localStorage + Clerk server sync
 - **Dark/light themes**: "Late Edition" (dark) and "Newsprint" (light) with warm editorial tones
 - **SiftLogo**: Diamond mark brand identity across all touchpoints
-- **Landing page**: Marketing page with feature showcase
 - **Auth**: Clerk (free to 10K MAU)
+
+## Features (civic-literacy MVP, in progress — see plan)
+
+- **Background primer**: *"What you should know first"* + 3–5 term definitions, AI-generated at ingest
+- **Cross-spectrum comparison**: how outlets across left / center / right framed the same story, with AllSides + MBFC ratings shown for each outlet
+- **Reading-level adjuster**: Simpler / Standard / Detailed slider, Claude-rewritten and cached
+- **Inline glossary with financial AND political context**: hover any entity (outlet, politician, think tank, pundit, bill) for an externally-sourced dossier — ownership, donors, voting records, foreign funding (FARA), interest-group ratings. All linked to AllSides, MBFC, OpenSecrets, GovTrack, ProPublica Nonprofit Explorer, FARA, Vote Smart, and FEC
+- **Methodology**: source curation policy and symmetric-application rules public at `/methodology`
 
 ## Quick start
 

--- a/app/colophon/page.tsx
+++ b/app/colophon/page.tsx
@@ -1,0 +1,156 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import LandingMasthead from "@/components/landing/LandingMasthead";
+import SiftLogo from "@/components/SiftLogo";
+
+export const metadata: Metadata = {
+  title: "Colophon",
+  description:
+    "How Sift is built. Stack, architecture, and credits for the AI-curated news aggregator.",
+};
+
+const STACK = [
+  { name: "Next.js 15", role: "Frontend & App Router on Vercel" },
+  { name: "FastAPI + LangGraph", role: "Pipeline & comparison workflow on Railway" },
+  { name: "Postgres + pgvector", role: "Articles, stories, embeddings, bookmarks" },
+  { name: "Claude (Anthropic)", role: "Summarization, story synthesis, comparison" },
+  { name: "Voyage AI", role: "Embeddings for semantic topic search" },
+  { name: "Clerk", role: "Auth & user management" },
+  { name: "Tailwind CSS", role: "Design system & theming" },
+  { name: "next/font", role: "Self-hosted Playfair Display & Source Sans 3" },
+];
+
+const ARCHITECTURE = [
+  "Articles load in under 50ms — AI processing happens in the background, not when you read.",
+  "Works without an account — sign in only if you want bookmarks synced across devices.",
+  "Graceful degradation: every feature works independently, so one slow service never blocks the page.",
+  "100+ sources are ingested, deduplicated, and ranked every 10 minutes before you open the app.",
+];
+
+export default function ColophonPage() {
+  return (
+    <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
+      <LandingMasthead />
+
+      <main id="main-content" className="max-w-[800px] mx-auto px-6 pt-12 pb-24">
+        {/* Section eyebrow + title */}
+        <header className="mb-9">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3 flex items-center">
+            <span aria-hidden className="inline-block w-7 h-px bg-[var(--border)] mr-3" />
+            Behind the masthead
+          </p>
+          <h1 className="font-heading text-[36px] md:text-[44px] font-bold leading-[1.05] tracking-tight text-[var(--text)]">
+            Colophon
+          </h1>
+          <p className="font-body text-[16px] text-[var(--text-secondary)] mt-3 max-w-[60ch] leading-relaxed">
+            A note on how Sift is built — the stack, the people, the principles.
+          </p>
+        </header>
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* Masthead-style credit */}
+        <section className="mb-12">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-4">
+            Masthead
+          </p>
+          <p className="font-heading text-[20px] leading-relaxed text-[var(--text)] max-w-[60ch]">
+            Edited by <span className="italic">Claude</span>. Built by{" "}
+            <a
+              href="https://github.com/kristenmartino"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[var(--accent)] no-underline hover:underline"
+            >
+              Kristen Martino
+            </a>
+            .
+          </p>
+        </section>
+
+        {/* Stack */}
+        <section className="mb-12">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-4">
+            Set in
+          </p>
+          <p className="font-body text-[16px] text-[var(--text-secondary)] leading-[1.7] max-w-[60ch] mb-7">
+            Sift is set in <strong className="text-[var(--text)] font-semibold">Playfair Display</strong>{" "}
+            and <strong className="text-[var(--text)] font-semibold">Source Sans 3</strong>, served from
+            same-origin via <code className="font-body text-[14px]">next/font</code>. The cover star{" "}
+            <SiftLogo variant="mark" size={16} className="inline-block align-[-3px]" />{" "}
+            is a vector diamond, sized to scale across PWA icons, OG cards, and tab favicons.
+          </p>
+          <ul className="space-y-3">
+            {STACK.map((s) => (
+              <li
+                key={s.name}
+                className="grid grid-cols-[180px_1fr] gap-x-6 items-baseline border-b border-[var(--border-subtle)] pb-3"
+              >
+                <span className="font-body text-outlet uppercase tracking-wider text-[var(--text)] font-semibold">
+                  {s.name}
+                </span>
+                <span className="font-body text-[14px] text-[var(--text-secondary)]">
+                  {s.role}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Architecture diagram */}
+        <section className="mb-12">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-4">
+            Architecture
+          </p>
+          <pre className="font-body text-[12px] leading-relaxed text-[var(--text-secondary)] bg-[var(--card-bg)] border border-[var(--border)] rounded-md p-5 overflow-x-auto whitespace-pre">
+{`Browser  →  Vercel (Next.js)  →  Neon Postgres (pgvector)
+                  ↑
+                  +— /api/compare ————→  Railway (FastAPI + LangGraph)
+                  ↑
+                  +— cron / 10 min ———→  Railway → writes to Postgres`}
+          </pre>
+        </section>
+
+        {/* Principles */}
+        <section className="mb-12">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-4">
+            Principles
+          </p>
+          <ul className="space-y-4 max-w-[60ch]">
+            {ARCHITECTURE.map((point) => (
+              <li
+                key={point}
+                className="font-body text-[15px] leading-relaxed text-[var(--text-secondary)] flex items-baseline gap-3"
+              >
+                <span aria-hidden className="text-[var(--accent)] shrink-0">
+                  ◆
+                </span>
+                {point}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* Back link */}
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <Link
+            href="/"
+            className="font-body text-outlet uppercase tracking-wider text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline inline-flex items-center gap-1.5"
+          >
+            <span aria-hidden>←</span> Back to Sift
+          </Link>
+          <a
+            href="https://github.com/kristenmartino/sift"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-body text-outlet uppercase tracking-wider text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline inline-flex items-center gap-1.5"
+          >
+            View source on GitHub <span aria-hidden>→</span>
+          </a>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -187,13 +187,6 @@ article,
   to   { opacity: 1; transform: translateY(0); }
 }
 
-/* One-shot tone-badge breathe, runs once on initial reveal. */
-@keyframes tone-breathe {
-  0%   { transform: scale(1); }
-  30%  { transform: scale(1.04); }
-  100% { transform: scale(1); }
-}
-
 /* ─── Story Row Affordances ───────────────────────────── */
 /* Used by both framing rows and article rows in the expanded
    StoryCard. Hover/focus reveals an accent rail, shifts the
@@ -246,17 +239,6 @@ article,
 .story-row:active {
   transform: scale(0.99);
   transition: transform 80ms var(--ease-snap);
-}
-/* Tone-color gutter — lives at row left edge, semantic content. */
-.story-row__tone-gutter {
-  position: absolute;
-  left: 0;
-  top: 6px;
-  bottom: 6px;
-  width: 2px;
-  opacity: 0.7;
-  pointer-events: none;
-  border-radius: 1px;
 }
 
 /* ─── Story Light-Source Highlight ────────────────────── */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,25 +23,25 @@ const fontBody = Source_Sans_3({
 
 export const metadata: Metadata = {
   title: {
-    default: "Sift — Intelligence, distilled",
+    default: "Sift — News with context, comparison, and transparency",
     template: "%s | Sift",
   },
   description:
-    "Sift reads hundreds of sources, summarizes the stories worth knowing, and links back to the originals. AI-curated news, refreshed every 10 minutes.",
+    "Sift reads hundreds of sources and surfaces the civic context the news assumes you already know — with cross-spectrum comparison and the financial and political ties behind every story. Every claim links to a public record.",
   metadataBase: new URL("https://siftnews.kristenmartino.ai"),
   openGraph: {
-    title: "Sift — Intelligence, distilled",
+    title: "Sift — Read the news with the context it deserves",
     description:
-      "Hundreds of sources, summarized and sourced. Read the day's news in five minutes.",
+      "The civics the news assumes. The framing across the political spectrum. The money and politics behind every story. Linked to public records.",
     siteName: "Sift",
     type: "website",
     locale: "en_US",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Sift — Intelligence, distilled",
+    title: "Sift — Read the news with the context it deserves",
     description:
-      "Hundreds of sources, summarized and sourced. Read the day's news in five minutes.",
+      "The civics the news assumes. The framing across the political spectrum. The money and politics behind every story.",
   },
 };
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,25 +23,25 @@ const fontBody = Source_Sans_3({
 
 export const metadata: Metadata = {
   title: {
-    default: "Sift — AI-Curated News, Already Read for You",
+    default: "Sift — Intelligence, distilled",
     template: "%s | Sift",
   },
   description:
-    "AI-curated news summaries from 100+ sources across technology, business, science, energy, world, and health. Updated every 10 minutes.",
+    "Sift reads hundreds of sources, summarizes the stories worth knowing, and links back to the originals. AI-curated news, refreshed every 10 minutes.",
   metadataBase: new URL("https://siftnews.kristenmartino.ai"),
   openGraph: {
-    title: "Sift — AI-Curated News",
+    title: "Sift — Intelligence, distilled",
     description:
-      "AI-curated news summaries from 100+ sources. Get the key points in 60 seconds.",
+      "Hundreds of sources, summarized and sourced. Read the day's news in five minutes.",
     siteName: "Sift",
     type: "website",
     locale: "en_US",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Sift — AI-Curated News",
+    title: "Sift — Intelligence, distilled",
     description:
-      "AI-curated news summaries from 100+ sources. Get the key points in 60 seconds.",
+      "Hundreds of sources, summarized and sourced. Read the day's news in five minutes.",
   },
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,10 +5,10 @@ import type { Article, CategoryId } from "@/lib/types";
 
 export const metadata: Metadata = {
   title: {
-    absolute: "Sift — Intelligence, distilled",
+    absolute: "Sift — News with context, comparison, and transparency",
   },
   description:
-    "AI-curated news summaries from 100+ sources across technology, business, science, energy, world, and health. Updated every 10 minutes.",
+    "Read the news with the civic context, cross-spectrum comparison, and source transparency it assumes you already know. Linked to public records. Refreshed every 10 minutes.",
 };
 
 // ISR: re-render at most once every 10 minutes — same heartbeat as the

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,38 @@
 import type { Metadata } from "next";
 import LandingPage from "@/components/LandingPage";
+import { getTopStoryForLanding } from "@/lib/db";
+import type { Article, CategoryId } from "@/lib/types";
 
 export const metadata: Metadata = {
   title: {
-    absolute: "Sift — AI-Curated News, Already Read for You",
+    absolute: "Sift — Intelligence, distilled",
   },
   description:
     "AI-curated news summaries from 100+ sources across technology, business, science, energy, world, and health. Updated every 10 minutes.",
 };
 
-export default function Home() {
-  return <LandingPage />;
+// ISR: re-render at most once every 10 minutes — same heartbeat as the
+// pipeline cron. The lead story above the fold stays at-most-one-cycle stale
+// without paying a DB round-trip on every visit.
+export const revalidate = 600;
+
+export default async function Home() {
+  const lead = await getTopStoryForLanding();
+  const leadStory: Article | null = lead
+    ? {
+        id: lead.id,
+        title: lead.title,
+        summary: lead.summary || "",
+        sourceUrl: lead.source_url,
+        sourceName: lead.source_name,
+        publishedDate: lead.published_date?.toISOString() ?? null,
+        imageUrl: lead.image_url,
+        category: lead.category as CategoryId,
+        readTime: lead.read_time,
+        whyItMatters: lead.why_it_matters ?? undefined,
+        importanceScore: lead.importance_score ?? undefined,
+      }
+    : null;
+
+  return <LandingPage leadStory={leadStory} />;
 }

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,371 +1,88 @@
 "use client";
 
 import Link from "next/link";
-import { CATEGORIES, CATEGORY_COLORS } from "@/lib/constants";
 import { COPY } from "@/lib/copy";
-import { useTheme } from "@/lib/hooks";
 import SiftLogo from "./SiftLogo";
-import type { CategoryId } from "@/lib/types";
+import LandingMasthead from "./landing/LandingMasthead";
+import LeadStory from "./landing/LeadStory";
+import ComparisonDemo from "./landing/ComparisonDemo";
+import SourceColophon from "./landing/SourceColophon";
+import type { Article } from "@/lib/types";
 
-// ─── Feature cards data ─────────────────────────────────
+interface LandingPageProps {
+  /** Server-fetched lead story (ISR @ 600s in app/page.tsx). Null = DB miss. */
+  leadStory: Article | null;
+}
 
-const FEATURES = [
-  {
-    icon: "✦",
-    title: "AI-Written Summaries",
-    description:
-      "Every article distilled into a concise summary by Claude. Get the key points without clicking through.",
-    accent: "#818cf8",
-  },
-  {
-    icon: "◆",
-    title: "10 Categories",
-    description:
-      "Technology, business, science, energy, world news, health, politics, sports, entertainment — plus curated top stories.",
-    accent: "#dc2626",
-  },
-  {
-    icon: "⬡",
-    title: "Custom Topic Search",
-    description:
-      "Search any topic. Sift finds relevant articles from its database or searches the web in real time.",
-    accent: "#2563eb",
-  },
-  {
-    icon: "⇌",
-    title: "Multi-Source Comparison",
-    description:
-      "Compare how different outlets cover the same story. See where they agree, disagree, and what's unique.",
-    accent: "#7c3aed",
-  },
-  {
-    icon: "★",
-    title: "Synced Bookmarks",
-    description:
-      "Save articles to read later. Sign in to sync bookmarks across devices, or use local storage.",
-    accent: "#d97706",
-  },
-  {
-    icon: "↻",
-    title: "Always Fresh",
-    description:
-      "Articles sourced from 100+ outlets and refreshed every 10 minutes. Never stale, always relevant.",
-    accent: "#059669",
-  },
-];
-
-// ─── How It Works steps ─────────────────────────────────
-
-const STEPS = [
-  {
-    number: "01",
-    title: "Open Sift",
-    description: "See top stories with AI-written summaries. Browse by category.",
-  },
-  {
-    number: "02",
-    title: "Go deeper",
-    description: "Search topics, compare sources, save articles for later.",
-  },
-  {
-    number: "03",
-    title: "Close it",
-    description: "60 seconds. You're caught up. Back to your day.",
-  },
-];
-
-// ─── Tech stack ─────────────────────────────────────────
-
-const TECH_STACK = [
-  { name: "Next.js", detail: "App Router, RSC" },
-  { name: "FastAPI + LangGraph", detail: "Pipeline orchestration" },
-  { name: "Postgres + pgvector", detail: "Storage & semantic search" },
-  { name: "Claude AI", detail: "Summarization & analysis" },
-  { name: "Voyage AI", detail: "Embedding generation" },
-  { name: "Clerk", detail: "Auth & user management" },
-];
-
-const ARCHITECTURE_POINTS = [
-  "Articles load in under 50ms — AI processing happens in the background, not when you read",
-  "Works without an account — sign in only if you want bookmarks synced across devices",
-  "Graceful degradation: every feature works independently, so one slow service never blocks you",
-  "100+ sources ingested, deduplicated, and ranked before you open the app",
-];
-
-// ─── Component ──────────────────────────────────────────
-
-export default function LandingPage() {
-  const { dark: darkMode, toggle: toggleDark, mounted } = useTheme();
-
+export default function LandingPage({ leadStory }: LandingPageProps) {
   return (
-    <div
-      style={{
-        background: "var(--bg)",
-        color: "var(--text)",
-        minHeight: "100vh",
-        transition: "background 0.3s, color 0.3s",
-      }}
-    >
-      {/* ── Nav ───────────────────────────────────── */}
-      <nav
-        className="sticky top-0 z-50 border-b border-[var(--border)]"
-        style={{ background: "var(--nav-bg)", backdropFilter: "blur(12px)", WebkitBackdropFilter: "blur(12px)" }}
-      >
-        <div className="max-w-[1200px] mx-auto px-6 h-14 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <SiftLogo variant="full" size={20} />
-            <span
-              className="px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-widest"
-              style={{
-                background: "rgba(99,102,241,0.1)",
-                color: "var(--accent)",
-                border: "1px solid rgba(99,102,241,0.2)",
-              }}
-            >
-              {COPY.header.tagline}
-            </span>
-          </div>
-          <div className="flex items-center gap-3">
-            {mounted && (
-              <button
-                onClick={toggleDark}
-                aria-label={darkMode ? "Switch to light mode" : "Switch to dark mode"}
-                className="w-8 h-8 flex items-center justify-center rounded-full border border-[var(--border)] bg-transparent text-[var(--text-secondary)] text-sm cursor-pointer transition-colors duration-200"
-              >
-                {darkMode ? "☀" : "☾"}
-              </button>
-            )}
-            <Link
-              href="/news"
-              className="px-4 py-1.5 rounded-full text-sm font-semibold transition-all duration-200 no-underline"
-              style={{
-                background: "var(--accent)",
-                color: "#fff",
-              }}
-            >
-              Try Sift &rarr;
-            </Link>
-          </div>
-        </div>
-      </nav>
+    <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
+      {/* Drop-cap rule, scoped to landing only — Sift's globals.css doesn't
+          have an equivalent yet, so we inline it here rather than touching
+          the system-wide stylesheet during a Phase A pass. */}
+      <style jsx global>{`
+        @media (min-width: 768px) {
+          [data-dropcap]::first-letter {
+            font-family: var(--font-heading), Georgia, serif;
+            font-weight: 800;
+            font-size: 4em;
+            line-height: 0.85;
+            float: left;
+            padding: 0.08em 0.12em 0 0;
+            margin-top: 0.05em;
+            color: var(--text);
+          }
+        }
+      `}</style>
+
+      <LandingMasthead />
 
       <main id="main-content">
-      {/* ── Hero ──────────────────────────────────── */}
-      <section className="max-w-[1200px] mx-auto px-6 pt-24 pb-20 text-center">
-        <h1 className="font-heading text-[clamp(36px,6vw,60px)] font-bold leading-[1.1] tracking-tight text-[var(--text)] mb-6">
-          The news, already read
-          <br />
-          for you.
-        </h1>
-        <p className="max-w-[560px] mx-auto text-[clamp(16px,2vw,20px)] leading-relaxed text-[var(--text-secondary)] mb-8">
-          Sift pulls from 100+ sources, summarizes every article with AI, and
-          gives you the key points in 60 seconds. No ads, no fluff, no infinite scroll.
-        </p>
-        <div className="flex items-center justify-center gap-2 text-xs text-[var(--text-muted)] mb-10">
-          <span>2,000+ articles</span>
-          <span className="opacity-30">&middot;</span>
-          <span>Updated every 10 min</span>
-          <span className="opacity-30">&middot;</span>
-          <span>10 categories</span>
-        </div>
-        <Link
-          href="/news"
-          className="inline-flex items-center gap-2 px-8 py-3 rounded-full text-base font-semibold transition-all duration-200 no-underline"
-          style={{
-            background: "var(--accent)",
-            color: "#fff",
-          }}
-        >
-          Start Reading &rarr;
-        </Link>
-        <div
-          className="mt-20 mx-auto max-w-[800px] h-px"
-          style={{ background: "var(--border)" }}
-        />
-      </section>
-
-      {/* ── Features ──────────────────────────────── */}
-      <section className="max-w-[1200px] mx-auto px-6 pb-20">
-        <h2 className="font-heading text-2xl font-bold text-center text-[var(--text)] mb-12">
-          Everything you need. Nothing you don&apos;t.
-        </h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {FEATURES.map((feature, i) => (
-            <div
-              key={feature.title}
-              className="rounded-[14px] p-6 transition-all duration-200 animate-fade-slide-in"
-              style={{
-                background: "var(--card-bg)",
-                border: "1px solid var(--border)",
-                borderTop: `3px solid ${feature.accent}`,
-                animationDelay: `${i * 80}ms`,
-              }}
-            >
-              <div
-                className="text-2xl mb-3"
-                style={{ color: feature.accent }}
-              >
-                {feature.icon}
-              </div>
-              <h3 className="font-heading text-base font-bold text-[var(--text)] mb-2">
-                {feature.title}
-              </h3>
-              <p className="text-sm leading-relaxed text-[var(--text-secondary)]">
-                {feature.description}
-              </p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* ── How It Works ──────────────────────────── */}
-      <section className="max-w-[1200px] mx-auto px-6 pb-20">
-        <h2 className="font-heading text-2xl font-bold text-center text-[var(--text)] mb-12">
-          How it works
-        </h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-          {STEPS.map((step) => (
-            <div key={step.number} className="text-center">
-              <div
-                className="font-heading text-[72px] font-bold leading-none mb-4"
-                style={{ color: "var(--accent)", opacity: 0.12 }}
-              >
-                {step.number}
-              </div>
-              <h3 className="font-heading text-lg font-bold text-[var(--text)] mb-2">
-                {step.title}
-              </h3>
-              <p className="text-sm text-[var(--text-secondary)] max-w-[280px] mx-auto">
-                {step.description}
-              </p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* ── Category Showcase ─────────────────────── */}
-      <section className="max-w-[1200px] mx-auto px-6 pb-20">
-        <h2 className="font-heading text-2xl font-bold text-center text-[var(--text)] mb-8">
-          10 categories, 100+ sources
-        </h2>
-        <div className="flex flex-wrap justify-center gap-2 mb-6">
-          {CATEGORIES.map((cat) => {
-            const color = CATEGORY_COLORS[cat.id as CategoryId];
-            return (
-              <span
-                key={cat.id}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold"
-                style={{
-                  background: `rgba(${color.rgb},0.1)`,
-                  color: color.hex,
-                  border: `1px solid rgba(${color.rgb},0.2)`,
-                }}
-              >
-                {cat.icon} {cat.label}
-              </span>
-            );
-          })}
-        </div>
-        <p className="text-center text-xs text-[var(--text-muted)] max-w-[760px] mx-auto leading-relaxed">
-          Reuters · AP · BBC · NPR · New York Times · Washington Post · Axios · Politico · PBS NewsHour
-          · TechCrunch · Ars Technica · The Verge · Wired · MIT Tech Review · Hacker News · TechMeme
-          · CNBC · Bloomberg · MarketWatch · Financial Times · The Economist · Fortune · Forbes
-          · Nature · Science · Phys.org · Scientific American · NASA · Quanta Magazine
-          · CleanTechnica · Electrek · Canary Media · Carbon Brief · Grist · Inside Climate News
-          · Al Jazeera · The Guardian · DW News · France 24 · South China Morning Post · Foreign Policy
-          · STAT News · WHO · The BMJ · NIH · The Lancet · Medscape
-          · Politico · The Hill · FiveThirtyEight · RealClearPolitics
-          · ESPN · BBC Sport · The Athletic · CBS Sports · Sports Illustrated
-          · Variety · Hollywood Reporter · Deadline · Rolling Stone · Pitchfork · IGN
-          · Vox · The Atlantic · ProPublica · Rest of World · and more
-        </p>
-      </section>
-
-      {/* ── Built for Production ──────────────────── */}
-      <section className="max-w-[1200px] mx-auto px-6 pb-20">
-        <h2 className="font-heading text-2xl font-bold text-center text-[var(--text)] mb-4">
-          Built to be fast and reliable
-        </h2>
-        <p className="text-center text-sm text-[var(--text-secondary)] mb-12 max-w-[500px] mx-auto">
-          A real system designed for speed, reliability, and always-fresh content.
-        </p>
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-10 max-w-[700px] mx-auto">
-          {TECH_STACK.map((tech) => (
-            <div
-              key={tech.name}
-              className="rounded-[12px] px-4 py-3 text-center"
-              style={{
-                background: "var(--card-bg)",
-                border: "1px solid var(--border)",
-              }}
-            >
-              <div className="text-sm font-semibold text-[var(--text)]">{tech.name}</div>
-              <div className="text-[11px] text-[var(--text-muted)] mt-0.5">{tech.detail}</div>
-            </div>
-          ))}
-        </div>
-        <ul className="max-w-[600px] mx-auto space-y-2">
-          {ARCHITECTURE_POINTS.map((point) => (
-            <li
-              key={point}
-              className="flex items-start gap-2 text-sm text-[var(--text-secondary)]"
-            >
-              <span className="text-[var(--accent)] mt-0.5 shrink-0">&#x2022;</span>
-              {point}
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      {/* ── Final CTA ─────────────────────────────── */}
-      <section className="max-w-[1200px] mx-auto px-6 pb-20 text-center">
-        <div
-          className="mx-auto max-w-[800px] h-px mb-16"
-          style={{ background: "var(--border)" }}
-        />
-        <h2 className="font-heading text-[clamp(28px,4vw,40px)] font-bold text-[var(--text)] mb-6">
-          Try Sift
-        </h2>
-        <p className="text-[var(--text-secondary)] mb-8 text-base">
-          Free. No account required.
-        </p>
-        <Link
-          href="/news"
-          className="inline-flex items-center gap-2 px-8 py-3 rounded-full text-base font-semibold transition-all duration-200 no-underline"
-          style={{
-            background: "var(--accent)",
-            color: "#fff",
-          }}
-        >
-          Start Reading &rarr;
-        </Link>
-      </section>
+        <LeadStory article={leadStory} />
+        <ComparisonDemo />
+        <SourceColophon />
       </main>
 
-      {/* ── Footer ────────────────────────────────── */}
-      <footer className="border-t border-[var(--border)] py-10 px-6 max-w-[1200px] mx-auto">
-        <div className="flex flex-col md:flex-row md:justify-between gap-6 mb-6">
-          <div className="flex flex-col gap-2">
+      {/* ── Colophon Footer ──────────────────────────── */}
+      <footer className="border-t border-[var(--border)] mt-8">
+        <div className="max-w-[1200px] mx-auto px-6 py-9 grid grid-cols-1 md:grid-cols-3 gap-y-6 md:gap-y-3">
+          <div className="md:order-1 flex flex-col gap-3 md:items-start items-center text-center md:text-left">
             <SiftLogo variant="full" size={20} />
-            <p className="text-xs text-[var(--text-muted)] max-w-[320px]">
+            <p className="font-body text-[13px] text-[var(--text-muted)] max-w-[320px] leading-relaxed">
               {COPY.footer.main}
             </p>
           </div>
-          <div className="flex gap-8 text-xs">
-            <div className="flex flex-col gap-1.5">
-              <span className="font-semibold text-[var(--text-secondary)]">Product</span>
-              <Link href="/news" className="text-[var(--text-muted)] no-underline hover:text-[var(--text-secondary)] transition-colors">News Feed</Link>
-              <Link href="/news?view=bookmarks" className="text-[var(--text-muted)] no-underline hover:text-[var(--text-secondary)] transition-colors">Bookmarks</Link>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <span className="font-semibold text-[var(--text-secondary)]">Legal</span>
-              <Link href="/privacy" className="text-[var(--text-muted)] no-underline hover:text-[var(--text-secondary)] transition-colors">Privacy</Link>
-              <Link href="/terms" className="text-[var(--text-muted)] no-underline hover:text-[var(--text-secondary)] transition-colors">Terms</Link>
-            </div>
+
+          <div className="md:order-2 flex flex-col gap-2 md:items-center items-center text-center font-body text-outlet uppercase tracking-wider">
+            <Link
+              href="/news"
+              className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline"
+            >
+              News
+            </Link>
+            <Link
+              href="/colophon"
+              className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline"
+            >
+              {COPY.landing.colophonLink}
+            </Link>
+            <Link
+              href="/privacy"
+              className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline"
+            >
+              Privacy
+            </Link>
+            <Link
+              href="/terms"
+              className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline"
+            >
+              Terms
+            </Link>
           </div>
-        </div>
-        <div className="border-t border-[var(--border)] pt-4 text-xs text-[var(--text-muted)] text-center">
-          &copy; {new Date().getFullYear()} Sift. Every story links to the original.
+
+          <p className="md:order-3 md:text-right text-center font-body text-outlet uppercase tracking-wider text-[var(--text-muted)]">
+            © {new Date().getFullYear()} Sift · Every story links to the original.
+          </p>
         </div>
       </footer>
     </div>

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -5,15 +5,11 @@ import { CATEGORIES, CATEGORY_COLORS } from "@/lib/constants";
 import { COPY } from "@/lib/copy";
 import { timeAgo } from "@/lib/utils";
 import CardImage from "./CardImage";
-import type { StoryCardProps, StoryFraming } from "@/lib/types";
+import type { StoryCardProps } from "@/lib/types";
 
-const TONE_COLORS: Record<StoryFraming["tone"], string> = {
-  neutral: "#6b7280",
-  urgent: "#dc2626",
-  analytical: "#2563eb",
-  critical: "#d97706",
-  optimistic: "#059669",
-};
+// Tone labels are no longer rendered (civic-literacy pivot, Phase 0).
+// Schema fields + COPY.stories.toneLabels lookup remain for backward
+// compatibility and possible future re-introduction. See plans/sift-civic-literacy.md.
 
 function Chevron({ expanded }: { expanded: boolean }) {
   return (
@@ -200,41 +196,20 @@ export default function StoryCard({
               />
             </div>
             <div className="flex flex-col">
-              {story.framings.map((f, i) => {
-                const toneHex = TONE_COLORS[f.tone] || TONE_COLORS.neutral;
-                return (
-                  <div
-                    key={f.sourceName}
-                    className="story-row flex items-start gap-4 py-2.5 border-b border-[color:var(--border-subtle)] last:border-b-0"
-                  >
-                    <span
-                      aria-hidden
-                      className="story-row__tone-gutter"
-                      style={{ background: toneHex }}
-                    />
-                    <span className="story-row__source text-outlet font-semibold uppercase text-[var(--text)] shrink-0 min-w-[88px]">
-                      {f.sourceName}
-                    </span>
-                    <span className="text-body text-[var(--text-secondary)] flex-1">
-                      {f.framing}
-                    </span>
-                    <span
-                      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-[var(--border)] text-[10px] font-medium tracking-[0.04em] text-[var(--text-secondary)] shrink-0"
-                      style={{
-                        animation: "tone-breathe 600ms var(--ease-spring) both",
-                        animationDelay: `${300 + i * 24}ms`,
-                      }}
-                    >
-                      <span
-                        aria-hidden
-                        className="inline-block rounded-full"
-                        style={{ width: 6, height: 6, background: toneHex }}
-                      />
-                      {COPY.stories.toneLabels[f.tone]}
-                    </span>
-                  </div>
-                );
-              })}
+              {story.framings.map((f) => (
+                <div
+                  key={f.sourceName}
+                  className="story-row flex items-start gap-4 py-2.5 border-b border-[color:var(--border-subtle)] last:border-b-0"
+                >
+                  <span aria-hidden className="story-row__rail" />
+                  <span className="story-row__source text-outlet font-semibold uppercase text-[var(--text)] shrink-0 min-w-[88px]">
+                    {f.sourceName}
+                  </span>
+                  <span className="text-body text-[var(--text-secondary)] flex-1">
+                    {f.framing}
+                  </span>
+                </div>
+              ))}
             </div>
           </div>
         )}

--- a/components/landing/ComparisonDemo.tsx
+++ b/components/landing/ComparisonDemo.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import Link from "next/link";
+import { COPY } from "@/lib/copy";
+import type { StoryFraming } from "@/lib/types";
+
+// Tone → display label is the canonical map already used by StoryCard.
+// Tone color matches StoryCard.tsx exactly; if that file changes, update here.
+const TONE_COLORS: Record<StoryFraming["tone"], string> = {
+  neutral: "#6b7280",
+  urgent: "#dc2626",
+  analytical: "#2563eb",
+  critical: "#d97706",
+  optimistic: "#059669",
+};
+
+// Hardcoded for the landing — this is the publication picking what goes on
+// the front page, not a live feed. Upgrade to a "featured comparison of the
+// day" DB row if/when that becomes a real concept (see plan).
+const DEMO: {
+  outlet: string;
+  tone: StoryFraming["tone"];
+  framing: string;
+}[] = [
+  {
+    outlet: "Reuters",
+    tone: "neutral",
+    framing:
+      "Powell signals patience as inflation stays sticky; Fed leaves rates unchanged.",
+  },
+  {
+    outlet: "Wall Street Journal",
+    tone: "critical",
+    framing:
+      "Markets read between the lines: rate cuts unlikely before the fall.",
+  },
+  {
+    outlet: "Bloomberg",
+    tone: "urgent",
+    framing:
+      "Wall Street recalibrates as rate-cut bets fade and bond yields climb.",
+  },
+];
+
+export default function ComparisonDemo() {
+  return (
+    <section className="max-w-[1100px] mx-auto px-6 pb-20">
+      {/* Section eyebrow + title */}
+      <div className="mb-7">
+        <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3 flex items-center">
+          <span aria-hidden className="inline-block w-7 h-px bg-[var(--border)] mr-3" />
+          {COPY.landing.compareEyebrow}
+        </p>
+        <h2 className="font-heading text-[26px] md:text-[30px] font-bold leading-tight tracking-tight text-[var(--text)]">
+          {COPY.landing.compareTitle}
+        </h2>
+        <p className="font-body text-[14px] text-[var(--text-secondary)] mt-2 max-w-[60ch]">
+          {COPY.landing.compareSubtitle}
+        </p>
+      </div>
+
+      {/* Three-row comparison */}
+      <div className="border-t border-b border-[var(--border)]">
+        {DEMO.map((row, i) => (
+          <div
+            key={row.outlet}
+            className={`story-row flex flex-col md:grid md:grid-cols-[140px_120px_1fr] md:items-baseline gap-x-5 gap-y-1 py-5 ${
+              i < DEMO.length - 1 ? "border-b border-[var(--border-subtle)]" : ""
+            }`}
+          >
+            <span aria-hidden className="story-row__rail" />
+            {/* Outlet name */}
+            <span className="story-row__source font-body text-outlet uppercase tracking-wider text-[var(--text)] font-semibold shrink-0">
+              {row.outlet}
+            </span>
+            {/* Tone badge */}
+            <span
+              className="font-body text-kicker uppercase tracking-wider font-semibold inline-flex items-center gap-1.5 shrink-0"
+              style={{ color: TONE_COLORS[row.tone] }}
+            >
+              <span
+                aria-hidden
+                className="inline-block w-1.5 h-1.5 rounded-full"
+                style={{ background: TONE_COLORS[row.tone] }}
+              />
+              {COPY.stories.toneLabels[row.tone]}
+            </span>
+            {/* Framing line */}
+            <span className="font-heading italic text-[17px] md:text-[18px] leading-snug text-[var(--text-secondary)]">
+              &ldquo;{row.framing}&rdquo;
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Footer CTA */}
+      <div className="mt-5 flex justify-end">
+        <Link
+          href="/news"
+          className="font-body text-outlet uppercase tracking-wider text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline inline-flex items-center gap-1.5"
+        >
+          {COPY.landing.compareCta} <span aria-hidden>→</span>
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/ComparisonDemo.tsx
+++ b/components/landing/ComparisonDemo.tsx
@@ -2,41 +2,23 @@
 
 import Link from "next/link";
 import { COPY } from "@/lib/copy";
-import type { StoryFraming } from "@/lib/types";
 
-// Tone → display label is the canonical map already used by StoryCard.
-// Tone color matches StoryCard.tsx exactly; if that file changes, update here.
-const TONE_COLORS: Record<StoryFraming["tone"], string> = {
-  neutral: "#6b7280",
-  urgent: "#dc2626",
-  analytical: "#2563eb",
-  critical: "#d97706",
-  optimistic: "#059669",
-};
-
-// Hardcoded for the landing — this is the publication picking what goes on
-// the front page, not a live feed. Upgrade to a "featured comparison of the
-// day" DB row if/when that becomes a real concept (see plan).
-const DEMO: {
-  outlet: string;
-  tone: StoryFraming["tone"];
-  framing: string;
-}[] = [
+// Phase 0 stub: shows side-by-side outlet headlines without tone labels.
+// Phase 2 will rebuild as <CrossSpectrumCompare> with AllSides political-lean
+// ratings and outlet provenance. See plans/sift-civic-literacy.md.
+const DEMO: { outlet: string; framing: string }[] = [
   {
     outlet: "Reuters",
-    tone: "neutral",
     framing:
       "Powell signals patience as inflation stays sticky; Fed leaves rates unchanged.",
   },
   {
     outlet: "Wall Street Journal",
-    tone: "critical",
     framing:
       "Markets read between the lines: rate cuts unlikely before the fall.",
   },
   {
     outlet: "Bloomberg",
-    tone: "urgent",
     framing:
       "Wall Street recalibrates as rate-cut bets fade and bond yields climb.",
   },
@@ -59,33 +41,19 @@ export default function ComparisonDemo() {
         </p>
       </div>
 
-      {/* Three-row comparison */}
+      {/* Outlet × headline rows. Phase 2 adds AllSides political-lean column. */}
       <div className="border-t border-b border-[var(--border)]">
         {DEMO.map((row, i) => (
           <div
             key={row.outlet}
-            className={`story-row flex flex-col md:grid md:grid-cols-[140px_120px_1fr] md:items-baseline gap-x-5 gap-y-1 py-5 ${
+            className={`story-row flex flex-col md:grid md:grid-cols-[160px_1fr] md:items-baseline gap-x-6 gap-y-1 py-5 ${
               i < DEMO.length - 1 ? "border-b border-[var(--border-subtle)]" : ""
             }`}
           >
             <span aria-hidden className="story-row__rail" />
-            {/* Outlet name */}
             <span className="story-row__source font-body text-outlet uppercase tracking-wider text-[var(--text)] font-semibold shrink-0">
               {row.outlet}
             </span>
-            {/* Tone badge */}
-            <span
-              className="font-body text-kicker uppercase tracking-wider font-semibold inline-flex items-center gap-1.5 shrink-0"
-              style={{ color: TONE_COLORS[row.tone] }}
-            >
-              <span
-                aria-hidden
-                className="inline-block w-1.5 h-1.5 rounded-full"
-                style={{ background: TONE_COLORS[row.tone] }}
-              />
-              {COPY.stories.toneLabels[row.tone]}
-            </span>
-            {/* Framing line */}
             <span className="font-heading italic text-[17px] md:text-[18px] leading-snug text-[var(--text-secondary)]">
               &ldquo;{row.framing}&rdquo;
             </span>
@@ -93,7 +61,6 @@ export default function ComparisonDemo() {
         ))}
       </div>
 
-      {/* Footer CTA */}
       <div className="mt-5 flex justify-end">
         <Link
           href="/news"

--- a/components/landing/LandingMasthead.tsx
+++ b/components/landing/LandingMasthead.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import Link from "next/link";
+import { CATEGORIES, CATEGORY_COLORS } from "@/lib/constants";
+import { COPY } from "@/lib/copy";
+import { useTheme } from "@/lib/hooks";
+import SiftLogo from "@/components/SiftLogo";
+import type { CategoryId } from "@/lib/types";
+
+const LAUNCH_DATE = new Date("2025-02-23T00:00:00Z");
+
+function issueNumber(now: Date): number {
+  const ms = now.getTime() - LAUNCH_DATE.getTime();
+  const weeks = Math.max(0, Math.floor(ms / (7 * 24 * 60 * 60 * 1000)));
+  return weeks + 1;
+}
+
+function formatMasthead(now: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  })
+    .format(now)
+    .toUpperCase();
+}
+
+export default function LandingMasthead() {
+  const { dark: darkMode, toggle: toggleDark, mounted } = useTheme();
+  const now = new Date();
+
+  return (
+    <header className="border-b border-[var(--border)] bg-[var(--nav-bg)]">
+      {/* Dateline strip */}
+      <div className="border-b border-[var(--border-subtle)]">
+        <div className="max-w-[1200px] mx-auto px-6 h-9 flex items-center justify-between gap-4">
+          <p className="font-body text-outlet uppercase text-[var(--text-secondary)] truncate">
+            <span>Issue №{String(issueNumber(now)).padStart(3, "0")}</span>
+            <span className="mx-2 text-[var(--text-muted)]">·</span>
+            <span>{formatMasthead(now)}</span>
+            <span className="mx-2 text-[var(--text-muted)] hidden sm:inline">·</span>
+            <span className="hidden sm:inline">{COPY.header.tagline}</span>
+          </p>
+
+          <div className="flex items-center gap-3 shrink-0">
+            {mounted && (
+              <button
+                onClick={toggleDark}
+                aria-label={darkMode ? "Switch to light mode" : "Switch to dark mode"}
+                className="font-body text-outlet uppercase tracking-wider text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors"
+              >
+                {darkMode ? "Newsprint" : "Late Edition"}
+              </button>
+            )}
+            <span className="text-[var(--text-muted)]">·</span>
+            <Link
+              href="/news"
+              className="font-body text-outlet uppercase tracking-wider text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline"
+            >
+              Open Sift →
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      {/* Wordmark */}
+      <div className="max-w-[1200px] mx-auto px-6 pt-7 pb-4 flex items-center justify-center">
+        <Link href="/" className="no-underline" aria-label="Sift — home">
+          <SiftLogo variant="full" size={56} />
+        </Link>
+      </div>
+
+      {/* Category nav */}
+      <nav aria-label="Sections" className="border-t border-[var(--border-subtle)]">
+        <div className="max-w-[1200px] mx-auto px-6 h-11 flex items-center gap-x-6 overflow-x-auto whitespace-nowrap scrollbar-none">
+          <Link
+            href="/news"
+            className="font-body text-outlet uppercase tracking-wider text-[var(--text)] hover:text-[var(--accent)] transition-colors no-underline shrink-0"
+          >
+            Today
+          </Link>
+          {CATEGORIES.filter((c) => c.id !== "top").map((cat) => {
+            const color = CATEGORY_COLORS[cat.id as CategoryId];
+            return (
+              <Link
+                key={cat.id}
+                href={`/news?category=${cat.id}`}
+                className="font-body text-outlet uppercase tracking-wider text-[var(--text-muted)] hover:text-[var(--text)] transition-colors no-underline inline-flex items-center gap-2 shrink-0"
+              >
+                <span
+                  aria-hidden
+                  className="inline-block w-1.5 h-1.5 rounded-full"
+                  style={{ background: color.hex }}
+                />
+                {cat.label}
+              </Link>
+            );
+          })}
+        </div>
+      </nav>
+    </header>
+  );
+}

--- a/components/landing/LeadStory.tsx
+++ b/components/landing/LeadStory.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import Link from "next/link";
+import { CATEGORIES, CATEGORY_COLORS } from "@/lib/constants";
+import { COPY } from "@/lib/copy";
+import { timeAgo } from "@/lib/utils";
+import CardImage from "@/components/CardImage";
+import type { Article } from "@/lib/types";
+
+interface LeadStoryProps {
+  article: Article | null;
+}
+
+export default function LeadStory({ article }: LeadStoryProps) {
+  return (
+    <section className="max-w-[1200px] mx-auto px-6 pt-12 pb-10">
+      {article ? <LeadFromDb article={article} /> : <LeadFallback />}
+
+      {/* Editorial explainer paragraph */}
+      <p className="mt-12 max-w-[60ch] mx-auto text-center font-body text-[16px] leading-[1.65] text-[var(--text-secondary)]">
+        {COPY.landing.explainer}
+      </p>
+    </section>
+  );
+}
+
+function LeadFromDb({ article }: { article: Article }) {
+  const cat = CATEGORIES.find((c) => c.id === article.category) || CATEGORIES[0];
+  const color = CATEGORY_COLORS[article.category] || CATEGORY_COLORS.top;
+
+  return (
+    <a
+      href={article.sourceUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="grid grid-cols-1 md:grid-cols-[5fr_7fr] gap-x-10 gap-y-6 group cursor-pointer no-underline pb-10 border-b border-[var(--border)]"
+    >
+      {/* Image */}
+      <div>
+        <CardImage
+          src={article.imageUrl}
+          alt={article.title}
+          featured
+          category={article.category}
+        />
+        <p className="mt-2.5 pt-2 border-t border-[var(--border)] font-body text-outlet uppercase text-[var(--text-muted)] truncate">
+          Photograph · {article.sourceName}
+        </p>
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-col">
+        <p className="font-body text-kicker uppercase text-[var(--text-secondary)] flex items-center mb-4">
+          <span
+            aria-hidden
+            className="inline-block w-1.5 h-1.5 rounded-full mr-2.5"
+            style={{ background: color.hex }}
+          />
+          <span className="text-[var(--accent)] font-semibold">
+            {COPY.landing.leadEyebrow}
+          </span>
+          <span className="mx-2 text-[var(--text-muted)]">·</span>
+          <span>{cat.label}</span>
+        </p>
+
+        <h2
+          className="font-heading text-[28px] sm:text-[34px] md:text-[40px] font-bold leading-[1.08] tracking-tight text-[var(--text)] transition-colors duration-200 group-hover:text-[var(--accent)]"
+        >
+          {article.title}
+        </h2>
+
+        <p className="font-body text-outlet uppercase text-[var(--text-muted)] mt-4 flex flex-wrap items-center gap-x-2">
+          <span className="text-[var(--text-secondary)] font-semibold normal-case tracking-normal text-[12px]">
+            {article.sourceName}
+          </span>
+          <span>·</span>
+          <span>{timeAgo(article.publishedDate)}</span>
+          <span>·</span>
+          <span>{article.readTime} min read</span>
+        </p>
+
+        <p
+          data-dropcap
+          className="font-body text-[16px] text-[var(--text-secondary)] mt-6 leading-[1.65] max-w-[60ch]"
+        >
+          {article.summary}
+        </p>
+
+        <p className="mt-6 font-body text-outlet uppercase text-[var(--text-muted)] inline-flex items-center gap-1.5 transition-colors group-hover:text-[var(--accent)]">
+          {COPY.landing.leadCta} <span aria-hidden>→</span>
+        </p>
+      </div>
+    </a>
+  );
+}
+
+function LeadFallback() {
+  return (
+    <div className="max-w-[640px] mx-auto text-center pt-8 pb-12 border-b border-[var(--border)]">
+      <p className="font-body text-kicker uppercase text-[var(--accent)] mb-4">
+        {COPY.landing.leadEyebrow}
+      </p>
+      <h2 className="font-heading text-[clamp(28px,5vw,40px)] font-bold leading-[1.1] tracking-tight text-[var(--text)] mb-5">
+        {COPY.landing.leadFallbackTitle}
+      </h2>
+      <p className="font-body text-[16px] leading-relaxed text-[var(--text-secondary)] mb-7">
+        {COPY.landing.leadFallbackBody}
+      </p>
+      <Link
+        href="/news"
+        className="font-body text-outlet uppercase tracking-wider text-[var(--accent)] hover:opacity-80 transition-opacity no-underline inline-flex items-center gap-1.5"
+      >
+        {COPY.landing.feedCta} <span aria-hidden>→</span>
+      </Link>
+    </div>
+  );
+}
+
+/* ─── CSS for drop cap ──────────────────────────────────
+   We rely on globals.css [data-dropcap]::first-letter — but that lives
+   in the-digest's globals. Sift's globals.css doesn't have it yet.
+   We inline the rule via a <style jsx global> in LandingPage instead,
+   so it's scoped to landing and doesn't affect the rest of Sift. */

--- a/components/landing/SourceColophon.tsx
+++ b/components/landing/SourceColophon.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { COPY } from "@/lib/copy";
+
+// Curated source list for the colophon. Two columns on desktop, one on mobile.
+// Order roughly matches reader prominence (wires & broadsheets first, then
+// trade press by category). Drop or reorder as the source set changes.
+const SOURCES: string[] = [
+  "Reuters", "Associated Press", "BBC", "NPR",
+  "The New York Times", "The Washington Post", "The Guardian",
+  "Bloomberg", "Financial Times", "The Economist", "Wall Street Journal",
+  "Axios", "Politico", "The Atlantic", "PBS NewsHour",
+  "TechCrunch", "Ars Technica", "The Verge", "Wired", "MIT Tech Review",
+  "Hacker News", "TechMeme",
+  "CNBC", "MarketWatch", "Fortune", "Forbes",
+  "Nature", "Science", "Phys.org", "Scientific American", "NASA",
+  "Quanta Magazine",
+  "CleanTechnica", "Electrek", "Canary Media", "Carbon Brief",
+  "Grist", "Inside Climate News",
+  "Al Jazeera", "DW News", "France 24", "South China Morning Post",
+  "Foreign Policy",
+  "STAT News", "WHO", "The BMJ", "NIH", "The Lancet", "Medscape",
+  "The Hill", "FiveThirtyEight", "RealClearPolitics",
+  "ESPN", "BBC Sport", "The Athletic", "Sports Illustrated",
+  "Variety", "Hollywood Reporter", "Deadline", "Rolling Stone",
+  "Pitchfork", "IGN",
+  "Vox", "ProPublica", "Rest of World",
+];
+
+export default function SourceColophon() {
+  return (
+    <section className="max-w-[1100px] mx-auto px-6 pb-20">
+      <div className="border-t border-b border-[var(--border)] py-9">
+        <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-5 flex items-center">
+          <span aria-hidden className="inline-block w-7 h-px bg-[var(--border)] mr-3" />
+          {COPY.landing.colophonHeading}
+        </p>
+        <ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-1.5 mb-6">
+          {SOURCES.map((s) => (
+            <li
+              key={s}
+              className="font-body text-[13px] text-[var(--text-secondary)] tracking-tight"
+            >
+              {s}
+            </li>
+          ))}
+          <li className="font-body text-[13px] italic text-[var(--text-muted)]">
+            … and others
+          </li>
+        </ul>
+        <p className="font-body text-outlet uppercase tracking-wider text-[var(--text-muted)] pt-5 border-t border-[var(--border-subtle)]">
+          {COPY.landing.colophonSummary}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -94,4 +94,25 @@ export const COPY = {
     body: "Try different words \u2014 or let the AI surprise you.",
     button: "Browse today\u2019s stories",
   },
+  landing: {
+    // Single editorial paragraph below the lead story. The "what is this".
+    explainer:
+      "Sift reads hundreds of sources every morning, summarizes the stories worth knowing, and links back to the originals \u2014 so you can stop checking ten tabs and get on with your day.",
+    leadEyebrow: "Today\u2019s lead",
+    leadFallbackTitle: "Today\u2019s stories are still being filed",
+    leadFallbackBody:
+      "The morning ingest is in progress. Open the feed for what\u2019s already in.",
+    leadCta: "Read in full",
+    feedCta: "Open the full feed",
+    // Section heading for the multi-source comparison demo.
+    compareEyebrow: "How outlets framed it",
+    compareTitle: "The Federal Reserve\u2019s May rate decision",
+    compareSubtitle: "One story, three angles. This is what Sift\u2019s compare view does on every topic.",
+    compareCta: "Compare any topic",
+    // Source colophon.
+    colophonHeading: "Read from",
+    colophonSummary: "100+ outlets \u00b7 10 categories \u00b7 refreshed every 10 minutes",
+    // Footer colophon link.
+    colophonLink: "Colophon",
+  },
 } as const;

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -1,17 +1,19 @@
 // ─── Sift Voice & Tone ──────────────────────────────────
 //
 // Every string in Sift passes through this file.
-// Voice: Bloomberg meets a smart friend. Conversational authority.
+// Voice: the patient teacher who never makes you feel dumb.
+// Authoritative without being preachy. Never partisan. Never editorializing.
 // Rules: contractions always, active voice, no jargon, no exclamation marks.
+// Show the data, link the source, let the reader conclude.
 
 import type { StoryFraming } from "./types";
 
 export const COPY = {
   header: {
-    tagline: "Intelligence, distilled",
+    tagline: "Context, comparison, transparency",
   },
   footer: {
-    main: "Sift reads hundreds of sources so you don't have to. Every story links to the original.",
+    main: "Sift reads hundreds of sources, surfaces the civic context the news assumes you already know, and shows you who's behind every story. Every link goes to the original.",
   },
   error: {
     title: "We hit a snag pulling today's stories",

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -186,6 +186,37 @@ export async function getStoriesWithArticles(
   return { stories, storyArticles, standaloneArticles };
 }
 
+// ─── Landing ───────────────────────────────────────────
+
+/**
+ * Fetch a single hero-quality article for the marketing landing page.
+ * Prefers articles that (a) have an image, (b) sit in the "top" category,
+ * and (c) rank high on importance × recency. Returns null if the DB has
+ * nothing usable — caller renders a fallback layout.
+ */
+export async function getTopStoryForLanding(): Promise<DbArticle | null> {
+  try {
+    const result = await pool.query<DbArticle>(
+      `SELECT id, title, summary, source_url, source_name, image_url,
+              category, published_date, read_time, why_it_matters, importance_score, created_at
+       FROM articles
+       WHERE category = 'top'
+         AND from_search = false
+         AND image_url IS NOT NULL
+         AND summary IS NOT NULL AND summary != ''
+         AND LOWER(summary) NOT LIKE 'unable to provide%'
+       ORDER BY
+         COALESCE(importance_score, 3)::float *
+         EXP(-LEAST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))) / 86400.0, 700))
+       DESC NULLS LAST
+       LIMIT 1`
+    );
+    return result.rows[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function getLastRefreshed(category: string): Promise<Date | null> {
   const result = await pool.query(
     "SELECT last_refreshed_at FROM pipeline_state WHERE category = $1",


### PR DESCRIPTION
## Summary

First commits toward the civic-literacy pivot. See [`plans/sift-civic-literacy.md`](https://github.com/kristenmartino/sift/blob/feat/civic-literacy-pivot-phase-0/plans/sift-civic-literacy.md) for the full multi-phase plan; this PR is **Phase 0** — the lowest-risk first move that establishes the new positioning in code.

The pre-pivot product is preserved at git tag [`v1-general-audience`](https://github.com/kristenmartino/sift/releases/tag/v1-general-audience). The IB-pivot direction is documented as deferred future direction (see `plans/sift-ib-pivot.md`), not actively built.

Two commits in this PR:

### `refactor(landing): rebuild as editorial publication, move tech stack to /colophon` ([`6e7f2da`](https://github.com/kristenmartino/sift/commit/6e7f2da))
Replaces the 6-feature-card SaaS landing with a publication-style home view: real today's-top-story SSR'd from Postgres (ISR @ 600s), a hardcoded multi-source comparison demo, a 60-source colophon, and a colophon-style footer. The relocated tech-stack content now lives at `/colophon`. LandingPage shrinks from ~370 → ~110 lines.

### `feat: civic-literacy pivot — Phase 0 (drop tone labels, reposition copy)` ([`6893471`](https://github.com/kristenmartino/sift/commit/6893471))
Removes tone-label rendering from UI everywhere it appeared (`StoryCard`, `ComparisonDemo`, `globals.css` keyframes + class). Schema fields (`StoryFraming.tone`) and `COPY.stories.toneLabels` lookup remain intact for backward compatibility. Positioning copy shifts from "Intelligence, distilled" → civic-literacy framing across `lib/copy.ts`, `app/layout.tsx`, `app/page.tsx`, and `README.md`.

## What's NOT in this PR

- Schema migrations (Phase 1)
- New LLM pipeline steps (Phase 1+)
- Visual register pass (Phase 5 — sequential after Phase 3)
- Auth changes, backend changes, feature behavior changes

## Test plan

- [x] `npm test` — 79/79 passing across 5 suites
- [x] `npx tsc --noEmit` — clean
- [x] Dev server: `http://localhost:3000` returns HTTP 200 with new positioning strings rendered
- [x] No tone-label artifacts in DOM (no `tone-breathe`, no `story-row__tone-gutter`, no rendered `Straight`/`Pressing`/`Skeptical`/`Hopeful`/`Deep read`)
- [ ] Eyeball deployed preview in both themes (Late Edition + Newsprint) — review locally before merge
- [ ] Eyeball mobile view on `/news`, `/`, `/colophon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)