### PR TITLE
fix(primer): clicks fall through to article link + drop "Key terms" label

### DIFF
--- a/components/primer/BackgroundPrimer.tsx
+++ b/components/primer/BackgroundPrimer.tsx
@@ -27,6 +27,13 @@ interface BackgroundPrimerProps {
  * teacher, never preachy, never partisan, never editorializing. The component
  * just plumbs the structured output into HTML; the editorial discipline is
  * upstream.
+ *
+ * z-index note: ArticleCard makes the entire card clickable via a stretched
+ * <a><span absolute inset-0 z-[1]> overlay. Anything inside the card that
+ * needs its own click target (bookmark button, primer toggle) must be
+ * relatively-positioned with z-[2]+ to sit above that overlay. The wrapping
+ * `relative z-[2]` on the outer div here makes the entire primer surface
+ * (collapsed pill + expanded panel) opt out of the card-link click handler.
  */
 export default function BackgroundPrimer({
   primer,
@@ -40,7 +47,7 @@ export default function BackgroundPrimer({
   if (!background && terms.length === 0) return null;
 
   return (
-    <div className="my-1">
+    <div className="my-1 relative z-[2]">
       {!expanded && (
         <button
           type="button"
@@ -63,6 +70,9 @@ export default function BackgroundPrimer({
           style={{
             background: "var(--well-bg)",
           }}
+          // Defensive: stop bubbling to the card-link overlay even on
+          // background clicks within the panel (text selection, e.g.).
+          onClick={(e) => e.stopPropagation()}
         >
           {/* Eyebrow + collapse */}
           <div className="flex items-center justify-between gap-3 mb-2.5">
@@ -90,26 +100,22 @@ export default function BackgroundPrimer({
             </p>
           )}
 
-          {/* Key terms */}
+          {/* Term/definition list — no "Key terms" label. Renders as a
+              reference panel rather than a textbook glossary. */}
           {terms.length > 0 && (
-            <div>
-              <p className="text-meta uppercase tracking-wider font-semibold text-[var(--text-muted)] mb-2">
-                {COPY.primer.termsLabel}
-              </p>
-              <dl className="flex flex-col gap-1.5">
-                {terms.map((t) => (
-                  <div key={t.term} className="text-body leading-snug">
-                    <dt className="inline font-semibold text-[var(--text)]">
-                      {t.term}
-                    </dt>
-                    <dd className="inline text-[var(--text-secondary)]">
-                      {" — "}
-                      {t.definition}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-            </div>
+            <dl className="flex flex-col gap-1.5">
+              {terms.map((t) => (
+                <div key={t.term} className="text-body leading-snug">
+                  <dt className="inline font-semibold text-[var(--text)]">
+                    {t.term}
+                  </dt>
+                  <dd className="inline text-[var(--text-secondary)]">
+                    {" — "}
+                    {t.definition}
+                  </dd>
+                </div>
+              ))}
+            </dl>
           )}
         </div>
       )}


### PR DESCRIPTION
## Two small fixes from living with the product post-#73

### 1. Click bug (the main one you flagged)

Clicking the **"What you should know first ▾"** pill on an ArticleCard navigated to the source article instead of expanding the primer panel.

**Why:** ArticleCard makes the whole card clickable via a stretched-overlay pattern — `<a><span className="absolute inset-0 z-[1]" /></a>`. Anything inside the card that needs its own click target must be relatively-positioned at `z-[2]+` to sit above that overlay. The bookmark button has it (`relative z-[2]`); the compare button has it; **my primer toggle didn't.** Click landed on the overlay first.

**Fix:** wrap the entire primer surface in `relative z-[2]`. Also added a defensive `onClick={e => e.stopPropagation()}` on the expanded panel itself so even background clicks (during text selection, etc.) don't bubble to the overlay.

### 2. "Key terms" label was reading as a school worksheet

You asked: *"Key terms — too directed at kids?"* Honest read after thinking it through:

- **Reading level (~8th grade)** — *correct for adults.* NYT writes at ~9th, NPR at 8th, BBC at 8–9th. Most US adults read 7th–10th. 8th grade plain language is mainstream-adult, not childish.
- **Term selection** (FOMC, filibuster, antitrust review, basis points) — *correct.* These are real civic-vocabulary stumbles for adults, not kid words.
- **The `KEY TERMS` sub-header above the list** — *that was the kid-coded thing.* Wikipedia doesn't have it. Britannica doesn't. Investopedia doesn't. K-12 textbooks do.

**Fix:** removed the sub-header. The term/definition pairs render directly under the background paragraph. Reads as a reference panel now, not a textbook glossary.

`COPY.primer.termsLabel` stays in `lib/copy.ts` as an unrendered string — cheap, doesn't break tests, easy to bring back if a future treatment wants the label again.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `npm test` — 104/104 still passing across 6 suites (no test referenced `termsLabel`)
- [ ] Eyeball after merge: click the pill on a populated card and confirm it expands instead of navigating; eyeball the expanded panel and confirm the term list reads as a reference block, not a worksheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)