### PR TITLE
feat: civic-literacy MVP Phase 2.C.1 — outlet dossier route

### DIFF
--- a/__tests__/outlet.test.ts
+++ b/__tests__/outlet.test.ts
@@ -1,5 +1,6 @@
 import {
   formatAllSidesLabel,
+  formatFundingLabel,
   formatMbfcLabel,
   parseDbOutletProfile,
   type DbOutletProfileRow,
@@ -37,6 +38,22 @@ describe("formatMbfcLabel", () => {
   });
 });
 
+describe("formatFundingLabel", () => {
+  it("formats every valid funding model", () => {
+    expect(formatFundingLabel("subscription")).toBe("Subscription");
+    expect(formatFundingLabel("advertising")).toBe("Advertising");
+    expect(formatFundingLabel("foundation")).toBe("Foundation");
+    expect(formatFundingLabel("donations")).toBe("Reader donations");
+    expect(formatFundingLabel("mixed")).toBe("Mixed");
+    expect(formatFundingLabel("public-service")).toBe("Public service");
+  });
+
+  it("returns null for null/undefined input", () => {
+    expect(formatFundingLabel(null)).toBeNull();
+    expect(formatFundingLabel(undefined)).toBeNull();
+  });
+});
+
 describe("parseDbOutletProfile", () => {
   const fullRow: DbOutletProfileRow = {
     slug: "reuters",
@@ -47,8 +64,13 @@ describe("parseDbOutletProfile", () => {
     funding_model: "subscription",
     allsides_rating: "center",
     allsides_url: "https://www.allsides.com/news-source/reuters",
+    allsides_last_checked: new Date("2026-05-06T00:00:00.000Z"),
     mbfc_factual: "very-high",
     mbfc_url: "https://mediabiasfactcheck.com/reuters/",
+    mbfc_last_checked: new Date("2026-05-02T00:00:00.000Z"),
+    major_funders: [],
+    external_links: { wikipedia: "https://en.wikipedia.org/wiki/Reuters" },
+    notes: null,
   };
 
   describe("happy path", () => {
@@ -63,8 +85,13 @@ describe("parseDbOutletProfile", () => {
         fundingModel: "subscription",
         allSidesRating: "center",
         allSidesUrl: "https://www.allsides.com/news-source/reuters",
+        allSidesLastChecked: "2026-05-06",
         mbfcFactual: "very-high",
         mbfcUrl: "https://mediabiasfactcheck.com/reuters/",
+        mbfcLastChecked: "2026-05-02",
+        majorFunders: [],
+        externalLinks: { wikipedia: "https://en.wikipedia.org/wiki/Reuters" },
+        notes: null,
       });
     });
 
@@ -143,8 +170,13 @@ describe("parseDbOutletProfile", () => {
         funding_model: null,
         allsides_rating: null,
         allsides_url: null,
+        allsides_last_checked: null,
         mbfc_factual: "high",
         mbfc_url: "https://mediabiasfactcheck.com/the-bulwark/",
+        mbfc_last_checked: null,
+        major_funders: null,
+        external_links: null,
+        notes: null,
       });
       expect(profile).toEqual({
         slug: "the-bulwark",
@@ -155,8 +187,13 @@ describe("parseDbOutletProfile", () => {
         fundingModel: null,
         allSidesRating: null,
         allSidesUrl: null,
+        allSidesLastChecked: null,
         mbfcFactual: "high",
         mbfcUrl: "https://mediabiasfactcheck.com/the-bulwark/",
+        mbfcLastChecked: null,
+        majorFunders: [],
+        externalLinks: {},
+        notes: null,
       });
     });
 
@@ -166,10 +203,124 @@ describe("parseDbOutletProfile", () => {
         parent_company: "",
         parent_company_url: "   ",
         allsides_url: "",
+        notes: "   ",
       });
       expect(profile?.parentCompany).toBeNull();
       expect(profile?.parentCompanyUrl).toBeNull();
       expect(profile?.allSidesUrl).toBeNull();
+      expect(profile?.notes).toBeNull();
+    });
+  });
+
+  describe("date column normalization", () => {
+    it("converts Date instances to YYYY-MM-DD strings", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        allsides_last_checked: new Date("2026-04-01T18:30:00.000Z"),
+        mbfc_last_checked: new Date("2026-04-15T00:00:00.000Z"),
+      });
+      expect(profile?.allSidesLastChecked).toBe("2026-04-01");
+      expect(profile?.mbfcLastChecked).toBe("2026-04-15");
+    });
+
+    it("accepts pre-formatted ISO date strings", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        allsides_last_checked: "2026-04-01",
+        mbfc_last_checked: "2026-04-15",
+      });
+      expect(profile?.allSidesLastChecked).toBe("2026-04-01");
+      expect(profile?.mbfcLastChecked).toBe("2026-04-15");
+    });
+
+    it("returns null for malformed date strings", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        allsides_last_checked: "not a date",
+      });
+      expect(profile?.allSidesLastChecked).toBeNull();
+    });
+
+    it("returns null for invalid Date instances", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        allsides_last_checked: new Date("invalid"),
+      });
+      expect(profile?.allSidesLastChecked).toBeNull();
+    });
+  });
+
+  describe("JSONB field validation", () => {
+    it("accepts a string array for major_funders", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        major_funders: ["MacArthur Foundation", "Knight Foundation"],
+      });
+      expect(profile?.majorFunders).toEqual([
+        "MacArthur Foundation",
+        "Knight Foundation",
+      ]);
+    });
+
+    it("filters non-string entries from major_funders", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        major_funders: ["MacArthur", 42, null, { foo: "bar" }, "Knight"],
+      });
+      expect(profile?.majorFunders).toEqual(["MacArthur", "Knight"]);
+    });
+
+    it("returns [] for non-array major_funders", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        major_funders: "not an array",
+      });
+      expect(profile?.majorFunders).toEqual([]);
+    });
+
+    it("trims and drops empty strings from major_funders", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        major_funders: ["  MacArthur  ", "", "   "],
+      });
+      expect(profile?.majorFunders).toEqual(["MacArthur"]);
+    });
+
+    it("accepts an object with string values for external_links", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        external_links: {
+          wikipedia: "https://en.wikipedia.org/wiki/Reuters",
+          official: "https://www.reuters.com",
+        },
+      });
+      expect(profile?.externalLinks).toEqual({
+        wikipedia: "https://en.wikipedia.org/wiki/Reuters",
+        official: "https://www.reuters.com",
+      });
+    });
+
+    it("drops non-string values from external_links", () => {
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        external_links: {
+          wikipedia: "https://en.wikipedia.org/wiki/Reuters",
+          weird: 42,
+          nested: { foo: "bar" },
+        },
+      });
+      expect(profile?.externalLinks).toEqual({
+        wikipedia: "https://en.wikipedia.org/wiki/Reuters",
+      });
+    });
+
+    it("returns {} for an array passed as external_links", () => {
+      // Arrays are objects in JS but should not be treated as link maps.
+      const profile = parseDbOutletProfile({
+        ...fullRow,
+        external_links: ["a", "b"],
+      });
+      expect(profile?.externalLinks).toEqual({});
     });
   });
 });

--- a/app/outlet/[slug]/page.tsx
+++ b/app/outlet/[slug]/page.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import OutletDossier from "@/components/outlet/OutletDossier";
+import { getOutletBySlug, getRecentArticlesByOutletSlug } from "@/lib/db";
+import { parseContextPrimer } from "@/lib/primer";
+import type { Article, CategoryId } from "@/lib/types";
+
+// ISR — same heartbeat as the landing page (10 minutes). The dossier reads
+// curated metadata that changes quarterly + recent articles that change every
+// pipeline cycle, so a 600s edge cache is well-matched on both sides.
+export const revalidate = 600;
+
+interface DossierRouteProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: DossierRouteProps): Promise<Metadata> {
+  const { slug } = await params;
+  const outlet = await getOutletBySlug(slug);
+  if (!outlet) return { title: "Outlet not found" };
+  return {
+    title: `${outlet.name} — Outlet dossier`,
+    description: `Ownership, funding, bias, and factual-reporting context for ${outlet.name} on Sift.`,
+  };
+}
+
+export default async function OutletDossierPage({ params }: DossierRouteProps) {
+  const { slug } = await params;
+
+  const [outlet, recentRows] = await Promise.all([
+    getOutletBySlug(slug),
+    // Best-effort prefetch — if the outlet doesn't exist we'll 404 below
+    // anyway, but running these in parallel saves a round-trip on the happy
+    // path. The query is slug-keyed and tolerates a non-curated slug (returns
+    // []) so this is safe to issue speculatively.
+    getRecentArticlesByOutletSlug(slug, 20),
+  ]);
+
+  if (!outlet) notFound();
+
+  const recentArticles: Article[] = recentRows.map((row) => {
+    const primer = parseContextPrimer(row.context_primer);
+    return {
+      id: row.id,
+      title: row.title,
+      summary: row.summary || "",
+      sourceUrl: row.source_url,
+      sourceName: row.source_name,
+      publishedDate: row.published_date ? row.published_date.toISOString() : null,
+      imageUrl: row.image_url,
+      category: row.category as CategoryId,
+      readTime: row.read_time || 1,
+      ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
+      ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
+      ...(primer ? { contextPrimer: primer } : {}),
+      // Outlet field intentionally omitted from the dossier's recent-stories
+      // list — every article here is from this outlet by construction; the
+      // OutletBadge in those rows would be redundant noise.
+    };
+  });
+
+  return <OutletDossier outlet={outlet} recentArticles={recentArticles} />;
+}

--- a/components/outlet/OutletDossier.tsx
+++ b/components/outlet/OutletDossier.tsx
@@ -1,0 +1,302 @@
+import Link from "next/link";
+
+import LandingMasthead from "@/components/landing/LandingMasthead";
+import {
+  formatAllSidesLabel,
+  formatFundingLabel,
+  formatMbfcLabel,
+} from "@/lib/outlet";
+import { COPY } from "@/lib/copy";
+import { timeAgo } from "@/lib/utils";
+import type { Article, OutletProfile } from "@/lib/types";
+
+interface OutletDossierProps {
+  outlet: OutletProfile;
+  recentArticles: Article[];
+}
+
+/**
+ * Server-rendered outlet dossier. Mirrors the editorial visual register of
+ * `app/colophon/page.tsx` — kicker eyebrows, hairline rules, mono labels,
+ * Fraunces display type. Content is read-only from `outlet_profiles` plus a
+ * recent-articles JOIN.
+ *
+ * The layout is intentionally one-column (max-w 800px). Outlet provenance
+ * deserves a contemplative reading register, not a dashboard. Mobile is the
+ * same layout, just narrower padding.
+ */
+export default function OutletDossier({
+  outlet,
+  recentArticles,
+}: OutletDossierProps) {
+  const allSidesLabel = formatAllSidesLabel(outlet.allSidesRating);
+  const mbfcLabel = formatMbfcLabel(outlet.mbfcFactual);
+  const fundingLabel = formatFundingLabel(outlet.fundingModel);
+
+  // Combine top-line metadata for the lede line under the headline.
+  const ledeBits: string[] = [];
+  if (outlet.parentCompany) ledeBits.push(outlet.parentCompany);
+  if (outlet.foundedYear) ledeBits.push(`Founded ${outlet.foundedYear}`);
+  if (fundingLabel) ledeBits.push(fundingLabel);
+
+  // Build the external-links list from the JSONB blob, in a stable order.
+  const linkOrder: Array<keyof typeof COPY.dossier.externalLinkLabels> = [
+    "wikipedia",
+    "official",
+    "ownership",
+  ];
+  const externalLinkEntries = linkOrder
+    .map((key) => {
+      const url = outlet.externalLinks[key];
+      return url ? { key, url, label: COPY.dossier.externalLinkLabels[key] } : null;
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null);
+
+  // Plus any extra external_links keys we haven't pre-labeled (forward-compat).
+  for (const [key, url] of Object.entries(outlet.externalLinks)) {
+    if (!linkOrder.includes(key as typeof linkOrder[number]) && url) {
+      externalLinkEntries.push({
+        key,
+        url,
+        label: COPY.dossier.externalLinkLabels[key] ?? key,
+      });
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
+      <LandingMasthead />
+
+      <main
+        id="main-content"
+        className="max-w-[800px] mx-auto px-6 pt-12 pb-24"
+      >
+        {/* Eyebrow + headline */}
+        <header className="mb-9">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3 flex items-center">
+            <span
+              aria-hidden
+              className="inline-block w-7 h-px bg-[var(--border)] mr-3"
+            />
+            {COPY.dossier.eyebrow}
+          </p>
+          <h1 className="font-heading text-[36px] md:text-[44px] font-bold leading-[1.05] tracking-tight text-[var(--text)]">
+            {outlet.name}
+          </h1>
+          {ledeBits.length > 0 && (
+            <p className="font-body text-[16px] text-[var(--text-secondary)] mt-3 max-w-[60ch] leading-relaxed">
+              {ledeBits.join(" · ")}
+            </p>
+          )}
+        </header>
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* Ratings: AllSides + MBFC. Each rating cites its source with a date
+            so the reader can verify and replicate; methodology page (Phase
+            2.D) will document the curation cadence. */}
+        {(allSidesLabel || mbfcLabel) && (
+          <section className="mb-12 grid gap-8 md:grid-cols-2">
+            {allSidesLabel && (
+              <div>
+                <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+                  {COPY.dossier.bias}
+                </p>
+                <p className="font-heading text-[26px] font-semibold text-[var(--text)] leading-tight mb-2">
+                  {allSidesLabel}
+                </p>
+                <p className="font-body text-[12px] text-[var(--text-muted)] leading-relaxed">
+                  {outlet.allSidesUrl ? (
+                    <a
+                      href={outlet.allSidesUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[var(--text-secondary)] no-underline hover:underline hover:text-[var(--accent)]"
+                    >
+                      {COPY.dossier.citation("AllSides", outlet.allSidesLastChecked)}{" "}
+                      <span aria-hidden>↗</span>
+                    </a>
+                  ) : (
+                    COPY.dossier.citation("AllSides", outlet.allSidesLastChecked)
+                  )}
+                </p>
+              </div>
+            )}
+            {mbfcLabel && (
+              <div>
+                <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+                  {COPY.dossier.factual}
+                </p>
+                <p className="font-heading text-[26px] font-semibold text-[var(--text)] leading-tight mb-2">
+                  {mbfcLabel}
+                </p>
+                <p className="font-body text-[12px] text-[var(--text-muted)] leading-relaxed">
+                  {outlet.mbfcUrl ? (
+                    <a
+                      href={outlet.mbfcUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[var(--text-secondary)] no-underline hover:underline hover:text-[var(--accent)]"
+                    >
+                      {COPY.dossier.citation(
+                        "Media Bias/Fact Check",
+                        outlet.mbfcLastChecked,
+                      )}{" "}
+                      <span aria-hidden>↗</span>
+                    </a>
+                  ) : (
+                    COPY.dossier.citation(
+                      "Media Bias/Fact Check",
+                      outlet.mbfcLastChecked,
+                    )
+                  )}
+                </p>
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* Ownership */}
+        {(outlet.parentCompany || outlet.parentCompanyUrl) && (
+          <section className="mb-10">
+            <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+              {COPY.dossier.ownership}
+            </p>
+            <p className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed max-w-[60ch]">
+              {outlet.parentCompanyUrl && outlet.parentCompany ? (
+                <a
+                  href={outlet.parentCompanyUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[var(--text)] no-underline hover:underline hover:text-[var(--accent)] font-semibold"
+                >
+                  {outlet.parentCompany} <span aria-hidden>↗</span>
+                </a>
+              ) : (
+                <span className="text-[var(--text)] font-semibold">
+                  {outlet.parentCompany}
+                </span>
+              )}
+            </p>
+          </section>
+        )}
+
+        {/* Major funders (foundation/donations-funded outlets) */}
+        {outlet.majorFunders.length > 0 && (
+          <section className="mb-10">
+            <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+              {COPY.dossier.majorFunders}
+            </p>
+            <ul className="space-y-1.5">
+              {outlet.majorFunders.map((funder) => (
+                <li
+                  key={funder}
+                  className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed"
+                >
+                  {funder}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* External links — Wikipedia, official site, ownership reference */}
+        {externalLinkEntries.length > 0 && (
+          <section className="mb-10">
+            <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+              {COPY.dossier.links}
+            </p>
+            <ul className="space-y-2.5">
+              {externalLinkEntries.map(({ key, url, label }) => (
+                <li
+                  key={key}
+                  className="grid grid-cols-[180px_1fr] gap-x-6 items-baseline border-b border-[var(--border-subtle)] pb-2.5"
+                >
+                  <span className="font-body text-outlet uppercase tracking-wider text-[var(--text-muted)]">
+                    {label}
+                  </span>
+                  <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-body text-[14px] text-[var(--text-secondary)] no-underline hover:underline hover:text-[var(--accent)] truncate"
+                  >
+                    {url} <span aria-hidden>↗</span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* Free-form notes */}
+        {outlet.notes && (
+          <section className="mb-10">
+            <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+              {COPY.dossier.notes}
+            </p>
+            <p className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed max-w-[60ch] italic">
+              {outlet.notes}
+            </p>
+          </section>
+        )}
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* Recent stories from this outlet on Sift */}
+        <section className="mb-12">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-5">
+            {COPY.dossier.recentStories}
+          </p>
+          {recentArticles.length === 0 ? (
+            <p className="font-body text-[14px] text-[var(--text-muted)] italic max-w-[60ch] leading-relaxed">
+              {COPY.dossier.noRecent}
+            </p>
+          ) : (
+            <ul className="space-y-0">
+              {recentArticles.map((article) => (
+                <li
+                  key={article.id}
+                  className="border-b border-[var(--border-subtle)] last:border-b-0 py-3.5"
+                >
+                  <a
+                    href={article.sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block group no-underline"
+                  >
+                    <p className="font-heading text-[17px] leading-snug text-[var(--text)] group-hover:text-[var(--accent)] transition-colors">
+                      {article.title}
+                    </p>
+                    <p className="font-body text-meta text-[var(--text-muted)] mt-1.5 flex items-center gap-3">
+                      <span>{timeAgo(article.publishedDate)}</span>
+                      <span className="opacity-30">·</span>
+                      <span>{article.readTime} min read</span>
+                    </p>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* Footer: methodology hint + back link */}
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <Link
+            href="/"
+            className="font-body text-outlet uppercase tracking-wider text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline inline-flex items-center gap-1.5"
+          >
+            <span aria-hidden>←</span> Back to Sift
+          </Link>
+          {/* Methodology link: queued for Phase 2.D. Until that route exists,
+              we render the hint as plain text rather than a broken link. */}
+          <span className="font-body text-meta text-[var(--text-muted)] italic">
+            {COPY.dossier.methodologyHint}
+          </span>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -105,6 +105,35 @@ export const COPY = {
     // Section header inside the expanded primer when there are key terms.
     termsLabel: "Key terms",
   },
+  dossier: {
+    // Eyebrow shown above the outlet name.
+    eyebrow: "Outlet dossier",
+    // Section labels (mono kicker style).
+    ownership: "Ownership",
+    funding: "Funding",
+    bias: "Political-lean rating",
+    factual: "Factual reporting",
+    links: "Where to read more",
+    notes: "Notes",
+    recentStories: "Recent stories on Sift",
+    // Citation footer notes.
+    citation: (source: string, lastChecked: string | null) =>
+      lastChecked
+        ? `Source: ${source} \u00b7 last verified ${lastChecked}`
+        : `Source: ${source}`,
+    methodologyHint: "Why these ratings? Read the methodology.",
+    // External-link labels.
+    externalLinkLabels: {
+      wikipedia: "Wikipedia",
+      official: "Official site",
+      ownership: "Ownership reference",
+    } as Record<string, string>,
+    // Funder list label.
+    majorFunders: "Major funders",
+    // Empty state for the recent-stories list.
+    noRecent:
+      "No recent stories from this outlet on Sift. The pipeline reads from this outlet \u2014 nothing has surfaced in the last day or two.",
+  },
   landing: {
     // Single editorial paragraph below the lead story. The "what is this".
     explainer:

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -420,7 +420,9 @@ async function loadOutletProfilesMap(): Promise<Map<string, OutletProfile>> {
   try {
     const result = await pool.query<DbOutletProfileRow>(
       `SELECT slug, name, parent_company, parent_company_url, founded_year,
-              funding_model, allsides_rating, allsides_url, mbfc_factual, mbfc_url
+              funding_model, allsides_rating, allsides_url, allsides_last_checked,
+              mbfc_factual, mbfc_url, mbfc_last_checked,
+              major_funders, external_links, notes
        FROM outlet_profiles`
     );
     profilesBySlug = new Map();
@@ -501,6 +503,84 @@ export function resolveOutletForSourceName(
 export function _resetOutletCacheForTesting(): void {
   outletCache = null;
   outletCacheInflight = null;
+}
+
+// ─── Outlet Dossier (Phase 2.C.1) ──────────────────────
+
+/**
+ * Fetch a single outlet profile by slug. Returns null when the slug isn't
+ * curated (caller should call notFound() for the dossier route) or when the
+ * outlet_profiles table doesn't exist yet (pre-Phase-2.A-merge prod).
+ */
+export async function getOutletBySlug(slug: string): Promise<OutletProfile | null> {
+  const trimmed = slug.trim().toLowerCase();
+  if (!trimmed) return null;
+
+  try {
+    const result = await pool.query<DbOutletProfileRow>(
+      `SELECT slug, name, parent_company, parent_company_url, founded_year,
+              funding_model, allsides_rating, allsides_url, allsides_last_checked,
+              mbfc_factual, mbfc_url, mbfc_last_checked,
+              major_funders, external_links, notes
+       FROM outlet_profiles
+       WHERE slug = $1
+       LIMIT 1`,
+      [trimmed]
+    );
+    if (result.rows.length === 0) return null;
+    return parseDbOutletProfile(result.rows[0]);
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("does not exist")) return null;
+    throw err;
+  }
+}
+
+/**
+ * Fetch the N most recent articles published by an outlet, identified by
+ * slug. Resolves the slug → set of source_names via `source_name_aliases`
+ * (explicit) ∪ `outlet_profiles.name` (implicit fallback), then queries
+ * articles whose lower-cased source_name lands in that set.
+ *
+ * Tolerates missing tables (returns []) so the dossier can render the
+ * outlet's static metadata even before sift-api Phase 2.A.1 lands in prod.
+ */
+export async function getRecentArticlesByOutletSlug(
+  slug: string,
+  limit = 20
+): Promise<DbArticle[]> {
+  const trimmed = slug.trim().toLowerCase();
+  if (!trimmed) return [];
+
+  try {
+    const result = await pool.query<DbArticle>(
+      `WITH outlet_source_names AS (
+         SELECT LOWER(name) AS sn
+         FROM outlet_profiles
+         WHERE slug = $1
+         UNION
+         SELECT LOWER(raw_source_name) AS sn
+         FROM source_name_aliases
+         WHERE outlet_slug = $1
+       )
+       SELECT id, title, summary, source_url, source_name, image_url,
+              category, published_date, read_time, why_it_matters, importance_score,
+              context_primer, reading_levels, created_at
+       FROM articles
+       WHERE LOWER(source_name) IN (SELECT sn FROM outlet_source_names)
+         AND from_search = false
+         AND summary IS NOT NULL AND summary != ''
+         AND LOWER(summary) NOT LIKE 'unable to provide%'
+       ORDER BY COALESCE(published_date, created_at) DESC NULLS LAST
+       LIMIT $2`,
+      [trimmed, limit]
+    );
+    return result.rows;
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("does not exist")) return [];
+    throw err;
+  }
 }
 
 export default pool;

--- a/lib/outlet.ts
+++ b/lib/outlet.ts
@@ -6,6 +6,7 @@
 
 import type {
   OutletAllSidesRating,
+  OutletExternalLinks,
   OutletFundingModel,
   OutletMbfcRating,
   OutletProfile,
@@ -79,13 +80,14 @@ export function formatMbfcLabel(
 // ─── DB-row parsing ───────────────────────────────────────────────────
 
 /**
- * Shape of a row from `outlet_profiles`. Fields are TEXT/INT/JSONB at the DB
- * layer; `parseDbOutletProfile` validates and maps them onto the typed
- * `OutletProfile` shape the client consumes.
+ * Shape of a row from `outlet_profiles`. Fields are TEXT/INT/JSONB/DATE at the
+ * DB layer; `parseDbOutletProfile` validates + normalizes them onto the
+ * typed `OutletProfile` shape the client consumes.
  *
- * Extra DB columns (notes, external_links, major_funders, *_last_checked,
- * updated_at) are intentionally omitted here — they're rendered on the
- * dossier page (Phase 2.C) but irrelevant to feed-card badges.
+ * Date columns arrive as `Date` instances from `pg`; we serialize to ISO
+ * YYYY-MM-DD so server→client transit is plain JSON.
+ *
+ * `updated_at` is intentionally omitted — internal-only, never surfaced.
  */
 export interface DbOutletProfileRow {
   slug: string;
@@ -96,8 +98,13 @@ export interface DbOutletProfileRow {
   funding_model: string | null;
   allsides_rating: string | null;
   allsides_url: string | null;
+  allsides_last_checked: Date | string | null;
   mbfc_factual: string | null;
   mbfc_url: string | null;
+  mbfc_last_checked: Date | string | null;
+  major_funders: unknown; // JSONB — validated below
+  external_links: unknown; // JSONB — validated below
+  notes: string | null;
 }
 
 function asAllSides(v: string | null): OutletAllSidesRating | null {
@@ -116,6 +123,52 @@ function asFunding(v: string | null): OutletFundingModel | null {
   if (!v) return null;
   const lower = v.toLowerCase();
   return FUNDING_VALUES.has(lower) ? (lower as OutletFundingModel) : null;
+}
+
+/**
+ * Coerce a Postgres date column value (Date | ISO string | null) to a stable
+ * `YYYY-MM-DD` string for serialization to Client Components. Returns null
+ * for invalid or missing values rather than throwing.
+ */
+function asIsoDate(v: Date | string | null | undefined): string | null {
+  if (v == null) return null;
+  if (v instanceof Date) {
+    if (Number.isNaN(v.getTime())) return null;
+    return v.toISOString().slice(0, 10);
+  }
+  // pg may return DATE columns as plain "YYYY-MM-DD" strings depending on
+  // type-parser config. Trust the prefix if it's well-formed, else null.
+  const trimmed = v.trim();
+  if (/^\d{4}-\d{2}-\d{2}/.test(trimmed)) return trimmed.slice(0, 10);
+  return null;
+}
+
+/**
+ * Validate JSONB `major_funders` (expected shape: `string[]`). Drops any
+ * non-string entries, normalizes whitespace, returns `[]` for malformed
+ * inputs rather than throwing — the dossier renders nothing on `[]`.
+ */
+function asMajorFunders(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+/**
+ * Validate JSONB `external_links` (expected shape: `Record<string, string>`).
+ * Drops non-string values; returns `{}` for malformed inputs.
+ */
+function asExternalLinks(v: unknown): OutletExternalLinks {
+  if (!v || typeof v !== "object" || Array.isArray(v)) return {};
+  const out: OutletExternalLinks = {};
+  for (const [key, value] of Object.entries(v as Record<string, unknown>)) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      out[key] = value.trim();
+    }
+  }
+  return out;
 }
 
 /**
@@ -141,7 +194,31 @@ export function parseDbOutletProfile(
     fundingModel: asFunding(row.funding_model),
     allSidesRating: asAllSides(row.allsides_rating),
     allSidesUrl: row.allsides_url?.trim() || null,
+    allSidesLastChecked: asIsoDate(row.allsides_last_checked),
     mbfcFactual: asMbfc(row.mbfc_factual),
     mbfcUrl: row.mbfc_url?.trim() || null,
+    mbfcLastChecked: asIsoDate(row.mbfc_last_checked),
+    majorFunders: asMajorFunders(row.major_funders),
+    externalLinks: asExternalLinks(row.external_links),
+    notes: row.notes?.trim() || null,
   };
+}
+
+// ─── Display labels for the rest of the dossier ─────────
+
+const FUNDING_LABELS: Record<OutletFundingModel, string> = {
+  subscription: "Subscription",
+  advertising: "Advertising",
+  foundation: "Foundation",
+  donations: "Reader donations",
+  mixed: "Mixed",
+  "public-service": "Public service",
+};
+
+/** Human label for a funding-model enum value. */
+export function formatFundingLabel(
+  model: OutletFundingModel | null | undefined,
+): string | null {
+  if (!model) return null;
+  return FUNDING_LABELS[model] ?? null;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -82,9 +82,23 @@ export type OutletFundingModel =
   | "public-service";
 
 /**
+ * Optional sub-shape: JSONB `external_links` from `outlet_profiles`. All keys
+ * optional and free-form; the dossier renders only the ones it knows about.
+ */
+export interface OutletExternalLinks {
+  wikipedia?: string;
+  official?: string;
+  ownership?: string;
+  [key: string]: string | undefined;
+}
+
+/**
  * Curated outlet metadata, mirrored from `outlet_profiles` in Postgres.
  * Hand-maintained quarterly. The dossier page (Phase 2.C) renders the full
  * shape; OutletBadge in feed cards renders only `name` + `allSidesRating`.
+ *
+ * Date fields are ISO YYYY-MM-DD strings (not Date) so Server Components can
+ * serialize them straight to Client Components without rehydration loss.
  */
 export interface OutletProfile {
   slug: string;
@@ -95,8 +109,13 @@ export interface OutletProfile {
   fundingModel: OutletFundingModel | null;
   allSidesRating: OutletAllSidesRating | null;
   allSidesUrl: string | null;
+  allSidesLastChecked: string | null;
   mbfcFactual: OutletMbfcRating | null;
   mbfcUrl: string | null;
+  mbfcLastChecked: string | null;
+  majorFunders: string[];
+  externalLinks: OutletExternalLinks;
+  notes: string | null;
 }
 
 export interface ContextPrimerTerm {


### PR DESCRIPTION
## Summary
- Adds **`/outlet/[slug]`** — server-rendered editorial dossier surfacing ownership, funding, AllSides bias, MBFC factual reporting, external links, and recent stories for each curated outlet
- Visual register matches `/colophon`: kicker eyebrows, hairline rules, mono labels, Fraunces display type
- Server component with `revalidate = 600` (10-minute ISR, same heartbeat as the landing)
- Builds on #76 (just merged); the OutletBadge in feed cards now links somewhere real

## What ships
| Layer | File | Change |
|---|---|---|
| Types | `lib/types.ts` | `OutletExternalLinks`; `OutletProfile` extended with `allSidesLastChecked`, `mbfcLastChecked`, `majorFunders`, `externalLinks`, `notes` |
| Parser | `lib/outlet.ts` | `asIsoDate`, `asMajorFunders`, `asExternalLinks` JSONB-safe parsers; `formatFundingLabel` |
| DB | `lib/db.ts` | `getOutletBySlug` + `getRecentArticlesByOutletSlug` (CTE: `source_name_aliases` ∪ `outlet_profiles.name`); existing `getOutletProfilesMap` query widened to the new columns |
| Route | `app/outlet/[slug]/page.tsx` (new) | Async server component, parallel fetch, `notFound()` on miss, `generateMetadata` for SEO |
| Component | `components/outlet/OutletDossier.tsx` (new) | One-column max-w-800 layout; conditional sections; recent-stories list (no OutletBadge — redundant by construction) |
| Copy | `lib/copy.ts` | `COPY.dossier.*` strings + citation formatter + external-link labels |
| Tests | `__tests__/outlet.test.ts` | +13 tests for funding label, date normalization, JSONB validation |

## Visual register
- **Header**: `Outlet dossier` kicker → outlet name in Fraunces 36-44 → lede line "`{parent} · Founded {year} · {funding}`"
- **Ratings strip**: AllSides + MBFC each in a half-column. Heading is the rating label in Fraunces 26 + a `mono 12px` citation line linking to the source page (opens new tab) with last-verified date
- **Ownership / funders / external links**: kicker label + content; external links use the same `180/1fr` grid as `/colophon`'s STACK list
- **Recent stories**: tight hairline list, headline + meta line, links open the source URL externally
- **Footer**: back-to-Sift + methodology hint placeholder (the methodology link goes live in Phase 2.D)

## Tests
- 7 suites / 132 tests pass; `tsc --noEmit` clean
- New tests exercise: funding label coverage, date instance/ISO/malformed handling, JSONB array+object validation with mixed types, whitespace + non-string filtering, array-as-object rejection

## Graceful degradation
- `getOutletBySlug` returns `null` when `outlet_profiles` doesn't exist → `notFound()` renders the existing global 404 page ("This page wandered off")
- `getRecentArticlesByOutletSlug` returns `[]` on missing tables → recent-stories empty-state copy renders gracefully
- Until [sift-api PR #25](https://github.com/kristenmartino/sift-api/pull/25) merges + Railway redeploys + `seed_outlet_profiles.py` runs, every `/outlet/[slug]` lands on a 404 — no broken half-state

## Out of scope (queued)
- **Phase 2.C.2** — framings → CrossSpectrumCompare in StoryCard
- **Phase 2.D** — `/methodology` page (footer hint is plain text until then)

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 132 passing
- [ ] Visual: dev preview `/outlet/reuters` once `outlet_profiles` is seeded in prod or locally
- [ ] Visual: `/outlet/does-not-exist` returns the global 404 page
- [ ] Visual: light + dark mode parity; mobile narrow-viewport reflow
- [ ] Recent-stories list: titles wrap correctly; `timeAgo` matches feed cards
- [ ] AllSides + MBFC citation links open in new tabs with rel noopener

🤖 Generated with [Claude Code](https://claude.com/claude-code)