### PR TITLE
feat: civic-literacy MVP Phase 2.B — outlet badges in feed cards

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -18,9 +18,14 @@ const mockGetStoriesWithArticles = jest.fn<
 >();
 const mockGetLastRefreshed = jest.fn<Promise<Date | null>, [string]>();
 
+// Phase 2.B: outlet provenance map. Tests pre-date the lookup, so default to
+// an empty Map (= no curated outlets resolved → API returns articles with
+// outlet absent, which is the graceful-degradation path the UI tolerates).
 jest.mock("@/lib/db", () => ({
   getStoriesWithArticles: (...args: [string]) => mockGetStoriesWithArticles(...args),
   getLastRefreshed: (...args: [string]) => mockGetLastRefreshed(...args),
+  getOutletProfilesMap: jest.fn().mockResolvedValue(new Map()),
+  resolveOutletForSourceName: jest.fn().mockReturnValue(null),
 }));
 
 import { GET } from "../app/api/news/route";

--- a/__tests__/outlet.test.ts
+++ b/__tests__/outlet.test.ts
@@ -1,0 +1,175 @@
+import {
+  formatAllSidesLabel,
+  formatMbfcLabel,
+  parseDbOutletProfile,
+  type DbOutletProfileRow,
+} from "@/lib/outlet";
+
+describe("formatAllSidesLabel", () => {
+  it("formats every valid AllSides bucket", () => {
+    expect(formatAllSidesLabel("left")).toBe("Left");
+    expect(formatAllSidesLabel("lean-left")).toBe("Lean Left");
+    expect(formatAllSidesLabel("center")).toBe("Center");
+    expect(formatAllSidesLabel("lean-right")).toBe("Lean Right");
+    expect(formatAllSidesLabel("right")).toBe("Right");
+    expect(formatAllSidesLabel("mixed")).toBe("Mixed");
+  });
+
+  it("returns null for null/undefined input", () => {
+    expect(formatAllSidesLabel(null)).toBeNull();
+    expect(formatAllSidesLabel(undefined)).toBeNull();
+  });
+});
+
+describe("formatMbfcLabel", () => {
+  it("formats every valid MBFC tier", () => {
+    expect(formatMbfcLabel("very-high")).toBe("Very High");
+    expect(formatMbfcLabel("high")).toBe("High");
+    expect(formatMbfcLabel("mostly-factual")).toBe("Mostly Factual");
+    expect(formatMbfcLabel("mixed")).toBe("Mixed");
+    expect(formatMbfcLabel("low")).toBe("Low");
+    expect(formatMbfcLabel("very-low")).toBe("Very Low");
+  });
+
+  it("returns null for null/undefined input", () => {
+    expect(formatMbfcLabel(null)).toBeNull();
+    expect(formatMbfcLabel(undefined)).toBeNull();
+  });
+});
+
+describe("parseDbOutletProfile", () => {
+  const fullRow: DbOutletProfileRow = {
+    slug: "reuters",
+    name: "Reuters",
+    parent_company: "Thomson Reuters Corporation",
+    parent_company_url: "https://en.wikipedia.org/wiki/Thomson_Reuters",
+    founded_year: 1851,
+    funding_model: "subscription",
+    allsides_rating: "center",
+    allsides_url: "https://www.allsides.com/news-source/reuters",
+    mbfc_factual: "very-high",
+    mbfc_url: "https://mediabiasfactcheck.com/reuters/",
+  };
+
+  describe("happy path", () => {
+    it("maps a fully populated row to OutletProfile shape", () => {
+      const profile = parseDbOutletProfile(fullRow);
+      expect(profile).toEqual({
+        slug: "reuters",
+        name: "Reuters",
+        parentCompany: "Thomson Reuters Corporation",
+        parentCompanyUrl: "https://en.wikipedia.org/wiki/Thomson_Reuters",
+        foundedYear: 1851,
+        fundingModel: "subscription",
+        allSidesRating: "center",
+        allSidesUrl: "https://www.allsides.com/news-source/reuters",
+        mbfcFactual: "very-high",
+        mbfcUrl: "https://mediabiasfactcheck.com/reuters/",
+      });
+    });
+
+    it("trims whitespace on identity fields", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        slug: "  reuters  ",
+        name: "  Reuters  ",
+      });
+      expect(profile?.slug).toBe("reuters");
+      expect(profile?.name).toBe("Reuters");
+    });
+  });
+
+  describe("null-returning inputs", () => {
+    it("returns null for null/undefined", () => {
+      expect(parseDbOutletProfile(null)).toBeNull();
+      expect(parseDbOutletProfile(undefined)).toBeNull();
+    });
+
+    it("returns null when slug is missing or empty", () => {
+      expect(parseDbOutletProfile({ ...fullRow, slug: "" })).toBeNull();
+      expect(parseDbOutletProfile({ ...fullRow, slug: "   " })).toBeNull();
+    });
+
+    it("returns null when name is missing or empty", () => {
+      expect(parseDbOutletProfile({ ...fullRow, name: "" })).toBeNull();
+      expect(parseDbOutletProfile({ ...fullRow, name: "   " })).toBeNull();
+    });
+  });
+
+  describe("partial rows + graceful degradation", () => {
+    it("nulls out unknown allsides_rating values rather than passing them through", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        allsides_rating: "very-left", // not in our enum
+      });
+      expect(profile?.allSidesRating).toBeNull();
+    });
+
+    it("nulls out unknown mbfc_factual values", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        mbfc_factual: "perfect", // not in our enum
+      });
+      expect(profile?.mbfcFactual).toBeNull();
+    });
+
+    it("nulls out unknown funding_model values", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        funding_model: "vibes", // not in our enum
+      });
+      expect(profile?.fundingModel).toBeNull();
+    });
+
+    it("accepts uppercase enum values (case-insensitive)", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        allsides_rating: "LEAN-LEFT",
+        mbfc_factual: "HIGH",
+        funding_model: "ADVERTISING",
+      });
+      expect(profile?.allSidesRating).toBe("lean-left");
+      expect(profile?.mbfcFactual).toBe("high");
+      expect(profile?.fundingModel).toBe("advertising");
+    });
+
+    it("preserves null on optional metadata fields", () => {
+      const profile = parseDbOutletProfile({
+        slug: "the-bulwark",
+        name: "The Bulwark",
+        parent_company: null,
+        parent_company_url: null,
+        founded_year: null,
+        funding_model: null,
+        allsides_rating: null,
+        allsides_url: null,
+        mbfc_factual: "high",
+        mbfc_url: "https://mediabiasfactcheck.com/the-bulwark/",
+      });
+      expect(profile).toEqual({
+        slug: "the-bulwark",
+        name: "The Bulwark",
+        parentCompany: null,
+        parentCompanyUrl: null,
+        foundedYear: null,
+        fundingModel: null,
+        allSidesRating: null,
+        allSidesUrl: null,
+        mbfcFactual: "high",
+        mbfcUrl: "https://mediabiasfactcheck.com/the-bulwark/",
+      });
+    });
+
+    it("normalizes empty-string optional fields to null", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        parent_company: "",
+        parent_company_url: "   ",
+        allsides_url: "",
+      });
+      expect(profile?.parentCompany).toBeNull();
+      expect(profile?.parentCompanyUrl).toBeNull();
+      expect(profile?.allSidesUrl).toBeNull();
+    });
+  });
+});

--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -6,6 +6,8 @@ import {
   addBookmark,
   removeBookmark,
   getBookmarkedArticles,
+  getOutletProfilesMap,
+  resolveOutletForSourceName,
 } from "@/lib/db";
 import { parseContextPrimer } from "@/lib/primer";
 import type { Article, CategoryId } from "@/lib/types";
@@ -28,9 +30,13 @@ export async function GET(request: NextRequest) {
     const full = request.nextUrl.searchParams.get("full") === "1";
 
     if (full) {
-      const rows = await getBookmarkedArticles(userId);
+      const [rows, outletMap] = await Promise.all([
+        getBookmarkedArticles(userId),
+        getOutletProfilesMap(),
+      ]);
       const articles: Article[] = rows.map((row) => {
         const primer = parseContextPrimer(row.context_primer);
+        const outlet = resolveOutletForSourceName(outletMap, row.source_name);
         return {
           id: row.id,
           title: row.title,
@@ -44,6 +50,7 @@ export async function GET(request: NextRequest) {
           ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
           ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
           ...(primer ? { contextPrimer: primer } : {}),
+          ...(outlet ? { outlet } : {}),
         };
       });
       return NextResponse.json({ articles });

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getStoriesWithArticles, getLastRefreshed } from "@/lib/db";
+import {
+  getStoriesWithArticles,
+  getLastRefreshed,
+  getOutletProfilesMap,
+  resolveOutletForSourceName,
+} from "@/lib/db";
 import { parseContextPrimer } from "@/lib/primer";
 import { stripHtml, sanitizeUrl } from "@/lib/sanitize";
 import type { CategoryId, Article, Story, StoryFraming, EntitySet, NewsApiResponse, NewsApiError } from "@/lib/types";
@@ -52,14 +57,17 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const [{ stories: dbStories, storyArticles, standaloneArticles }, lastRefreshed] = await Promise.all([
-      getStoriesWithArticles(category),
-      getLastRefreshed(category),
-    ]);
+    const [{ stories: dbStories, storyArticles, standaloneArticles }, lastRefreshed, outletMap] =
+      await Promise.all([
+        getStoriesWithArticles(category),
+        getLastRefreshed(category),
+        getOutletProfilesMap(),
+      ]);
 
     // Map standalone articles
     const articles: Article[] = standaloneArticles.map((row) => {
       const primer = parseContextPrimer(row.context_primer);
+      const outlet = resolveOutletForSourceName(outletMap, row.source_name);
       return {
         id: row.id,
         title: row.title,
@@ -73,6 +81,7 @@ export async function GET(request: NextRequest) {
         ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
         ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
         ...(primer ? { contextPrimer: primer } : {}),
+        ...(outlet ? { outlet } : {}),
       };
     });
 
@@ -81,6 +90,7 @@ export async function GET(request: NextRequest) {
       const childRows = storyArticles[s.id] || [];
       const childArticles: Article[] = childRows.map((row) => {
         const primer = parseContextPrimer(row.context_primer);
+        const outlet = resolveOutletForSourceName(outletMap, row.source_name);
         return {
           id: row.id,
           title: row.title,
@@ -94,6 +104,7 @@ export async function GET(request: NextRequest) {
           ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
           ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
           ...(primer ? { contextPrimer: primer } : {}),
+          ...(outlet ? { outlet } : {}),
         };
       });
 

--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
-import { searchArticlesByEmbedding, insertArticle } from "@/lib/db";
+import {
+  searchArticlesByEmbedding,
+  insertArticle,
+  getOutletProfilesMap,
+  resolveOutletForSourceName,
+} from "@/lib/db";
 import { parseContextPrimer } from "@/lib/primer";
 import { stableHash, estimateReadTime } from "@/lib/utils";
 import { stripHtml, sanitizeUrl } from "@/lib/sanitize";
@@ -186,16 +191,16 @@ export async function GET(request: NextRequest) {
           setCachedEmbedding(query, embedding);
         }
 
-        // 2. Vector similarity search in Postgres
-        const rows = await searchArticlesByEmbedding(
-          embedding,
-          SIMILARITY_THRESHOLD,
-          MAX_RESULTS
-        );
+        // 2. Vector similarity search in Postgres + outlet map (parallel)
+        const [rows, outletMap] = await Promise.all([
+          searchArticlesByEmbedding(embedding, SIMILARITY_THRESHOLD, MAX_RESULTS),
+          getOutletProfilesMap(),
+        ]);
 
         // 3. Map DB rows to Article type
         const articles: Article[] = rows.map((row) => {
           const primer = parseContextPrimer(row.context_primer);
+          const outlet = resolveOutletForSourceName(outletMap, row.source_name);
           return {
             id: row.id,
             title: row.title,
@@ -211,6 +216,7 @@ export async function GET(request: NextRequest) {
             ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
             ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
             ...(primer ? { contextPrimer: primer } : {}),
+            ...(outlet ? { outlet } : {}),
           };
         });
 
@@ -229,11 +235,16 @@ export async function GET(request: NextRequest) {
 
           try {
             const fallbackArticles = await webSearchFallback(query);
-            // Dedupe against vector results
+            // Dedupe against vector results, then enrich with outlet provenance
+            // when the source_name matches a curated outlet (web-search results
+            // often surface the same outlets we ingest from).
             const seenIds = new Set(articles.map((a) => a.id));
-            const newArticles = fallbackArticles.filter(
-              (a) => !seenIds.has(a.id)
-            );
+            const newArticles = fallbackArticles
+              .filter((a) => !seenIds.has(a.id))
+              .map((a) => {
+                const outlet = resolveOutletForSourceName(outletMap, a.sourceName);
+                return outlet ? { ...a, outlet } : a;
+              });
 
             if (newArticles.length > 0) {
               controller.enqueue(

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -6,6 +6,7 @@ import { COPY } from "@/lib/copy";
 import { timeAgo } from "@/lib/utils";
 import CardImage from "./CardImage";
 import BackgroundPrimer from "./primer/BackgroundPrimer";
+import OutletBadge from "./outlet/OutletBadge";
 import type { ArticleCardProps } from "@/lib/types";
 
 // Fan-out stagger: even-indexed cards drift from left, odd from right
@@ -210,9 +211,7 @@ export default function ArticleCard({
 
         {/* Meta */}
         <div className="flex items-center gap-3 mt-auto pt-2 text-xs text-[var(--text-muted)] font-medium flex-wrap">
-          <span className="font-bold text-[var(--text-secondary)]">
-            {article.sourceName}
-          </span>
+          <OutletBadge outlet={article.outlet} fallback={article.sourceName} />
           <span className="opacity-30">&middot;</span>
           <span>{timeAgo(article.publishedDate)}</span>
           <span className="opacity-30">&middot;</span>

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -5,6 +5,7 @@ import { CATEGORIES, CATEGORY_COLORS } from "@/lib/constants";
 import { COPY } from "@/lib/copy";
 import { timeAgo } from "@/lib/utils";
 import CardImage from "./CardImage";
+import OutletBadge from "./outlet/OutletBadge";
 import type { StoryCardProps } from "@/lib/types";
 
 // Tone labels are no longer rendered (civic-literacy pivot, Phase 0).
@@ -307,9 +308,12 @@ export default function StoryCard({
                         }}
                       >
                         <span aria-hidden className="story-row__rail" />
-                        <span className="story-row__source text-outlet font-semibold uppercase text-[var(--text)] shrink-0 min-w-[88px]">
-                          {article.sourceName}
-                        </span>
+                        <OutletBadge
+                          outlet={article.outlet}
+                          fallback={article.sourceName}
+                          variant="rail"
+                          className="story-row__source shrink-0 min-w-[88px]"
+                        />
                         <span
                           className="text-body text-[var(--text)] flex-1"
                           style={{

--- a/components/outlet/OutletBadge.tsx
+++ b/components/outlet/OutletBadge.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { formatAllSidesLabel } from "@/lib/outlet";
+import type { OutletProfile } from "@/lib/types";
+
+interface OutletBadgeProps {
+  /**
+   * Curated outlet provenance from the API. When null/undefined the component
+   * falls back to plain `fallback` text — graceful degradation while
+   * source_name_aliases is still being populated in prod.
+   */
+  outlet?: OutletProfile | null;
+  /** Plain source-name string used when no curated outlet matches. */
+  fallback: string;
+  /**
+   * Visual register:
+   *   - "meta": small mixed-case meta line (ArticleCard footer). Default.
+   *   - "rail": uppercase rail style (StoryCard expanded child rows).
+   */
+  variant?: "meta" | "rail";
+  /**
+   * Optional extra Tailwind classes appended to the wrapper. Lets parent
+   * cards continue controlling sizing (e.g. `min-w-[88px]` on the rail).
+   */
+  className?: string;
+}
+
+/**
+ * Renders an outlet name with optional inline AllSides rating.
+ *
+ * Two click affordances when the outlet is matched:
+ *   1. Outlet name → /outlet/[slug]   (Sift-internal dossier, Phase 2.C)
+ *   2. AllSides label → outlet's AllSides page  (citation, opens new tab)
+ *
+ * z-index note: ArticleCard wraps its title in a stretched `<a>` overlay
+ * (`<span class="absolute inset-0 z-[1]">`). Anchors here use `relative z-[2]`
+ * + `e.stopPropagation()` to opt out of that overlay, mirroring how the
+ * bookmark button and primer toggle escape the card-link.
+ *
+ * Phase 2.C will add the dossier route. Until then `/outlet/[slug]` 404s
+ * gracefully — no soft-broken interactions, just a not-found page.
+ */
+export default function OutletBadge({
+  outlet,
+  fallback,
+  variant = "meta",
+  className,
+}: OutletBadgeProps) {
+  const isRail = variant === "rail";
+
+  // Fallback: no curated outlet match → render plain text matching the
+  // existing visual register at each callsite.
+  if (!outlet) {
+    if (isRail) {
+      return (
+        <span
+          className={`text-outlet font-semibold uppercase text-[var(--text)] ${className ?? ""}`}
+        >
+          {fallback}
+        </span>
+      );
+    }
+    return (
+      <span className={`font-bold text-[var(--text-secondary)] ${className ?? ""}`}>
+        {fallback}
+      </span>
+    );
+  }
+
+  const allSides = formatAllSidesLabel(outlet.allSidesRating);
+
+  // Rail variant (StoryCard rows): tight uppercase, no AllSides chip yet —
+  // the row already has limited horizontal space and Phase 2.C's
+  // CrossSpectrumCompare is the better surface for the lean indicator.
+  if (isRail) {
+    return (
+      <span className={`inline-flex items-center ${className ?? ""}`}>
+        <a
+          href={`/outlet/${outlet.slug}`}
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`Outlet dossier for ${outlet.name}`}
+          className="text-outlet font-semibold uppercase text-[var(--text)] no-underline hover:underline relative z-[2]"
+        >
+          {outlet.name}
+        </a>
+      </span>
+    );
+  }
+
+  // Meta variant (ArticleCard footer): outlet name link + small mono
+  // AllSides chip linking to the citation source. Whole thing wraps if the
+  // meta line wraps on narrow viewports.
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 flex-wrap ${className ?? ""}`}
+    >
+      <a
+        href={`/outlet/${outlet.slug}`}
+        onClick={(e) => e.stopPropagation()}
+        aria-label={`Outlet dossier for ${outlet.name}`}
+        className="font-bold text-[var(--text-secondary)] no-underline hover:underline hover:text-[var(--text)] relative z-[2]"
+      >
+        {outlet.name}
+      </a>
+      {allSides && (
+        <a
+          href={outlet.allSidesUrl ?? `/outlet/${outlet.slug}`}
+          target={outlet.allSidesUrl ? "_blank" : undefined}
+          rel={outlet.allSidesUrl ? "noopener noreferrer" : undefined}
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`AllSides bias rating: ${allSides}${outlet.allSidesUrl ? " (opens AllSides in a new tab)" : ""}`}
+          className="font-mono text-[10px] uppercase tracking-wider text-[var(--text-muted)] no-underline hover:text-[var(--text-secondary)] hover:underline relative z-[2] whitespace-nowrap"
+        >
+          {allSides}
+        </a>
+      )}
+    </span>
+  );
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,5 +1,8 @@
 import { Pool } from "pg";
 
+import { parseDbOutletProfile, type DbOutletProfileRow } from "./outlet";
+import type { OutletProfile } from "./types";
+
 if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL environment variable is not set");
 }
@@ -385,6 +388,119 @@ export async function deleteCustomTopic(id: string, userId: string): Promise<voi
     "DELETE FROM custom_topics WHERE id = $1 AND user_id = $2",
     [id, userId]
   );
+}
+
+// ─── Outlet Provenance (Phase 2.B) ─────────────────────
+
+/**
+ * Lookup map: lowercase `articles.source_name` → curated `OutletProfile`.
+ *
+ * Built from two relations:
+ *   1. `source_name_aliases` — explicit, hand-curated raw_source_name → outlet_slug
+ *   2. `outlet_profiles.LOWER(name)` — implicit fallback for outlets whose
+ *      RSS source_name happens to match the canonical name verbatim
+ *
+ * Aliases beat name-fallback when both are present for the same key.
+ *
+ * Cached at the module level for `OUTLET_CACHE_TTL_MS`. The underlying tables
+ * change quarterly (manual hand-curation), so a stale cache is harmless. If
+ * either table is missing (typical until sift-api Phase 2.A.1 lands in prod),
+ * `getOutletProfilesMap` returns an empty Map and the API mapping degrades to
+ * outlet=null, which OutletBadge renders as plain source-name text.
+ */
+const OUTLET_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+let outletCache: { data: Map<string, OutletProfile>; expiresAt: number } | null = null;
+let outletCacheInflight: Promise<Map<string, OutletProfile>> | null = null;
+
+async function loadOutletProfilesMap(): Promise<Map<string, OutletProfile>> {
+  const out = new Map<string, OutletProfile>();
+  let profilesBySlug: Map<string, OutletProfile>;
+
+  // 1. Load all outlet_profiles. Tolerate missing table.
+  try {
+    const result = await pool.query<DbOutletProfileRow>(
+      `SELECT slug, name, parent_company, parent_company_url, founded_year,
+              funding_model, allsides_rating, allsides_url, mbfc_factual, mbfc_url
+       FROM outlet_profiles`
+    );
+    profilesBySlug = new Map();
+    for (const row of result.rows) {
+      const profile = parseDbOutletProfile(row);
+      if (!profile) continue;
+      profilesBySlug.set(profile.slug, profile);
+      // Implicit name-match fallback (case-insensitive, trimmed).
+      out.set(profile.name.trim().toLowerCase(), profile);
+    }
+  } catch (err) {
+    const msg = String(err);
+    if (!msg.includes("does not exist")) throw err;
+    // outlet_profiles missing — return empty map; aliases lookup also pointless.
+    return out;
+  }
+
+  // 2. Layer source_name_aliases on top. Tolerate missing table.
+  try {
+    const result = await pool.query<{ raw_source_name: string; outlet_slug: string }>(
+      `SELECT raw_source_name, outlet_slug FROM source_name_aliases`
+    );
+    for (const { raw_source_name, outlet_slug } of result.rows) {
+      const profile = profilesBySlug.get(outlet_slug);
+      if (!profile) continue; // orphan alias; FK should prevent this but defend anyway
+      out.set(raw_source_name.trim().toLowerCase(), profile);
+    }
+  } catch (err) {
+    const msg = String(err);
+    if (!msg.includes("does not exist")) throw err;
+    // source_name_aliases missing — fall through with name-only matches.
+  }
+
+  return out;
+}
+
+/**
+ * Returns the cached source_name → OutletProfile map, refreshing if expired.
+ * Concurrent callers share a single in-flight fetch promise to avoid
+ * duplicate DB round-trips on cold starts.
+ */
+export async function getOutletProfilesMap(): Promise<Map<string, OutletProfile>> {
+  const now = Date.now();
+  if (outletCache && outletCache.expiresAt > now) return outletCache.data;
+  if (outletCacheInflight) return outletCacheInflight;
+
+  outletCacheInflight = loadOutletProfilesMap()
+    .then((data) => {
+      outletCache = { data, expiresAt: Date.now() + OUTLET_CACHE_TTL_MS };
+      return data;
+    })
+    .catch((err) => {
+      console.error("getOutletProfilesMap: failed to load", err);
+      // Don't cache failure; next caller will retry. Return empty map so the
+      // API still serves articles, just without outlet provenance.
+      return new Map<string, OutletProfile>();
+    })
+    .finally(() => {
+      outletCacheInflight = null;
+    });
+
+  return outletCacheInflight;
+}
+
+/**
+ * Resolve a single source_name to an OutletProfile via the cached map.
+ * Returns null when no alias/name match exists. Does not hit the DB itself.
+ */
+export function resolveOutletForSourceName(
+  outletMap: Map<string, OutletProfile>,
+  sourceName: string | null | undefined,
+): OutletProfile | null {
+  if (!sourceName) return null;
+  return outletMap.get(sourceName.trim().toLowerCase()) ?? null;
+}
+
+/** Test-only: reset the cache between unit-test runs. */
+export function _resetOutletCacheForTesting(): void {
+  outletCache = null;
+  outletCacheInflight = null;
 }
 
 export default pool;

--- a/lib/outlet.ts
+++ b/lib/outlet.ts
@@ -1,0 +1,147 @@
+// Outlet-provenance helpers — civic-literacy MVP Phase 2.B.
+//
+// Parses curated rows from `outlet_profiles` into the typed `OutletProfile`
+// shape the UI consumes, and provides label formatters for AllSides + MBFC
+// values. Everything here is pure-function so it's trivial to unit test.
+
+import type {
+  OutletAllSidesRating,
+  OutletFundingModel,
+  OutletMbfcRating,
+  OutletProfile,
+} from "./types";
+
+// ─── Enums (kept in sync with sift-api's seed_outlet_profiles.py) ─────
+
+const ALLSIDES_VALUES: ReadonlySet<string> = new Set([
+  "left",
+  "lean-left",
+  "center",
+  "lean-right",
+  "right",
+  "mixed",
+]);
+
+const MBFC_VALUES: ReadonlySet<string> = new Set([
+  "very-high",
+  "high",
+  "mostly-factual",
+  "mixed",
+  "low",
+  "very-low",
+]);
+
+const FUNDING_VALUES: ReadonlySet<string> = new Set([
+  "subscription",
+  "advertising",
+  "foundation",
+  "donations",
+  "mixed",
+  "public-service",
+]);
+
+// ─── Display labels ───────────────────────────────────────────────────
+
+const ALLSIDES_LABELS: Record<OutletAllSidesRating, string> = {
+  left: "Left",
+  "lean-left": "Lean Left",
+  center: "Center",
+  "lean-right": "Lean Right",
+  right: "Right",
+  mixed: "Mixed",
+};
+
+const MBFC_LABELS: Record<OutletMbfcRating, string> = {
+  "very-high": "Very High",
+  high: "High",
+  "mostly-factual": "Mostly Factual",
+  mixed: "Mixed",
+  low: "Low",
+  "very-low": "Very Low",
+};
+
+/** Human label for an AllSides rating, e.g. `"lean-left"` → `"Lean Left"`. */
+export function formatAllSidesLabel(
+  rating: OutletAllSidesRating | null | undefined,
+): string | null {
+  if (!rating) return null;
+  return ALLSIDES_LABELS[rating] ?? null;
+}
+
+/** Human label for an MBFC factual rating, e.g. `"mostly-factual"` → `"Mostly Factual"`. */
+export function formatMbfcLabel(
+  rating: OutletMbfcRating | null | undefined,
+): string | null {
+  if (!rating) return null;
+  return MBFC_LABELS[rating] ?? null;
+}
+
+// ─── DB-row parsing ───────────────────────────────────────────────────
+
+/**
+ * Shape of a row from `outlet_profiles`. Fields are TEXT/INT/JSONB at the DB
+ * layer; `parseDbOutletProfile` validates and maps them onto the typed
+ * `OutletProfile` shape the client consumes.
+ *
+ * Extra DB columns (notes, external_links, major_funders, *_last_checked,
+ * updated_at) are intentionally omitted here — they're rendered on the
+ * dossier page (Phase 2.C) but irrelevant to feed-card badges.
+ */
+export interface DbOutletProfileRow {
+  slug: string;
+  name: string;
+  parent_company: string | null;
+  parent_company_url: string | null;
+  founded_year: number | null;
+  funding_model: string | null;
+  allsides_rating: string | null;
+  allsides_url: string | null;
+  mbfc_factual: string | null;
+  mbfc_url: string | null;
+}
+
+function asAllSides(v: string | null): OutletAllSidesRating | null {
+  if (!v) return null;
+  const lower = v.toLowerCase();
+  return ALLSIDES_VALUES.has(lower) ? (lower as OutletAllSidesRating) : null;
+}
+
+function asMbfc(v: string | null): OutletMbfcRating | null {
+  if (!v) return null;
+  const lower = v.toLowerCase();
+  return MBFC_VALUES.has(lower) ? (lower as OutletMbfcRating) : null;
+}
+
+function asFunding(v: string | null): OutletFundingModel | null {
+  if (!v) return null;
+  const lower = v.toLowerCase();
+  return FUNDING_VALUES.has(lower) ? (lower as OutletFundingModel) : null;
+}
+
+/**
+ * Validate + shape a raw `outlet_profiles` row. Returns null if the row is
+ * missing the two required identity fields (slug, name); unknown enum values
+ * are silently dropped to null so the UI degrades gracefully rather than
+ * rendering garbage labels.
+ */
+export function parseDbOutletProfile(
+  row: DbOutletProfileRow | null | undefined,
+): OutletProfile | null {
+  if (!row) return null;
+  const slug = (row.slug ?? "").trim();
+  const name = (row.name ?? "").trim();
+  if (!slug || !name) return null;
+
+  return {
+    slug,
+    name,
+    parentCompany: row.parent_company?.trim() || null,
+    parentCompanyUrl: row.parent_company_url?.trim() || null,
+    foundedYear: typeof row.founded_year === "number" ? row.founded_year : null,
+    fundingModel: asFunding(row.funding_model),
+    allSidesRating: asAllSides(row.allsides_rating),
+    allSidesUrl: row.allsides_url?.trim() || null,
+    mbfcFactual: asMbfc(row.mbfc_factual),
+    mbfcUrl: row.mbfc_url?.trim() || null,
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -43,6 +43,60 @@ export interface Article {
    * the pipeline starts writing this field.
    */
   readingLevels?: ReadingLevels | null;
+  /**
+   * Curated outlet provenance — civic-literacy MVP Phase 2.B. Resolved at
+   * the API boundary by mapping `sourceName` through `source_name_aliases`
+   * → `outlet_profiles`. Null/undefined when the source_name has no alias
+   * yet (graceful degradation: OutletBadge renders the plain source name).
+   */
+  outlet?: OutletProfile | null;
+}
+
+// ─── Outlet Provenance ─────────────────────────────────
+
+/** AllSides political-lean buckets. Mirrors `outlet_profiles.allsides_rating`. */
+export type OutletAllSidesRating =
+  | "left"
+  | "lean-left"
+  | "center"
+  | "lean-right"
+  | "right"
+  | "mixed";
+
+/** MBFC factual-reporting tiers. Mirrors `outlet_profiles.mbfc_factual`. */
+export type OutletMbfcRating =
+  | "very-high"
+  | "high"
+  | "mostly-factual"
+  | "mixed"
+  | "low"
+  | "very-low";
+
+/** Funding-model categories used in outlet dossiers. */
+export type OutletFundingModel =
+  | "subscription"
+  | "advertising"
+  | "foundation"
+  | "donations"
+  | "mixed"
+  | "public-service";
+
+/**
+ * Curated outlet metadata, mirrored from `outlet_profiles` in Postgres.
+ * Hand-maintained quarterly. The dossier page (Phase 2.C) renders the full
+ * shape; OutletBadge in feed cards renders only `name` + `allSidesRating`.
+ */
+export interface OutletProfile {
+  slug: string;
+  name: string;
+  parentCompany: string | null;
+  parentCompanyUrl: string | null;
+  foundedYear: number | null;
+  fundingModel: OutletFundingModel | null;
+  allSidesRating: OutletAllSidesRating | null;
+  allSidesUrl: string | null;
+  mbfcFactual: OutletMbfcRating | null;
+  mbfcUrl: string | null;
 }
 
 export interface ContextPrimerTerm {


### PR DESCRIPTION
## Summary
- Surfaces curated outlet provenance (name + AllSides bias rating) inline in every feed card by reading the `outlet_profiles` + `source_name_aliases` tables defined in [sift-api PR #25](https://github.com/kristenmartino/sift-api/pull/25)
- Adds `lib/outlet.ts` (parser + label formatters), extends `lib/db.ts` with a 1-hour-TTL cached `getOutletProfilesMap()` lookup, threads outlet onto `Article` in three API routes, and ships `OutletBadge` integrated into `ArticleCard` + `StoryCard`
- Graceful-degrades to the current plain-source-name rendering until sift-api #25 merges + Railway redeploys; no visual regression risk to ship before #25

## What ships
| Layer | File | Change |
|---|---|---|
| Types | `lib/types.ts` | `OutletProfile`, `OutletAllSidesRating`, `OutletMbfcRating`, `OutletFundingModel`; optional `Article.outlet` |
| Helpers | `lib/outlet.ts` (new) | `parseDbOutletProfile`, `formatAllSidesLabel`, `formatMbfcLabel` |
| DB | `lib/db.ts` | `getOutletProfilesMap()` (cached) + `resolveOutletForSourceName()` |
| API | `app/api/news/route.ts`, `bookmarks/route.ts`, `news/topic/route.ts` | Resolve `outlet` per article; web-search fallback also opportunistically enriches |
| Component | `components/outlet/OutletBadge.tsx` (new) | `meta` + `rail` variants; `relative z-[2]` opts out of card-link overlay |
| Cards | `ArticleCard.tsx`, `StoryCard.tsx` | Replace plain `<span>{sourceName}</span>` with `<OutletBadge />` |
| Tests | `__tests__/outlet.test.ts` (new) | 15 tests covering parser + formatters |

## Visual register
- **Meta variant** (ArticleCard footer): outlet name links to `/outlet/[slug]` (Sift dossier, Phase 2.C); small `font-mono text-[10px] uppercase` AllSides chip links to the outlet's AllSides citation page in a new tab
- **Rail variant** (StoryCard expanded child rows): uppercase rail style preserved; chip omitted to keep rows tight — CrossSpectrumCompare in 2.C is the better surface for the lean indicator
- Both opt out of the stretched card-link via `relative z-[2]` + `e.stopPropagation()`, matching the bookmark/primer-toggle pattern

## Tests
- 7 suites / 119 tests pass; `tsc --noEmit` clean
- New `__tests__/outlet.test.ts` covers happy path, null-returning inputs, partial rows, case-insensitive enums, empty-string normalization
- Existing `api.test.ts` updated to stub the new `lib/db` exports (returns empty map → existing assertions about Article shape stay green)

## Graceful degradation
`getOutletProfilesMap()` catches `relation "..." does not exist` from Postgres and returns an empty Map. Until sift-api PR #25 lands + Railway redeploys, every article renders the plain source name exactly as today. No user-visible regression.

## Out of scope (queued for later phases)
- `/outlet/[slug]` dossier page (Phase 2.C) — outlet-name links 404 gracefully until then
- `CrossSpectrumCompare` rebuild of StoryCard framings (Phase 2.C)
- `/methodology` page (Phase 2.D)

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 119 passing
- [ ] Visual: dev preview, confirm article cards render plain source name today (since prod outlet_profiles is empty); confirm hover/click on the badge once sift-api #25 merges
- [ ] Visual: hover state on outlet name shows underline + color shift; AllSides chip is tappable on mobile
- [ ] Verify no regression on bookmark, primer toggle, compare button click handlers (the z-index neighbor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)