### PR TITLE
copy: replace "hundreds of sources" / "100+ outlets" with curated-50 framing (Phase 2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sift
 
-**The news, with footnotes.** A civic-literacy news app for the American public. Sift reads hundreds of vetted sources, adds the footnotes the news assumes you don't need — civic context, cross-spectrum framing, and the financial and political ties behind every entity — all linked to public records.
+**The news, with footnotes.** A civic-literacy news app for the American public. Sift reads from ~50 vetted outlets across the political spectrum, adds the footnotes the news assumes you don't need — civic context, cross-spectrum framing, and the financial and political ties behind every entity — all linked to public records.
 
 **Live:** [siftnews.kristenmartino.ai](https://siftnews.kristenmartino.ai)
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
     template: "%s | Sift",
   },
   description:
-    "Sift reads hundreds of sources and adds the footnotes — the civic context the news assumes, the framing across the political spectrum, and the financial and political ties behind every story. Every claim links to a public record.",
+    "Sift reads from ~50 vetted outlets across the political spectrum and adds the footnotes — the civic context the news assumes, the framing across the spectrum, and the financial and political ties behind every story. Every claim links to a public record.",
   metadataBase: new URL("https://siftnews.kristenmartino.ai"),
   openGraph: {
     title: "Sift — The news, with footnotes.",

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -13,7 +13,7 @@ export const COPY = {
     tagline: "The news, with footnotes",
   },
   footer: {
-    main: "Sift reads hundreds of sources, surfaces the civic context the news assumes you already know, and shows you who's behind every story. Every link goes to the original.",
+    main: "Sift reads from ~50 vetted outlets across the political spectrum, surfaces the civic context the news assumes you already know, and shows you who's behind every story. Every link goes to the original.",
   },
   error: {
     title: "We hit a snag pulling today's stories",
@@ -108,7 +108,7 @@ export const COPY = {
   landing: {
     // Single editorial paragraph below the lead story. The "what is this".
     explainer:
-      "Sift reads hundreds of sources every morning, summarizes the stories worth knowing, and links back to the originals \u2014 so you can stop checking ten tabs and get on with your day.",
+      "Sift reads from ~50 vetted outlets every morning, summarizes the stories worth knowing, and links back to the originals \u2014 so you can stop checking ten tabs and get on with your day.",
     leadEyebrow: "Today\u2019s lead",
     leadFallbackTitle: "Today\u2019s stories are still being filed",
     leadFallbackBody:
@@ -122,7 +122,7 @@ export const COPY = {
     compareCta: "Compare any topic",
     // Source colophon.
     colophonHeading: "Read from",
-    colophonSummary: "100+ outlets \u00b7 10 categories \u00b7 refreshed every 10 minutes",
+    colophonSummary: "~50 vetted outlets \u00b7 across the political spectrum \u00b7 refreshed every 10 minutes",
     // Footer colophon link.
     colophonLink: "Colophon",
   },


### PR DESCRIPTION
## Summary

Companion to [sift-api#23](https://github.com/kristenmartino/sift-api/pull/23), which trims the RSS source whitelist from ~110 feeds to 54 across ~40 canonical outlets. This PR aligns the user-visible marketing copy with that ingest reality.

## Why

The *"hundreds of sources"* / *"100+ outlets"* claim was inherited from the pre-pivot positioning where **breadth** was the pitch. Civic-literacy positioning values **curation quality** over volume — *"~50 vetted outlets across the political spectrum"* is a stronger pitch than *"100+ sources"* with no enumeration. The next-up Phase 2.A (outlet_profiles seed + publish at `/methodology`) makes the "~50" claim audit-able.

## Sites updated (5 strings across 4 files)

| File | Before | After |
|---|---|---|
| `lib/copy.ts` `footer.main` | *"Sift reads **hundreds of sources**..."* | *"Sift reads from **~50 vetted outlets across the political spectrum**..."* |
| `lib/copy.ts` `landing.explainer` | *"Sift reads **hundreds of sources** every morning..."* | *"Sift reads from **~50 vetted outlets** every morning..."* |
| `lib/copy.ts` `landing.colophonSummary` | *"**100+ outlets** · 10 categories · refreshed every 10 minutes"* | *"**~50 vetted outlets** · **across the political spectrum** · refreshed every 10 minutes"* |
| `app/layout.tsx` `metadata.description` | *"Sift reads **hundreds of sources** and adds the footnotes..."* | *"Sift reads from **~50 vetted outlets across the political spectrum** and adds the footnotes..."* |
| `README.md` top paragraph | *"Sift reads **hundreds of vetted sources**..."* | *"Sift reads from **~50 vetted outlets across the political spectrum**..."* |

The `~` prefix accommodates final-list flex. Current count: **52** (50 from the initial list + Foreign Affairs, American Conservative, Bulwark added during walkthrough; Newsmax dropped over Low/Mixed factual record + defamation-suit history). Phase 2.D's `/methodology` page publishes the exact set.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 104/104 across 6 suites
- [ ] Eyeball after merge: tab title, OG card description, masthead colophon, `/news` footer all reflect the new framing

## Why now (Phase 2.0)

Bringing marketing into line with reality is cheap. Doing it before Phase 2.A's seed work means the seed can confidently target ~52 outlets without "but we promised 100+" pushback later. The two PRs (this + sift-api#23) merge as a pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)