### PR TITLE
feat: civic-literacy MVP Phase 2.C.2 — cross-spectrum framings view

### DIFF
--- a/__tests__/crossSpectrum.test.ts
+++ b/__tests__/crossSpectrum.test.ts
@@ -1,0 +1,226 @@
+import {
+  bucketize,
+  groupFramingsByBucket,
+  shouldRenderCrossSpectrum,
+  CROSS_SPECTRUM_BUCKETS,
+} from "@/lib/crossSpectrum";
+import type {
+  OutletAllSidesRating,
+  OutletProfile,
+  StoryFraming,
+} from "@/lib/types";
+
+// ─── Test fixtures ────────────────────────────────────────
+
+function makeOutlet(
+  slug: string,
+  rating: OutletAllSidesRating | null,
+): OutletProfile {
+  return {
+    slug,
+    name: slug.replace(/-/g, " "),
+    parentCompany: null,
+    parentCompanyUrl: null,
+    foundedYear: null,
+    fundingModel: null,
+    allSidesRating: rating,
+    allSidesUrl: null,
+    allSidesLastChecked: null,
+    mbfcFactual: null,
+    mbfcUrl: null,
+    mbfcLastChecked: null,
+    majorFunders: [],
+    externalLinks: {},
+    notes: null,
+  };
+}
+
+function makeFraming(
+  sourceName: string,
+  rating: OutletAllSidesRating | null,
+): StoryFraming {
+  return {
+    sourceName,
+    framing: `${sourceName} took this angle.`,
+    tone: "neutral",
+    outlet: rating === null
+      ? null
+      : makeOutlet(sourceName.toLowerCase(), rating),
+  };
+}
+
+// ─── bucketize ─────────────────────────────────────────────
+
+describe("bucketize", () => {
+  it("groups left + lean-left under 'left'", () => {
+    expect(bucketize("left")).toBe("left");
+    expect(bucketize("lean-left")).toBe("left");
+  });
+
+  it("groups right + lean-right under 'right'", () => {
+    expect(bucketize("right")).toBe("right");
+    expect(bucketize("lean-right")).toBe("right");
+  });
+
+  it("returns 'center' only for literal center", () => {
+    expect(bucketize("center")).toBe("center");
+  });
+
+  it("returns null for 'mixed' (intentionally unbucketable)", () => {
+    expect(bucketize("mixed")).toBeNull();
+  });
+
+  it("returns null for null/undefined", () => {
+    expect(bucketize(null)).toBeNull();
+    expect(bucketize(undefined)).toBeNull();
+  });
+});
+
+describe("CROSS_SPECTRUM_BUCKETS", () => {
+  it("is left → center → right (stable column order)", () => {
+    expect([...CROSS_SPECTRUM_BUCKETS]).toEqual(["left", "center", "right"]);
+  });
+});
+
+// ─── groupFramingsByBucket ─────────────────────────────────
+
+describe("groupFramingsByBucket", () => {
+  it("places each framing in the correct bucket", () => {
+    const groups = groupFramingsByBucket([
+      makeFraming("Vox", "left"),
+      makeFraming("NPR", "center"),
+      makeFraming("WSJ", "lean-right"),
+    ]);
+    expect(groups.left.map((f) => f.sourceName)).toEqual(["Vox"]);
+    expect(groups.center.map((f) => f.sourceName)).toEqual(["NPR"]);
+    expect(groups.right.map((f) => f.sourceName)).toEqual(["WSJ"]);
+    expect(groups.unbucketed).toEqual([]);
+  });
+
+  it("preserves input order within each bucket", () => {
+    const groups = groupFramingsByBucket([
+      makeFraming("Atlantic", "lean-left"),
+      makeFraming("Vox", "left"),
+      makeFraming("Mother Jones", "left"),
+    ]);
+    expect(groups.left.map((f) => f.sourceName)).toEqual([
+      "Atlantic",
+      "Vox",
+      "Mother Jones",
+    ]);
+  });
+
+  it("collects mixed-rated outlets in unbucketed", () => {
+    const groups = groupFramingsByBucket([
+      makeFraming("Some Outlet", "mixed"),
+    ]);
+    expect(groups.unbucketed.map((f) => f.sourceName)).toEqual(["Some Outlet"]);
+    expect(groups.left).toEqual([]);
+    expect(groups.center).toEqual([]);
+    expect(groups.right).toEqual([]);
+  });
+
+  it("collects framings with no outlet match in unbucketed", () => {
+    const groups = groupFramingsByBucket([
+      makeFraming("Unmatched Outlet", null),
+    ]);
+    expect(groups.unbucketed.map((f) => f.sourceName)).toEqual([
+      "Unmatched Outlet",
+    ]);
+  });
+
+  it("handles an empty input array", () => {
+    expect(groupFramingsByBucket([])).toEqual({
+      left: [],
+      center: [],
+      right: [],
+      unbucketed: [],
+    });
+  });
+});
+
+// ─── shouldRenderCrossSpectrum ──────────────────────────────
+
+describe("shouldRenderCrossSpectrum", () => {
+  it("returns true when ≥3 framings span all 3 buckets", () => {
+    expect(
+      shouldRenderCrossSpectrum([
+        makeFraming("Vox", "left"),
+        makeFraming("NPR", "center"),
+        makeFraming("WSJ", "lean-right"),
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns true when ≥3 framings span exactly 2 buckets", () => {
+    expect(
+      shouldRenderCrossSpectrum([
+        makeFraming("Vox", "left"),
+        makeFraming("Mother Jones", "left"),
+        makeFraming("WSJ", "lean-right"),
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when only 2 framings, even if cross-bucket", () => {
+    // The plan-recommended Moderate threshold is ≥3 framings; a 2-framing
+    // disagreement still falls back to the flat list view.
+    expect(
+      shouldRenderCrossSpectrum([
+        makeFraming("Vox", "left"),
+        makeFraming("WSJ", "right"),
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns false when 3 framings all sit in one bucket", () => {
+    // 3 Lean-Left outlets isn't editorially cross-spectrum.
+    expect(
+      shouldRenderCrossSpectrum([
+        makeFraming("Vox", "left"),
+        makeFraming("Mother Jones", "left"),
+        makeFraming("Atlantic", "lean-left"),
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns false when unbucketed framings can't substitute for L/C/R diversity", () => {
+    // Vox (Left) + 2 unbucketed = 1 occupied bucket, not 2.
+    expect(
+      shouldRenderCrossSpectrum([
+        makeFraming("Vox", "left"),
+        makeFraming("Mixed Outlet", "mixed"),
+        makeFraming("Unmatched Outlet", null),
+      ]),
+    ).toBe(false);
+  });
+
+  it("counts only bucketed framings toward the ≥3 threshold", () => {
+    // 2 bucketed (Vox, WSJ) + 2 unbucketed = only 2 bucketed, fails the ≥3
+    // threshold even though 4 framings total and 2 buckets occupied.
+    expect(
+      shouldRenderCrossSpectrum([
+        makeFraming("Vox", "left"),
+        makeFraming("WSJ", "right"),
+        makeFraming("Mixed Outlet", "mixed"),
+        makeFraming("Unmatched Outlet", null),
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns false for an empty array", () => {
+    expect(shouldRenderCrossSpectrum([])).toBe(false);
+  });
+
+  it("ignores duplicate-source framings (caller is responsible for dedup)", () => {
+    // The function bucketizes whatever it's given; StoryCard dedupes by
+    // sourceName upstream. Confirms we don't re-validate that here.
+    expect(
+      shouldRenderCrossSpectrum([
+        makeFraming("Vox", "left"),
+        makeFraming("Vox", "left"),
+        makeFraming("WSJ", "right"),
+      ]),
+    ).toBe(true);
+  });
+});

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -112,11 +112,16 @@ export async function GET(request: NextRequest) {
       const rawFramings = Array.isArray(s.framings) ? s.framings : [];
       const framings: StoryFraming[] = (rawFramings as unknown[])
         .filter((f): f is Record<string, unknown> => typeof f === "object" && f !== null)
-        .map((f) => ({
-          sourceName: stripHtml(String(f.source_name ?? "")),
-          framing: stripHtml(String(f.framing ?? "")),
-          tone: (typeof f.tone === "string" ? f.tone : "neutral") as StoryFraming["tone"],
-        }));
+        .map((f) => {
+          const sourceName = stripHtml(String(f.source_name ?? ""));
+          const outlet = resolveOutletForSourceName(outletMap, sourceName);
+          return {
+            sourceName,
+            framing: stripHtml(String(f.framing ?? "")),
+            tone: (typeof f.tone === "string" ? f.tone : "neutral") as StoryFraming["tone"],
+            ...(outlet ? { outlet } : {}),
+          };
+        });
 
       // Parse JSONB entities (validate types, sanitize external text)
       const rawEntities = Array.isArray(s.entities) ? s.entities : [];

--- a/components/CrossSpectrumCompare.tsx
+++ b/components/CrossSpectrumCompare.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { COPY } from "@/lib/copy";
+import {
+  CROSS_SPECTRUM_BUCKETS,
+  groupFramingsByBucket,
+  shouldRenderCrossSpectrum,
+  type CrossSpectrumBucket,
+} from "@/lib/crossSpectrum";
+import type { StoryFraming } from "@/lib/types";
+import OutletBadge from "./outlet/OutletBadge";
+
+interface CrossSpectrumCompareProps {
+  framings: StoryFraming[];
+}
+
+/**
+ * Side-by-side cross-spectrum view of how outlets across the political
+ * spectrum framed the same story. Civic-literacy MVP Phase 2.C.2.
+ *
+ * Renders as a 2- or 3-column grid (one column per occupied bucket) on
+ * desktop, stacked sections on mobile. Each column shows its bucketed
+ * framings as `outlet name + headline-style framing text`.
+ *
+ * Returns null when the story doesn't clear the cross-spectrum threshold
+ * (≥3 bucketed framings, ≥2 buckets). The caller should fall back to the
+ * flat-list framings render in that case — see StoryCard for the
+ * integration. Unbucketed framings (mixed-rated outlets, unmatched
+ * source_names) drop out of this view entirely; the StoryCard's expanded
+ * "View N articles" list still surfaces them.
+ *
+ * Visual register matches StoryCard's existing framings block — same
+ * `.story-row` hover affordance, same `text-outlet` register on outlet
+ * names, just laid out in columns instead of rows.
+ */
+export default function CrossSpectrumCompare({
+  framings,
+}: CrossSpectrumCompareProps) {
+  if (!shouldRenderCrossSpectrum(framings)) return null;
+
+  const groups = groupFramingsByBucket(framings);
+  const occupied = CROSS_SPECTRUM_BUCKETS.filter(
+    (b) => groups[b].length > 0,
+  );
+
+  // Adapt the grid to the number of populated buckets so 2-column stories
+  // (Left + Right but no Center, e.g.) don't render an empty third column.
+  // Mobile always single-column; desktop 2 or 3 columns matching `occupied`.
+  const desktopCols =
+    occupied.length === 3 ? "md:grid-cols-3" : "md:grid-cols-2";
+
+  return (
+    <div className="mt-1">
+      <div className="flex items-center gap-3 mb-3">
+        <p className="text-kicker font-bold uppercase text-[var(--text-muted)] shrink-0">
+          {COPY.stories.crossSpectrumHeader}
+        </p>
+        <span
+          aria-hidden
+          className="flex-1 h-px bg-gradient-to-r from-[var(--border)] to-transparent"
+        />
+      </div>
+      <div className={`grid grid-cols-1 ${desktopCols} gap-x-5 gap-y-4`}>
+        {occupied.map((bucket) => (
+          <CrossSpectrumColumn
+            key={bucket}
+            bucket={bucket}
+            framings={groups[bucket]}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface CrossSpectrumColumnProps {
+  bucket: CrossSpectrumBucket;
+  framings: StoryFraming[];
+}
+
+function CrossSpectrumColumn({ bucket, framings }: CrossSpectrumColumnProps) {
+  const label = COPY.stories.crossSpectrumBucketLabels[bucket];
+  return (
+    <div className="flex flex-col">
+      {/* Bucket header — uppercase rail-style label with hairline underline.
+          Same register as the outer "Across the spectrum" eyebrow but
+          tighter, so the column hierarchy reads at a glance. */}
+      <div className="flex items-center gap-2 mb-2.5">
+        <span className="text-outlet font-semibold uppercase text-[var(--text)] shrink-0">
+          {label}
+        </span>
+        <span
+          aria-hidden
+          className="flex-1 h-px bg-[var(--border-subtle)]"
+        />
+      </div>
+      <div className="flex flex-col">
+        {framings.map((f) => (
+          <div
+            key={f.sourceName}
+            className="story-row flex flex-col gap-1.5 py-2.5 border-b border-[color:var(--border-subtle)] last:border-b-0"
+          >
+            <span aria-hidden className="story-row__rail" />
+            <OutletBadge
+              outlet={f.outlet}
+              fallback={f.sourceName}
+              variant="rail"
+              className="story-row__source shrink-0"
+            />
+            <span className="text-body text-[var(--text-secondary)] leading-snug">
+              {f.framing}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -5,7 +5,9 @@ import { CATEGORIES, CATEGORY_COLORS } from "@/lib/constants";
 import { COPY } from "@/lib/copy";
 import { timeAgo } from "@/lib/utils";
 import CardImage from "./CardImage";
+import CrossSpectrumCompare from "./CrossSpectrumCompare";
 import OutletBadge from "./outlet/OutletBadge";
+import { shouldRenderCrossSpectrum } from "@/lib/crossSpectrum";
 import type { StoryCardProps } from "@/lib/types";
 
 // Tone labels are no longer rendered (civic-literacy pivot, Phase 0).
@@ -84,6 +86,11 @@ export default function StoryCard({
   // Below threshold, the cluster reads as related coverage from one
   // outlet and the article-list expand still works as intended.
   const isMultiSource = uniqueSourceCount >= 2;
+  // Stricter check: the cross-spectrum L/C/R view needs ≥3 framings
+  // bucketed across ≥2 of the L/C/R buckets (the plan-recommended
+  // "Moderate" threshold). When this clears, render CrossSpectrumCompare;
+  // otherwise fall back to the existing flat-list framings render.
+  const renderCrossSpectrum = isMultiSource && shouldRenderCrossSpectrum(uniqueFramings);
 
   return (
     <article
@@ -210,8 +217,17 @@ export default function StoryCard({
         {/* Framings section — only render when 2+ unique outlets disagree
             on framing. Single-outlet clusters (one outlet, multiple
             near-duplicate articles) skip this section entirely so the card
-            never claims cross-outlet coverage that doesn't exist. */}
-        {isMultiSource && (
+            never claims cross-outlet coverage that doesn't exist.
+
+            When the cross-spectrum threshold clears (≥3 framings, ≥2 of
+            L/C/R buckets occupied — Phase 2.C.2), render the side-by-side
+            CrossSpectrumCompare. Otherwise render the historical flat list,
+            which still makes a multi-outlet point even without political
+            spectrum diversity (e.g. all framings from Lean Left outlets). */}
+        {isMultiSource && renderCrossSpectrum && (
+          <CrossSpectrumCompare framings={uniqueFramings} />
+        )}
+        {isMultiSource && !renderCrossSpectrum && (
           <div className="mt-1">
             <div className="flex items-center gap-3 mb-3">
               <p className="text-kicker font-bold uppercase text-[var(--text-muted)] shrink-0">
@@ -229,9 +245,12 @@ export default function StoryCard({
                   className="story-row flex items-start gap-4 py-2.5 border-b border-[color:var(--border-subtle)] last:border-b-0"
                 >
                   <span aria-hidden className="story-row__rail" />
-                  <span className="story-row__source text-outlet font-semibold uppercase text-[var(--text)] shrink-0 min-w-[88px]">
-                    {f.sourceName}
-                  </span>
+                  <OutletBadge
+                    outlet={f.outlet}
+                    fallback={f.sourceName}
+                    variant="rail"
+                    className="story-row__source shrink-0 min-w-[88px]"
+                  />
                   <span className="text-body text-[var(--text-secondary)] flex-1">
                     {f.framing}
                   </span>

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -63,6 +63,15 @@ export const COPY = {
         : count <= 3
           ? `How ${count} outlets framed it`
           : `How ${count} outlets covered this`,
+    // Eyebrow shown above the cross-spectrum L/C/R columns, in place of
+    // the standard "How N outlets framed it" header when the story
+    // qualifies for cross-spectrum (≥3 bucketed framings, ≥2 buckets).
+    crossSpectrumHeader: "Across the spectrum",
+    crossSpectrumBucketLabels: {
+      left: "Left",
+      center: "Center",
+      right: "Right",
+    } as const,
     compareRow: "See angles",
     expandedMeta: (when: string, count: number) =>
       `Updated ${when} · ${count} ${count === 1 ? "source" : "sources"}`,

--- a/lib/crossSpectrum.ts
+++ b/lib/crossSpectrum.ts
@@ -1,0 +1,93 @@
+// Cross-spectrum bucketing + threshold helpers — civic-literacy MVP
+// Phase 2.C.2.
+//
+// Pure functions for grouping framings by political-lean bucket and deciding
+// when a story qualifies for the side-by-side cross-spectrum view. Isolated
+// from the React component so the bucketing logic is unit-testable on its
+// own and CrossSpectrumCompare can stay declarative.
+
+import type { OutletAllSidesRating, StoryFraming } from "./types";
+
+/**
+ * Three editorial buckets the cross-spectrum view groups outlets into.
+ * "lean-left" + "left" both land in `left`; "lean-right" + "right" in
+ * `right`; only literal `center` lands in `center`. AllSides' "mixed"
+ * rating is intentionally not bucketable — those framings drop out of the
+ * cross-spectrum view (they read as "doesn't take a consistent side").
+ */
+export type CrossSpectrumBucket = "left" | "center" | "right";
+
+/** Stable column order: left → center → right (mirrors AllSides' L/C/R). */
+export const CROSS_SPECTRUM_BUCKETS: readonly CrossSpectrumBucket[] = [
+  "left",
+  "center",
+  "right",
+];
+
+/**
+ * Map an AllSides rating to a cross-spectrum bucket. Returns null for
+ * `mixed`, null, undefined, or any unexpected value — callers should drop
+ * unbucketable framings from the cross-spectrum render.
+ */
+export function bucketize(
+  rating: OutletAllSidesRating | null | undefined,
+): CrossSpectrumBucket | null {
+  if (rating === "left" || rating === "lean-left") return "left";
+  if (rating === "center") return "center";
+  if (rating === "right" || rating === "lean-right") return "right";
+  return null;
+}
+
+/**
+ * Group framings into the three cross-spectrum buckets. Framings without a
+ * resolved outlet, or whose outlet has a null/`mixed` AllSides rating, are
+ * collected under `unbucketed`. CrossSpectrumCompare drops `unbucketed`
+ * from its render; the StoryCard's flat-list fallback still surfaces them.
+ */
+export interface BucketizedFramings {
+  left: StoryFraming[];
+  center: StoryFraming[];
+  right: StoryFraming[];
+  unbucketed: StoryFraming[];
+}
+
+export function groupFramingsByBucket(
+  framings: StoryFraming[],
+): BucketizedFramings {
+  const groups: BucketizedFramings = {
+    left: [],
+    center: [],
+    right: [],
+    unbucketed: [],
+  };
+  for (const framing of framings) {
+    const bucket = bucketize(framing.outlet?.allSidesRating);
+    if (bucket) {
+      groups[bucket].push(framing);
+    } else {
+      groups.unbucketed.push(framing);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Plan-recommended threshold ("Moderate") for rendering cross-spectrum:
+ *   - At least 3 framings whose outlets resolve to a L/C/R bucket
+ *   - Those framings span at least 2 of the three buckets
+ *
+ * Stricter than `isMultiSource` (≥2 outlets) — a Left + Lean-Left
+ * disagreement would clear `isMultiSource` but isn't editorially
+ * cross-spectrum. Looser than the strict (L+C+R required) — most stories
+ * never have all three by chance. Rejected unbucketed framings are still
+ * surfaced via the StoryCard's flat-list fallback.
+ */
+export function shouldRenderCrossSpectrum(framings: StoryFraming[]): boolean {
+  const groups = groupFramingsByBucket(framings);
+  const bucketed = groups.left.length + groups.center.length + groups.right.length;
+  if (bucketed < 3) return false;
+  const occupied = (CROSS_SPECTRUM_BUCKETS).filter(
+    (b) => groups[b].length > 0,
+  ).length;
+  return occupied >= 2;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -142,6 +142,14 @@ export interface StoryFraming {
   sourceName: string;
   framing: string;
   tone: "neutral" | "urgent" | "analytical" | "critical" | "optimistic";
+  /**
+   * Outlet provenance — civic-literacy MVP Phase 2.C.2. Resolved at the API
+   * boundary by mapping `sourceName` through `source_name_aliases` →
+   * `outlet_profiles`. Drives the cross-spectrum bucketing + dossier link
+   * inside CrossSpectrumCompare. Null/undefined when the source_name has no
+   * curated outlet (graceful degradation: fallback to the flat list).
+   */
+  outlet?: OutletProfile | null;
 }
 
 export interface EntitySet {


### PR DESCRIPTION
## Summary
When a story qualifies (≥3 framings, ≥2 of L/C/R buckets), StoryCard's framings section becomes a 2- or 3-column side-by-side view of how outlets across the political spectrum framed the same story. Falls back to the existing flat-list render when the threshold isn't met (e.g., 3 Lean-Left framings — multi-source, but not editorially cross-spectrum).

## What ships
| Layer | File | Change |
|---|---|---|
| Types | `lib/types.ts` | `StoryFraming.outlet?: OutletProfile` (optional, mirrors 2.B's Article treatment) |
| Helpers | `lib/crossSpectrum.ts` (new) | `bucketize`, `groupFramingsByBucket`, `shouldRenderCrossSpectrum`, `CROSS_SPECTRUM_BUCKETS` — pure functions, isolated from the component for testing |
| API | `app/api/news/route.ts` | Framings now enriched with outlet via the same `resolveOutletForSourceName` lookup; no extra DB round-trip |
| Component | `components/CrossSpectrumCompare.tsx` (new) | "use client"; renders 2- or 3-col grid matching occupied buckets; reuses `.story-row` hover + `text-outlet` register |
| Integration | `components/StoryCard.tsx` | Framings render branches on `renderCrossSpectrum`; `isMultiSource` remains the outer gate |
| Copy | `lib/copy.ts` | `crossSpectrumHeader: "Across the spectrum"`, `crossSpectrumBucketLabels: { left, center, right }` |
| Tests | `__tests__/crossSpectrum.test.ts` (new) | 19 tests covering bucketing logic + threshold predicate |

## Bucketing rules
- `left` ∪ `lean-left` → **Left**
- `center` → **Center**
- `right` ∪ `lean-right` → **Right**
- `mixed` and unmatched outlets → unbucketed (drop from cross-spectrum view; expanded "View N articles" list still shows them)

## Threshold (plan-recommended "Moderate")
- ≥ 3 framings whose outlets resolve to a L/C/R bucket
- Those framings span ≥ 2 of {Left, Center, Right}

Stricter than `isMultiSource` (≥2 outlets) — Vox + Mother Jones still reads as "agreement among Lean Left peers." Looser than strict L+C+R required — most stories never have all three by chance.

## Visual register
- Outer eyebrow: `Across the spectrum` in kicker style + hairline rule, mirroring the existing `How N outlets framed it` pattern
- Per-column header: `LEFT` / `CENTER` / `RIGHT` in `text-outlet` rail register + thin hairline underline
- Per-framing row: outlet name (linked to dossier via OutletBadge `variant="rail"`) over the framing text. Same `.story-row` hover affordance as the flat list (accent rail, 2px source-name slide, fade-in CTA)
- 1 column on mobile (stacks Left → Center → Right vertically); `md:grid-cols-{2,3}` on desktop

## Tests
- 8 suites / 151 tests pass; `tsc --noEmit` clean
- New tests exercise: bucketize edge cases, group-by routing + order preservation, threshold positive cases (3-bucket spread, 2-bucket spread), threshold negatives (only 2 framings, all-one-bucket, unbucketed can't substitute, < 3 bucketed total, empty input)

## Graceful degradation
When outlet data is missing or sparse (`shouldRenderCrossSpectrum` returns false), the historical flat-list framings render is unchanged. No regression risk independent of the data layer's state.

## Out of scope (queued for Phase 2.D)
- `/methodology` page documenting the L/C/R bucketing, AllSides + MBFC source links, inclusion/exclusion criteria, quarterly refresh cadence
- The dossier footer's "methodology hint" stays plain text until 2.D ships

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 151 passing
- [ ] Visual: dev preview — find a story with ≥3 outlet diversity (e.g. a top-news cluster covered by NPR + Vox + WSJ); confirm 3-column desktop layout; mobile stack
- [ ] Visual: a 2-bucket story renders as 2 columns (no empty Right column)
- [ ] Visual: a 3-Lean-Left-outlet story renders as the flat list (cross-spectrum threshold not met)
- [ ] Hover affordance preserved: rail fades in, source-name slides 2px right
- [ ] Click outlet name → lands on `/outlet/[slug]` dossier (Phase 2.C.1)
- [ ] Light + dark mode parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)