### PR TITLE
Civic-literacy MVP Phase 1C — render context_primer in ArticleCard

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -40,6 +40,8 @@ const MOCK_DB_ROWS: DbArticle[] = [
     read_time: 2,
     why_it_matters: null,
     importance_score: null,
+    context_primer: null,
+    reading_levels: null,
     created_at: new Date("2026-03-28T10:00:00Z"),
   },
   {
@@ -54,6 +56,8 @@ const MOCK_DB_ROWS: DbArticle[] = [
     read_time: 3,
     why_it_matters: null,
     importance_score: null,
+    context_primer: null,
+    reading_levels: null,
     created_at: new Date("2026-03-28T08:00:00Z"),
   },
 ];

--- a/__tests__/primer.test.ts
+++ b/__tests__/primer.test.ts
@@ -1,0 +1,242 @@
+import { parseContextPrimer } from "@/lib/primer";
+
+describe("parseContextPrimer", () => {
+  describe("null-returning inputs", () => {
+    it("returns null for null", () => {
+      expect(parseContextPrimer(null)).toBeNull();
+    });
+
+    it("returns null for undefined", () => {
+      expect(parseContextPrimer(undefined)).toBeNull();
+    });
+
+    it("returns null for non-object primitives", () => {
+      expect(parseContextPrimer("not an object")).toBeNull();
+      expect(parseContextPrimer(42)).toBeNull();
+      expect(parseContextPrimer(true)).toBeNull();
+    });
+
+    it("returns null for an empty object (no background, no terms)", () => {
+      expect(parseContextPrimer({})).toBeNull();
+    });
+
+    it("returns null when background is empty AND terms is empty", () => {
+      expect(parseContextPrimer({ background: "", terms: [] })).toBeNull();
+    });
+
+    it("returns null when background is whitespace-only AND terms is empty", () => {
+      expect(parseContextPrimer({ background: "   \n  ", terms: [] })).toBeNull();
+    });
+
+    it("returns null when terms is malformed (all entries dropped) and background is empty", () => {
+      expect(
+        parseContextPrimer({
+          background: "",
+          terms: [{ term: "" }, { foo: "bar" }, "string-not-object"],
+        })
+      ).toBeNull();
+    });
+  });
+
+  describe("happy path", () => {
+    it("parses a primer with background + terms", () => {
+      const result = parseContextPrimer({
+        background: "The Federal Reserve is the central bank of the United States.",
+        terms: [
+          { term: "FOMC", definition: "Federal Open Market Committee." },
+          { term: "basis points", definition: "One-hundredth of a percentage point." },
+        ],
+      });
+      expect(result).not.toBeNull();
+      expect(result?.background).toBe(
+        "The Federal Reserve is the central bank of the United States."
+      );
+      expect(result?.terms).toHaveLength(2);
+      expect(result?.terms[0].term).toBe("FOMC");
+      expect(result?.terms[0].definition).toBe("Federal Open Market Committee.");
+    });
+
+    it("parses a primer with only background (no terms)", () => {
+      const result = parseContextPrimer({
+        background: "Some context.",
+        terms: [],
+      });
+      expect(result?.background).toBe("Some context.");
+      expect(result?.terms).toEqual([]);
+    });
+
+    it("parses a primer with only terms (no background)", () => {
+      const result = parseContextPrimer({
+        background: "",
+        terms: [{ term: "X", definition: "Y" }],
+      });
+      expect(result?.background).toBe("");
+      expect(result?.terms).toHaveLength(1);
+    });
+
+    it("preserves generated_at when present and a string", () => {
+      const result = parseContextPrimer({
+        background: "x",
+        terms: [],
+        generated_at: "2026-05-05T12:00:00Z",
+      });
+      expect(result?.generated_at).toBe("2026-05-05T12:00:00Z");
+    });
+
+    it("omits generated_at when missing or non-string", () => {
+      const a = parseContextPrimer({ background: "x", terms: [] });
+      expect(a?.generated_at).toBeUndefined();
+
+      const b = parseContextPrimer({
+        background: "x",
+        terms: [],
+        generated_at: 12345 as unknown as string,
+      });
+      expect(b?.generated_at).toBeUndefined();
+    });
+  });
+
+  describe("LLM short-key tolerance", () => {
+    it("accepts `def` as an alias for `definition`", () => {
+      const result = parseContextPrimer({
+        background: "x",
+        terms: [{ term: "FOMC", def: "Federal Open Market Committee." }],
+      });
+      expect(result?.terms).toHaveLength(1);
+      expect(result?.terms[0].definition).toBe("Federal Open Market Committee.");
+    });
+
+    it("prefers `definition` over `def` when both present", () => {
+      const result = parseContextPrimer({
+        background: "x",
+        terms: [
+          { term: "FOMC", definition: "canonical", def: "short-key" },
+        ],
+      });
+      expect(result?.terms[0].definition).toBe("canonical");
+    });
+  });
+
+  describe("malformed term filtering", () => {
+    it("drops terms missing the term field", () => {
+      const result = parseContextPrimer({
+        background: "x",
+        terms: [
+          { definition: "no term" },
+          { term: "ok", definition: "valid" },
+        ],
+      });
+      expect(result?.terms).toHaveLength(1);
+      expect(result?.terms[0].term).toBe("ok");
+    });
+
+    it("drops terms missing the definition field", () => {
+      const result = parseContextPrimer({
+        background: "x",
+        terms: [{ term: "FOMC" }, { term: "ok", definition: "valid" }],
+      });
+      expect(result?.terms).toHaveLength(1);
+    });
+
+    it("drops non-object term entries", () => {
+      const result = parseContextPrimer({
+        background: "x",
+        terms: [
+          "not an object",
+          null,
+          42,
+          { term: "ok", definition: "valid" },
+        ],
+      });
+      expect(result?.terms).toHaveLength(1);
+    });
+
+    it("drops terms with whitespace-only strings", () => {
+      const result = parseContextPrimer({
+        background: "x",
+        terms: [
+          { term: "   ", definition: "valid" },
+          { term: "ok", definition: "  " },
+          { term: "good", definition: "fine" },
+        ],
+      });
+      expect(result?.terms).toHaveLength(1);
+      expect(result?.terms[0].term).toBe("good");
+    });
+  });
+
+  describe("HTML stripping", () => {
+    it("strips HTML tags from background", () => {
+      const result = parseContextPrimer({
+        background: "<script>alert(1)</script>Real context.",
+        terms: [],
+      });
+      expect(result?.background).toBe("alert(1)Real context.");
+    });
+
+    it("strips HTML tags from term + definition", () => {
+      const result = parseContextPrimer({
+        background: "x",
+        terms: [
+          { term: "<b>FOMC</b>", definition: "<i>federal</i> committee" },
+        ],
+      });
+      expect(result?.terms[0].term).toBe("FOMC");
+      expect(result?.terms[0].definition).toBe("federal committee");
+    });
+  });
+
+  describe("source field", () => {
+    it("preserves source on terms when present", () => {
+      const result = parseContextPrimer({
+        background: "x",
+        terms: [
+          { term: "FOMC", definition: "committee", source: "Federal Reserve" },
+        ],
+      });
+      expect(result?.terms[0].source).toBe("Federal Reserve");
+    });
+
+    it("omits source when absent or non-string", () => {
+      const a = parseContextPrimer({
+        background: "x",
+        terms: [{ term: "ok", definition: "fine" }],
+      });
+      expect(a?.terms[0].source).toBeUndefined();
+
+      const b = parseContextPrimer({
+        background: "x",
+        terms: [
+          { term: "ok", definition: "fine", source: 123 as unknown as string },
+        ],
+      });
+      expect(b?.terms[0].source).toBeUndefined();
+    });
+  });
+
+  describe("non-array terms tolerance", () => {
+    it("treats non-array terms as empty", () => {
+      const result = parseContextPrimer({
+        background: "real background here",
+        terms: "not an array" as unknown as [],
+      });
+      expect(result?.terms).toEqual([]);
+      expect(result?.background).toBe("real background here");
+    });
+
+    it("treats missing terms field as empty", () => {
+      const result = parseContextPrimer({ background: "x" });
+      expect(result?.terms).toEqual([]);
+    });
+  });
+
+  describe("non-string background tolerance", () => {
+    it("treats non-string background as empty", () => {
+      const result = parseContextPrimer({
+        background: 123 as unknown as string,
+        terms: [{ term: "ok", definition: "fine" }],
+      });
+      expect(result?.background).toBe("");
+    });
+  });
+});

--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -7,6 +7,7 @@ import {
   removeBookmark,
   getBookmarkedArticles,
 } from "@/lib/db";
+import { parseContextPrimer } from "@/lib/primer";
 import type { Article, CategoryId } from "@/lib/types";
 import { checkCsrf } from "@/lib/security";
 
@@ -28,17 +29,23 @@ export async function GET(request: NextRequest) {
 
     if (full) {
       const rows = await getBookmarkedArticles(userId);
-      const articles: Article[] = rows.map((row) => ({
-        id: row.id,
-        title: row.title,
-        summary: row.summary || "",
-        sourceUrl: row.source_url,
-        sourceName: row.source_name,
-        publishedDate: row.published_date ? row.published_date.toISOString() : null,
-        imageUrl: row.image_url,
-        category: row.category as CategoryId,
-        readTime: row.read_time || 1,
-      }));
+      const articles: Article[] = rows.map((row) => {
+        const primer = parseContextPrimer(row.context_primer);
+        return {
+          id: row.id,
+          title: row.title,
+          summary: row.summary || "",
+          sourceUrl: row.source_url,
+          sourceName: row.source_name,
+          publishedDate: row.published_date ? row.published_date.toISOString() : null,
+          imageUrl: row.image_url,
+          category: row.category as CategoryId,
+          readTime: row.read_time || 1,
+          ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
+          ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
+          ...(primer ? { contextPrimer: primer } : {}),
+        };
+      });
       return NextResponse.json({ articles });
     }
 

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getStoriesWithArticles, getLastRefreshed } from "@/lib/db";
+import { parseContextPrimer } from "@/lib/primer";
 import { stripHtml, sanitizeUrl } from "@/lib/sanitize";
 import type { CategoryId, Article, Story, StoryFraming, EntitySet, NewsApiResponse, NewsApiError } from "@/lib/types";
 
@@ -57,24 +58,9 @@ export async function GET(request: NextRequest) {
     ]);
 
     // Map standalone articles
-    const articles: Article[] = standaloneArticles.map((row) => ({
-      id: row.id,
-      title: row.title,
-      summary: cleanSummary(row.summary),
-      sourceUrl: row.source_url,
-      sourceName: row.source_name,
-      publishedDate: row.published_date ? row.published_date.toISOString() : null,
-      imageUrl: cleanImageUrl(row.image_url),
-      category: row.category as CategoryId,
-      readTime: row.read_time || 1,
-      ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
-      ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
-    }));
-
-    // Map stories with nested articles
-    const stories: Story[] = dbStories.map((s) => {
-      const childRows = storyArticles[s.id] || [];
-      const childArticles: Article[] = childRows.map((row) => ({
+    const articles: Article[] = standaloneArticles.map((row) => {
+      const primer = parseContextPrimer(row.context_primer);
+      return {
         id: row.id,
         title: row.title,
         summary: cleanSummary(row.summary),
@@ -86,7 +72,30 @@ export async function GET(request: NextRequest) {
         readTime: row.read_time || 1,
         ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
         ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
-      }));
+        ...(primer ? { contextPrimer: primer } : {}),
+      };
+    });
+
+    // Map stories with nested articles
+    const stories: Story[] = dbStories.map((s) => {
+      const childRows = storyArticles[s.id] || [];
+      const childArticles: Article[] = childRows.map((row) => {
+        const primer = parseContextPrimer(row.context_primer);
+        return {
+          id: row.id,
+          title: row.title,
+          summary: cleanSummary(row.summary),
+          sourceUrl: row.source_url,
+          sourceName: row.source_name,
+          publishedDate: row.published_date ? row.published_date.toISOString() : null,
+          imageUrl: cleanImageUrl(row.image_url),
+          category: row.category as CategoryId,
+          readTime: row.read_time || 1,
+          ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
+          ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
+          ...(primer ? { contextPrimer: primer } : {}),
+        };
+      });
 
       // Parse JSONB framings (validate types, sanitize external text)
       const rawFramings = Array.isArray(s.framings) ? s.framings : [];

--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
 import { searchArticlesByEmbedding, insertArticle } from "@/lib/db";
+import { parseContextPrimer } from "@/lib/primer";
 import { stableHash, estimateReadTime } from "@/lib/utils";
 import { stripHtml, sanitizeUrl } from "@/lib/sanitize";
 import type { Article, CategoryId } from "@/lib/types";
@@ -193,21 +194,25 @@ export async function GET(request: NextRequest) {
         );
 
         // 3. Map DB rows to Article type
-        const articles: Article[] = rows.map((row) => ({
-          id: row.id,
-          title: row.title,
-          summary: cleanSummary(row.summary),
-          sourceUrl: row.source_url,
-          sourceName: row.source_name,
-          publishedDate: row.published_date
-            ? row.published_date.toISOString()
-            : null,
-          imageUrl: cleanImageUrl(row.image_url),
-          category: row.category as CategoryId,
-          readTime: row.read_time || 1,
-          ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
-          ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
-        }));
+        const articles: Article[] = rows.map((row) => {
+          const primer = parseContextPrimer(row.context_primer);
+          return {
+            id: row.id,
+            title: row.title,
+            summary: cleanSummary(row.summary),
+            sourceUrl: row.source_url,
+            sourceName: row.source_name,
+            publishedDate: row.published_date
+              ? row.published_date.toISOString()
+              : null,
+            imageUrl: cleanImageUrl(row.image_url),
+            category: row.category as CategoryId,
+            readTime: row.read_time || 1,
+            ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
+            ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
+            ...(primer ? { contextPrimer: primer } : {}),
+          };
+        });
 
         // 4. Stream vector results immediately
         if (articles.length > 0) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import LandingPage from "@/components/LandingPage";
 import { getTopStoryForLanding } from "@/lib/db";
+import { parseContextPrimer } from "@/lib/primer";
 import type { Article, CategoryId } from "@/lib/types";
 
 export const metadata: Metadata = {
@@ -18,6 +19,7 @@ export const revalidate = 600;
 
 export default async function Home() {
   const lead = await getTopStoryForLanding();
+  const primer = lead ? parseContextPrimer(lead.context_primer) : null;
   const leadStory: Article | null = lead
     ? {
         id: lead.id,
@@ -31,6 +33,7 @@ export default async function Home() {
         readTime: lead.read_time,
         whyItMatters: lead.why_it_matters ?? undefined,
         importanceScore: lead.importance_score ?? undefined,
+        ...(primer ? { contextPrimer: primer } : {}),
       }
     : null;
 

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -5,6 +5,7 @@ import { CATEGORIES, CATEGORY_COLORS } from "@/lib/constants";
 import { COPY } from "@/lib/copy";
 import { timeAgo } from "@/lib/utils";
 import CardImage from "./CardImage";
+import BackgroundPrimer from "./primer/BackgroundPrimer";
 import type { ArticleCardProps } from "@/lib/types";
 
 // Fan-out stagger: even-indexed cards drift from left, odd from right
@@ -194,6 +195,17 @@ export default function ArticleCard({
           >
             {article.whyItMatters}
           </p>
+        )}
+
+        {/* Background primer ("What you should know first") — civic-literacy
+            MVP Phase 1C. Renders nothing when contextPrimer is absent.
+            Featured cards default expanded so the primer is visible without a
+            click; standard cards default collapsed to keep feed scannable. */}
+        {article.contextPrimer && (
+          <BackgroundPrimer
+            primer={article.contextPrimer}
+            defaultExpanded={!!featured}
+          />
         )}
 
         {/* Meta */}

--- a/components/primer/BackgroundPrimer.tsx
+++ b/components/primer/BackgroundPrimer.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+import { COPY } from "@/lib/copy";
+import type { ContextPrimer } from "@/lib/types";
+
+interface BackgroundPrimerProps {
+  primer: ContextPrimer | null | undefined;
+  /**
+   * Default expanded state. Cards in dense feeds default to collapsed (a small
+   * "Show context" toggle), while detail pages or hero positions can default
+   * to expanded. Per-card collapse state is local; no localStorage persistence
+   * in this first cut — Phase 1C just renders the affordance.
+   */
+  defaultExpanded?: boolean;
+}
+
+/**
+ * Renders the "What you should know first" panel for an article.
+ *
+ * Hides itself entirely when there's no primer data. Otherwise renders a small
+ * collapsed pill ("Show context ▾") that expands inline to reveal the
+ * background paragraph and key terms, both AI-generated at ingest by the
+ * primer pipeline (sift-api/services/primer_generator.py).
+ *
+ * The voice doc lives at sift-api/services/primer_generator.py — patient
+ * teacher, never preachy, never partisan, never editorializing. The component
+ * just plumbs the structured output into HTML; the editorial discipline is
+ * upstream.
+ */
+export default function BackgroundPrimer({
+  primer,
+  defaultExpanded = false,
+}: BackgroundPrimerProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  if (!primer) return null;
+
+  const { background, terms } = primer;
+  if (!background && terms.length === 0) return null;
+
+  return (
+    <div className="my-1">
+      {!expanded && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            setExpanded(true);
+          }}
+          aria-expanded={false}
+          className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-bold tracking-[0.04em] uppercase border border-[var(--border)] bg-transparent text-[var(--text-secondary)] hover:text-[var(--text)] hover:border-[var(--text-muted)] transition-colors duration-200 cursor-pointer"
+        >
+          <span aria-hidden>◆</span>
+          <span>{COPY.primer.eyebrow}</span>
+          <span aria-hidden className="text-[var(--text-muted)]">▾</span>
+        </button>
+      )}
+
+      {expanded && (
+        <div
+          className="rounded-[10px] border border-[var(--border-subtle)] p-3.5"
+          style={{
+            background: "var(--well-bg)",
+          }}
+        >
+          {/* Eyebrow + collapse */}
+          <div className="flex items-center justify-between gap-3 mb-2.5">
+            <p className="text-kicker font-bold uppercase text-[var(--text-muted)]">
+              <span aria-hidden className="mr-1.5">◆</span>
+              {COPY.primer.eyebrow}
+            </p>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setExpanded(false);
+              }}
+              aria-expanded={true}
+              className="text-meta uppercase tracking-wider text-[var(--text-secondary)] hover:text-[var(--text)] cursor-pointer transition-colors duration-200 bg-transparent border-none p-0"
+            >
+              {COPY.primer.hide} <span aria-hidden>▴</span>
+            </button>
+          </div>
+
+          {/* Background paragraph */}
+          {background && (
+            <p className="text-body text-[var(--text-secondary)] leading-relaxed mb-3">
+              {background}
+            </p>
+          )}
+
+          {/* Key terms */}
+          {terms.length > 0 && (
+            <div>
+              <p className="text-meta uppercase tracking-wider font-semibold text-[var(--text-muted)] mb-2">
+                {COPY.primer.termsLabel}
+              </p>
+              <dl className="flex flex-col gap-1.5">
+                {terms.map((t) => (
+                  <div key={t.term} className="text-body leading-snug">
+                    <dt className="inline font-semibold text-[var(--text)]">
+                      {t.term}
+                    </dt>
+                    <dd className="inline text-[var(--text-secondary)]">
+                      {" — "}
+                      {t.definition}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -96,6 +96,15 @@ export const COPY = {
     body: "Try different words \u2014 or let the AI surprise you.",
     button: "Browse today\u2019s stories",
   },
+  primer: {
+    // Eyebrow shown above the collapsed/expanded primer panel.
+    eyebrow: "What you should know first",
+    // Toggle button copy. Closed \u2192 opens; open \u2192 closes.
+    show: "Show context",
+    hide: "Hide context",
+    // Section header inside the expanded primer when there are key terms.
+    termsLabel: "Key terms",
+  },
   landing: {
     // Single editorial paragraph below the lead story. The "what is this".
     explainer:

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -27,6 +27,14 @@ export interface DbArticle {
   why_it_matters: string | null;
   importance_score: number | null;
   created_at: Date;
+  // Civic-literacy MVP additions. Both columns added in
+  // sift-api/migrations/005_context_primer_and_reading_levels.sql.
+  // context_primer is populated by Phase 1A primer_generator;
+  // reading_levels is reserved for Phase 1B (always NULL today).
+  // pg returns JSONB as already-parsed objects, so type as `unknown`
+  // here and validate at the API boundary via lib/primer.ts.
+  context_primer: unknown;
+  reading_levels: unknown;
 }
 
 export async function getArticlesByCategory(
@@ -35,7 +43,7 @@ export async function getArticlesByCategory(
 ): Promise<DbArticle[]> {
   const result = await pool.query<DbArticle>(
     `SELECT id, title, summary, source_url, source_name, image_url,
-            category, published_date, read_time, why_it_matters, importance_score, created_at
+            category, published_date, read_time, why_it_matters, importance_score, context_primer, reading_levels, created_at
      FROM articles
      WHERE category = $1 AND from_search = false
        AND summary IS NOT NULL AND summary != ''
@@ -120,7 +128,7 @@ export async function getStoriesWithArticles(
     try {
       const storyArticlesResult = await pool.query<DbStoryArticle>(
         `SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, created_at, story_id
+                category, published_date, read_time, why_it_matters, importance_score, context_primer, reading_levels, created_at, story_id
          FROM articles
          WHERE story_id = ANY($1::text[])
            AND from_search = false
@@ -149,7 +157,7 @@ export async function getStoriesWithArticles(
   try {
     const standaloneResult = await pool.query<DbArticle>(
       `SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, created_at
+              category, published_date, read_time, why_it_matters, importance_score, context_primer, reading_levels, created_at
        FROM articles
        WHERE category = $1 AND from_search = false
          AND (story_id IS NULL OR story_id <> ALL($2::text[]))
@@ -168,7 +176,7 @@ export async function getStoriesWithArticles(
     if (!msg.includes("story_id")) throw err;
     const fallback = await pool.query<DbArticle>(
       `SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, created_at
+              category, published_date, read_time, why_it_matters, importance_score, context_primer, reading_levels, created_at
        FROM articles
        WHERE category = $1 AND from_search = false
          AND summary IS NOT NULL AND summary != ''
@@ -198,7 +206,7 @@ export async function getTopStoryForLanding(): Promise<DbArticle | null> {
   try {
     const result = await pool.query<DbArticle>(
       `SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, created_at
+              category, published_date, read_time, why_it_matters, importance_score, context_primer, reading_levels, created_at
        FROM articles
        WHERE category = 'top'
          AND from_search = false
@@ -261,7 +269,8 @@ export async function removeBookmark(userId: string, articleId: string): Promise
 export async function getBookmarkedArticles(userId: string): Promise<DbArticle[]> {
   const result = await pool.query<DbArticle>(
     `SELECT a.id, a.title, a.summary, a.source_url, a.source_name, a.image_url,
-            a.category, a.published_date, a.read_time, a.why_it_matters, a.importance_score, a.created_at
+            a.category, a.published_date, a.read_time, a.why_it_matters, a.importance_score,
+            a.context_primer, a.reading_levels, a.created_at
      FROM articles a
      JOIN bookmarks b ON b.article_id = a.id
      WHERE b.user_id = $1
@@ -294,7 +303,7 @@ export async function searchArticlesByEmbedding(
   const vectorStr = toVectorString(embedding);
   const result = await pool.query<DbArticle & { similarity: number }>(
     `SELECT id, title, summary, source_url, source_name, image_url,
-            category, published_date, read_time, why_it_matters, importance_score, created_at,
+            category, published_date, read_time, why_it_matters, importance_score, context_primer, reading_levels, created_at,
             1 - (embedding <=> $1::vector) AS similarity
      FROM articles
      WHERE embedding IS NOT NULL

--- a/lib/primer.ts
+++ b/lib/primer.ts
@@ -1,0 +1,55 @@
+/**
+ * Parse the JSONB context_primer column from Postgres into the canonical
+ * ContextPrimer shape, with defensive validation. Returns null for any row
+ * whose primer is missing, malformed, or fully empty (so the UI's "no
+ * primer data" branch fires).
+ *
+ * The pipeline (sift-api/services/primer_generator.py) writes:
+ *   { background: string, terms: [{ term, definition }], generated_at: ISO }
+ *
+ * Empty primers (background: "" + terms: []) are NOT persisted — see the
+ * primer_generator's _parse_primers and process_primer_batch_results, which
+ * skip writes for those. So a non-null primer here always has *something*
+ * worth rendering, but we still defend against bad shapes.
+ */
+import { stripHtml } from "./sanitize";
+import type { ContextPrimer, ContextPrimerTerm } from "./types";
+
+export function parseContextPrimer(raw: unknown): ContextPrimer | null {
+  if (!raw || typeof raw !== "object") return null;
+
+  const obj = raw as Record<string, unknown>;
+  const background =
+    typeof obj.background === "string" ? stripHtml(obj.background).trim() : "";
+
+  const rawTerms = Array.isArray(obj.terms) ? obj.terms : [];
+  const terms: ContextPrimerTerm[] = rawTerms
+    .filter((t): t is Record<string, unknown> => typeof t === "object" && t !== null)
+    .map((t) => {
+      const term = typeof t.term === "string" ? stripHtml(t.term).trim() : "";
+      // Tolerate both `definition` (canonical) and `def` (LLM short-key form
+      // that occasionally leaks past the parse step in primer_generator).
+      const def =
+        typeof t.definition === "string"
+          ? stripHtml(t.definition).trim()
+          : typeof t.def === "string"
+            ? stripHtml(t.def).trim()
+            : "";
+      const source = typeof t.source === "string" ? stripHtml(t.source).trim() : undefined;
+      return { term, definition: def, ...(source ? { source } : {}) };
+    })
+    .filter((t) => t.term && t.definition);
+
+  // If the primer is structurally present but holds nothing renderable,
+  // treat as null so the UI hides the affordance entirely.
+  if (!background && terms.length === 0) return null;
+
+  const generated_at =
+    typeof obj.generated_at === "string" ? obj.generated_at : undefined;
+
+  return {
+    background,
+    terms,
+    ...(generated_at ? { generated_at } : {}),
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -30,6 +30,37 @@ export interface Article {
   readTime: number;
   whyItMatters?: string;
   importanceScore?: number;
+  /**
+   * AI-generated "What you should know first" panel — civic-literacy MVP.
+   * Populated by sift-api's primer_generator. Null/undefined when the article
+   * is short enough to need no context, or when the pipeline hasn't run for it
+   * yet. UI tolerates absence (BackgroundPrimer renders nothing).
+   */
+  contextPrimer?: ContextPrimer | null;
+  /**
+   * Reading-level alternates — civic-literacy MVP Phase 1B (not yet
+   * populated). Forward-declared here so the type contract is stable when
+   * the pipeline starts writing this field.
+   */
+  readingLevels?: ReadingLevels | null;
+}
+
+export interface ContextPrimerTerm {
+  term: string;
+  definition: string;
+  source?: string;
+}
+
+export interface ContextPrimer {
+  background: string;
+  terms: ContextPrimerTerm[];
+  generated_at?: string;
+}
+
+export interface ReadingLevels {
+  simpler?: { headline?: string; summary?: string };
+  detailed?: { headline?: string; summary?: string };
+  generated_at?: string;
 }
 
 // ─── Story Types ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Makes the AI-generated *"What you should know first"* panel visible to readers. Phase 1A ([sift-api #19](https://github.com/kristenmartino/sift-api/pull/19), merged) populates the data; this PR plumbs it through the type system, API mappings, and into a new `BackgroundPrimer` component rendered inline on every `ArticleCard`.

After merge: ~2,263 articles in prod immediately show a primer affordance. New articles continue gaining primers via the live pipeline path (Batch API, 50% off).

## What ships

| Layer | Change |
|---|---|
| **Types** | `Article.contextPrimer` (+ `readingLevels` forward-declared for Phase 1B); new `ContextPrimer`, `ContextPrimerTerm`, `ReadingLevels` interfaces. |
| **Parser** | `lib/primer.ts` — defensive JSONB validator that returns null for missing / malformed / empty primers. Tolerates LLM short-key drift (`def` vs `definition`). Strips HTML. Used at every API boundary. |
| **Database** | All 7 `DbArticle`-returning queries in `lib/db.ts` extended to select `context_primer` + `reading_levels`. `DbArticle` interface updated. |
| **API mapping** | 4 sites: `app/api/news/route.ts` (×2), `app/api/news/topic/route.ts`, `app/api/bookmarks/route.ts`, `app/page.tsx` (landing lead). |
| **Component** | `components/primer/BackgroundPrimer.tsx` — collapsed-by-default pill, expands inline to show background paragraph + key terms in a `dt/dl`. Renders nothing when primer is null/empty. |
| **Integration** | `ArticleCard` renders the primer between *"why it matters"* and the meta footer. Featured cards default expanded; standard cards default collapsed. |
| **Copy** | `COPY.primer` block — eyebrow, show/hide toggles, terms label. |

Bonus side-fix uncovered while extending the bookmarks mapping: the `/api/bookmarks?full=1` endpoint was previously dropping `whyItMatters` and `importanceScore` en route to the client. Fixed in the same diff.

## What this does NOT do

- **No StoryCard rendering.** Stories are clusters; the primer column is per-article. Story-level primer is a separate surface decision.
- **No prompt/pipeline changes.** Voice was validated [in the Phase 1A backfill investigation](https://github.com/kristenmartino/sift-api/issues/21#issuecomment-4381153888) (200-sample voice-check, both flagged drift candidates were false positives).
- **No localStorage persistence** for per-card collapsed state. Local component state for now.
- **No Phase 1B** (reading-level adjuster) — `readingLevels` is forward-declared in the type but never populated; UI doesn't reference it.

## Verification

- [x] `tsc --noEmit` — clean
- [x] `npm test` — 79/79 passing across 5 suites
- [x] `GET /api/news?category=technology` against prod DB returns **65/66 articles** with `contextPrimer` populated. Sampled primer (a Pennsylvania-sues-Character.AI story) has clean voice — factual background, terms `chatbot` + `misrepresentation` defined plainly. Voice rules holding.
- [ ] **Visual eyeball pending** — preview iframe in this environment is stuck on an `Awaiting server…` interstitial (same quirk we hit during landing-rewrite testing). Server itself is healthy; iframe just doesn't navigate. Reviewer can verify locally: `npm run dev` → `/news?category=technology` → spot-check a few cards expand the primer cleanly.

## Pre-existing UI caveat (not blocking)

[#72](https://github.com/kristenmartino/sift/pull/72) (StoryCard dedupe-by-outlet) is still open. That PR's render-layer fix and this PR don't conflict — they touch different components — but if #72 lands first we'll want to make sure StoryCards in the wild correctly dedupe when surrounded by primer-bearing ArticleCards. Easy to verify post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)