### PR TITLE
copy: replace tagline with "The news, with footnotes."

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sift
 
-A civic-literacy news app for the American public. Sift reads hundreds of vetted sources, surfaces the civic context the news assumes you already know, compares how outlets across the political spectrum frame the same story, and shows the financial and political ties behind every entity — all linked to public records.
+**The news, with footnotes.** A civic-literacy news app for the American public. Sift reads hundreds of vetted sources, adds the footnotes the news assumes you don't need — civic context, cross-spectrum framing, and the financial and political ties behind every entity — all linked to public records.
 
 **Live:** [siftnews.kristenmartino.ai](https://siftnews.kristenmartino.ai)
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,25 +23,25 @@ const fontBody = Source_Sans_3({
 
 export const metadata: Metadata = {
   title: {
-    default: "Sift — News with context, comparison, and transparency",
+    default: "Sift — The news, with footnotes.",
     template: "%s | Sift",
   },
   description:
-    "Sift reads hundreds of sources and surfaces the civic context the news assumes you already know — with cross-spectrum comparison and the financial and political ties behind every story. Every claim links to a public record.",
+    "Sift reads hundreds of sources and adds the footnotes — the civic context the news assumes, the framing across the political spectrum, and the financial and political ties behind every story. Every claim links to a public record.",
   metadataBase: new URL("https://siftnews.kristenmartino.ai"),
   openGraph: {
-    title: "Sift — Read the news with the context it deserves",
+    title: "Sift — The news, with footnotes.",
     description:
-      "The civics the news assumes. The framing across the political spectrum. The money and politics behind every story. Linked to public records.",
+      "The civic context the news assumes. The framing across the political spectrum. The money behind every story. Linked to public records.",
     siteName: "Sift",
     type: "website",
     locale: "en_US",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Sift — Read the news with the context it deserves",
+    title: "Sift — The news, with footnotes.",
     description:
-      "The civics the news assumes. The framing across the political spectrum. The money and politics behind every story.",
+      "The civic context the news assumes. The framing across the political spectrum. The money behind every story.",
   },
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,10 +5,10 @@ import type { Article, CategoryId } from "@/lib/types";
 
 export const metadata: Metadata = {
   title: {
-    absolute: "Sift — News with context, comparison, and transparency",
+    absolute: "Sift — The news, with footnotes.",
   },
   description:
-    "Read the news with the civic context, cross-spectrum comparison, and source transparency it assumes you already know. Linked to public records. Refreshed every 10 minutes.",
+    "Sift reads hundreds of sources and adds the footnotes the news assumes you don't need — civic context, cross-spectrum framing, and the money behind every story. Linked to public records. Refreshed every 10 minutes.",
 };
 
 // ISR: re-render at most once every 10 minutes — same heartbeat as the

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -10,7 +10,7 @@ import type { StoryFraming } from "./types";
 
 export const COPY = {
   header: {
-    tagline: "Context, comparison, transparency",
+    tagline: "The news, with footnotes",
   },
   footer: {
     main: "Sift reads hundreds of sources, surfaces the civic context the news assumes you already know, and shows you who's behind every story. Every link goes to the original.",


### PR DESCRIPTION
## Summary

Tiny follow-up to [#70](https://github.com/kristenmartino/sift/pull/70). The *"Context, comparison, transparency"* tagline that shipped in Phase 0 read as corporate-values rather than a brand promise.

Replacing it with **"The news, with footnotes."** — four words that:

- Imply sourcing, references, and extra material below the line — which is literally what Phases 2–4 are building (outlet provenance, politician dossiers, glossary tooltips, all linked to public records).
- Leave no room for a "we tell you what to think" misreading.
- Read aloud easy and aren't generic to any other aggregator.

## Where it cascades

- `lib/copy.ts` `header.tagline` — rendered in masthead chrome (mono caps → `THE NEWS, WITH FOOTNOTES.`)
- `app/layout.tsx` — tab title, description, OG title, OG description, Twitter title, Twitter description
- `app/page.tsx` — absolute tab title for the home route + description
- `README.md` top paragraph — positioning lede

Tab title becomes `Sift — The news, with footnotes.`

## Test plan

- [x] `npm test` — 79/79 passing
- [x] `npx tsc --noEmit` — clean
- [ ] Eyeball local: dev server tab title, masthead rendering, OG card preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)