### PR TITLE
fix(StoryCard): dedupe framings by outlet, suppress single-outlet "multi-source" claims

### DIFF
--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -63,6 +63,27 @@ export default function StoryCard({
   }
   const visibleTags = entityTags.slice(0, 6);
 
+  // Dedupe framings by source so a story doesn't claim multi-outlet
+  // coverage when one outlet just published several near-duplicate
+  // articles. The clusterer can group same-outlet posts into a single
+  // story; we should never render that as "How 4 outlets covered this".
+  // Keeps first-seen framing per outlet (preserves the LLM's chosen
+  // representative wording per source).
+  const uniqueFramings = (() => {
+    const sourcesSeen = new Set<string>();
+    return story.framings.filter((f) => {
+      if (sourcesSeen.has(f.sourceName)) return false;
+      sourcesSeen.add(f.sourceName);
+      return true;
+    });
+  })();
+  const uniqueSourceCount = uniqueFramings.length;
+  // Only show multi-source affordances (the "N sources" badge + the
+  // framings section) when there are at least 2 distinct outlets.
+  // Below threshold, the cluster reads as related coverage from one
+  // outlet and the article-list expand still works as intended.
+  const isMultiSource = uniqueSourceCount >= 2;
+
   return (
     <article
       onMouseEnter={() => setHovered(true)}
@@ -114,7 +135,7 @@ export default function StoryCard({
       )}
 
       <div className={`flex flex-col gap-3 ${featured ? "p-7 md:p-8" : "p-5"}`}>
-        {/* Category badge + sources badge */}
+        {/* Category badge + sources badge (only when multi-outlet) */}
         <div className="flex items-center gap-2 flex-wrap">
           <span
             className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wide"
@@ -126,15 +147,17 @@ export default function StoryCard({
           >
             {cat.icon} {cat.label}
           </span>
-          <span
-            className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-[11px] font-bold tracking-wide"
-            style={{
-              background: "var(--accent)",
-              color: "#fff",
-            }}
-          >
-            {COPY.stories.sourcesBadge(story.articleCount)}
-          </span>
+          {isMultiSource && (
+            <span
+              className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-[11px] font-bold tracking-wide"
+              style={{
+                background: "var(--accent)",
+                color: "#fff",
+              }}
+            >
+              {COPY.stories.sourcesBadge(uniqueSourceCount)}
+            </span>
+          )}
         </div>
 
         {/* Headline */}
@@ -183,12 +206,15 @@ export default function StoryCard({
           </div>
         )}
 
-        {/* Framings section */}
-        {story.framings.length > 0 && (
+        {/* Framings section — only render when 2+ unique outlets disagree
+            on framing. Single-outlet clusters (one outlet, multiple
+            near-duplicate articles) skip this section entirely so the card
+            never claims cross-outlet coverage that doesn't exist. */}
+        {isMultiSource && (
           <div className="mt-1">
             <div className="flex items-center gap-3 mb-3">
               <p className="text-kicker font-bold uppercase text-[var(--text-muted)] shrink-0">
-                {COPY.stories.framing(story.framings.length)}
+                {COPY.stories.framing(uniqueSourceCount)}
               </p>
               <span
                 aria-hidden
@@ -196,7 +222,7 @@ export default function StoryCard({
               />
             </div>
             <div className="flex flex-col">
-              {story.framings.map((f) => (
+              {uniqueFramings.map((f) => (
                 <div
                   key={f.sourceName}
                   className="story-row flex items-start gap-4 py-2.5 border-b border-[color:var(--border-subtle)] last:border-b-0"
@@ -214,12 +240,20 @@ export default function StoryCard({
           </div>
         )}
 
-        {/* Empty-framings fallback — articles exist but framings still pending */}
-        {story.framings.length === 0 && story.articles.length > 0 && (
-          <p className="text-body text-[var(--text-muted)] italic">
-            {COPY.stories.analyzingFallback}
-          </p>
-        )}
+        {/* Empty-framings fallback — articles exist but framings still pending.
+            Only shown for multi-outlet clusters; single-outlet clusters render
+            as a regular card (no synthesis pending state). */}
+        {story.framings.length === 0 && story.articles.length > 0 && (() => {
+          const uniqueSourcesInArticles = new Set(
+            story.articles.map((a) => a.sourceName)
+          ).size;
+          if (uniqueSourcesInArticles < 2) return null;
+          return (
+            <p className="text-body text-[var(--text-muted)] italic">
+              {COPY.stories.analyzingFallback}
+            </p>
+          );
+        })()}
 
         {/* Expand/collapse toggle */}
         <button
@@ -266,7 +300,10 @@ export default function StoryCard({
                         className="story-row flex items-center gap-4 py-3 no-underline border-b border-[color:var(--border-subtle)] last:border-b-0"
                         style={{
                           animation: "row-reveal 320ms var(--ease-out-expo) both",
-                          animationDelay: `${(story.framings.length + Math.min(i, 11)) * 24}ms`,
+                          // Stagger after the framings rows when those render;
+                          // otherwise start from zero so the article list
+                          // doesn't pause for invisible framings.
+                          animationDelay: `${((isMultiSource ? uniqueSourceCount : 0) + Math.min(i, 11)) * 24}ms`,
                         }}
                       >
                         <span aria-hidden className="story-row__rail" />


### PR DESCRIPTION
## The bug (with screenshots)

Stories where the clusterer grouped **N near-duplicate articles from a single outlet** were rendering as if N different outlets had covered the same event. Real example from production:

> **Story:** Apple iOS 26.5 RC release
> **Renders as:** *"How 4 outlets covered this"* — followed by 4 framing rows, all labeled `9TO5MAC`, with framings that are slightly different angles on the same 9to5mac coverage.
> **Source list expand:** four `9TO5MAC` rows with near-duplicate truncated headlines (`Apple highl…`, `Apple rolls…`, `Apple debu…`, `Apple relea…`).

This is **trust-violating**: the reader is told they're seeing diverse coverage; they're actually seeing one outlet's editorial decision to write four articles. *Worse than not having the feature*, because it implies cross-outlet consensus that doesn't exist.

## Root cause

Render layer used `story.framings.length` and `story.articleCount` directly, without deduping by `sourceName`. The pipeline correctly clustered these as related coverage; the frontend just didn't notice they're all from one outlet.

## What this PR changes

Render-layer dedupe in [`components/StoryCard.tsx`](https://github.com/kristenmartino/sift/pull/72/files):

- Compute `uniqueFramings` (first-seen per outlet) and `uniqueSourceCount`.
- `isMultiSource = uniqueSourceCount >= 2`.
- **Sources badge** (`4 SOURCES`): hidden when `!isMultiSource`. When shown, uses `uniqueSourceCount`, not `articleCount`.
- **Framings section** (*"How N outlets covered this"*): hidden when `!isMultiSource`. When shown, uses `uniqueSourceCount` and renders `uniqueFramings`.
- **Analyzing fallback** (*"Sources are still being analyzed"*): also gated by unique-source-count derived from `story.articles`, so single-outlet clusters never display a synthesis-pending state for a story that will never have meaningful framings.
- **Row-reveal animation delay** in the article-list expand no longer waits for invisible framings rows.

## What stays

- **Expand button + article list still render.** `View N articles` is accurate — these are real distinct articles, even when from one outlet.
- **Headline, summary, entity tags, meta footer** all render normally. Only the multi-source affordances are gated.
- `story.framings` persisted shape unchanged. `story.articleCount` unchanged.
- No backend / API / DB changes.

## What's NOT in this PR (intentionally)

- **Pipeline-side suppression**: the durable fix is to require ≥2 unique outlets before persisting a cluster as a story (`story_clusterer.py` in `sift-api`). That's a follow-up. This PR is the render-layer guard so the front page stops misleading users immediately.
- **Article-list dedupe**: the four near-duplicate `9TO5MAC` articles in the expand list are still all there. Dedupe-by-source-with-roll-up is a UX call worth its own PR; for this fix the article list stays accurate (these are different articles even if near-duplicate).

## User-visible diff on the screenshot case

| Before | After |
|---|---|
| `◆ TECHNOLOGY  4 SOURCES` | `◆ TECHNOLOGY` |
| *"How 4 outlets covered this"* + 4 framings, all 9TO5MAC | (section hidden) |
| Article list: 4 9TO5MAC entries | (unchanged — these are real distinct articles) |
| Bottom meta: `2h ago · 4 articles` | (unchanged) |

The misleading cross-outlet claim is gone. The card reads as a single-source story with 4 related articles in the expand. Honest.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `npm test` — 79/79 passing
- [ ] Eyeball locally on the same Apple/9to5mac story
- [ ] Eyeball a real multi-source story (e.g., a Fed decision covered by Reuters/WSJ/Bloomberg) and confirm the badge + framings section still render correctly with deduped sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)