### PR TITLE
feat: civic-literacy MVP Phase 2.D — methodology page

### DIFF
--- a/app/methodology/page.tsx
+++ b/app/methodology/page.tsx
@@ -1,0 +1,240 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import LandingMasthead from "@/components/landing/LandingMasthead";
+import { getAllOutletProfiles } from "@/lib/db";
+import { COPY } from "@/lib/copy";
+import { bucketize, type CrossSpectrumBucket } from "@/lib/crossSpectrum";
+import type { OutletProfile } from "@/lib/types";
+
+export const metadata: Metadata = {
+  title: "Methodology — How Sift sources the news",
+  description:
+    "How Sift selects outlets, surfaces ownership and funding, cites AllSides and MBFC ratings, and applies symmetric treatment across the political spectrum.",
+};
+
+// ISR — methodology copy itself is static, but the live outlet list reads
+// from outlet_profiles which changes when new outlets are curated. Same
+// 10-minute heartbeat as the landing keeps the list fresh without paying
+// the DB cost on every visit.
+export const revalidate = 600;
+
+type BucketKey = CrossSpectrumBucket | "unrated";
+
+function bucketForList(rating: OutletProfile["allSidesRating"]): BucketKey {
+  return bucketize(rating) ?? "unrated";
+}
+
+const BUCKET_ORDER: readonly BucketKey[] = [
+  "left",
+  "center",
+  "right",
+  "unrated",
+];
+
+export default async function MethodologyPage() {
+  const outlets = await getAllOutletProfiles();
+
+  // Group outlets into Left / Center / Right / Unrated. "mixed" + null
+  // ratings land in `unrated` since AllSides treats both as
+  // non-bucketable; the unratedNote in copy explains the distinction.
+  const groups: Record<BucketKey, OutletProfile[]> = {
+    left: [],
+    center: [],
+    right: [],
+    unrated: [],
+  };
+  for (const outlet of outlets) {
+    groups[bucketForList(outlet.allSidesRating)].push(outlet);
+  }
+
+  const m = COPY.methodology;
+
+  return (
+    <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
+      <LandingMasthead />
+
+      <main
+        id="main-content"
+        className="max-w-[800px] mx-auto px-6 pt-12 pb-24"
+      >
+        {/* Eyebrow + headline + lede */}
+        <header className="mb-9">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3 flex items-center">
+            <span
+              aria-hidden
+              className="inline-block w-7 h-px bg-[var(--border)] mr-3"
+            />
+            {m.eyebrow}
+          </p>
+          <h1 className="font-heading text-[36px] md:text-[44px] font-bold leading-[1.05] tracking-tight text-[var(--text)]">
+            {m.title}
+          </h1>
+          <p className="font-body text-[16px] text-[var(--text-secondary)] mt-3 max-w-[60ch] leading-relaxed">
+            {m.lede}
+          </p>
+        </header>
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* What Sift reads — live outlet list grouped by AllSides bucket */}
+        <section className="mb-12">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-4">
+            {m.sections.includes.kicker}
+          </p>
+          <p className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed max-w-[60ch] mb-7">
+            {m.sections.includes.body}
+          </p>
+          {outlets.length > 0 ? (
+            <div className="space-y-7">
+              {BUCKET_ORDER.map((bucket) => {
+                const list = groups[bucket];
+                if (list.length === 0) return null;
+                return (
+                  <div key={bucket}>
+                    <p className="font-body text-outlet uppercase tracking-wider text-[var(--text)] font-semibold mb-2.5">
+                      {m.sections.includes.bucketLabels[bucket]} ({list.length})
+                    </p>
+                    <ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-1.5">
+                      {list.map((outlet) => (
+                        <li key={outlet.slug}>
+                          <Link
+                            href={`/outlet/${outlet.slug}`}
+                            className="font-body text-[13px] text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline tracking-tight"
+                          >
+                            {outlet.name}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                );
+              })}
+              {groups.unrated.length > 0 && (
+                <p className="font-body text-[12px] text-[var(--text-muted)] italic max-w-[60ch] leading-relaxed pt-2">
+                  {m.sections.includes.unratedNote}
+                </p>
+              )}
+            </div>
+          ) : (
+            // Graceful: outlet_profiles isn't populated yet (or table missing).
+            // The page still reads as a methodology doc; the missing list is
+            // an acceptable empty state rather than a broken section.
+            <p className="font-body text-[14px] text-[var(--text-muted)] italic max-w-[60ch] leading-relaxed">
+              The curated outlet list will appear here once it's seeded.
+            </p>
+          )}
+        </section>
+
+        {/* What Sift excludes */}
+        <section className="mb-12">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-4">
+            {m.sections.excludes.kicker}
+          </p>
+          <p className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed max-w-[60ch] mb-4">
+            {m.sections.excludes.body}
+          </p>
+          <ul className="space-y-2.5 max-w-[60ch]">
+            {m.sections.excludes.items.map((item) => (
+              <li
+                key={item}
+                className="font-body text-[14px] text-[var(--text-secondary)] leading-relaxed flex items-baseline gap-3"
+              >
+                <span aria-hidden className="text-[var(--accent)] shrink-0">
+                  ◆
+                </span>
+                {item}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Bias ratings explainer */}
+        <section className="mb-12">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-4">
+            {m.sections.bias.kicker}
+          </p>
+          <p className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed max-w-[60ch] mb-3">
+            {m.sections.bias.body}
+          </p>
+          <a
+            href={m.sections.bias.citeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-body text-meta text-[var(--text-muted)] no-underline hover:underline hover:text-[var(--accent)]"
+          >
+            {m.sections.bias.cite} <span aria-hidden>↗</span>
+          </a>
+        </section>
+
+        {/* Factual-reporting explainer */}
+        <section className="mb-12">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-4">
+            {m.sections.factual.kicker}
+          </p>
+          <p className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed max-w-[60ch] mb-3">
+            {m.sections.factual.body}
+          </p>
+          <a
+            href={m.sections.factual.citeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-body text-meta text-[var(--text-muted)] no-underline hover:underline hover:text-[var(--accent)]"
+          >
+            {m.sections.factual.cite} <span aria-hidden>↗</span>
+          </a>
+        </section>
+
+        {/* Symmetric application */}
+        <section className="mb-12">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-4">
+            {m.sections.symmetric.kicker}
+          </p>
+          <p className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed max-w-[60ch]">
+            {m.sections.symmetric.body}
+          </p>
+        </section>
+
+        {/* Refresh cadence */}
+        <section className="mb-12">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-4">
+            {m.sections.cadence.kicker}
+          </p>
+          <p className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed max-w-[60ch]">
+            {m.sections.cadence.body}
+          </p>
+        </section>
+
+        {/* Suggest an addition or correction */}
+        <section className="mb-12">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-4">
+            {m.sections.suggest.kicker}
+          </p>
+          <p className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed max-w-[60ch] mb-3">
+            {m.sections.suggest.body}
+          </p>
+          <a
+            href={m.sections.suggest.githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-body text-meta text-[var(--text-muted)] no-underline hover:underline hover:text-[var(--accent)]"
+          >
+            {m.sections.suggest.github} <span aria-hidden>↗</span>
+          </a>
+        </section>
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* Back link */}
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <Link
+            href="/"
+            className="font-body text-outlet uppercase tracking-wider text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline inline-flex items-center gap-1.5"
+          >
+            <span aria-hidden>←</span> {m.backLink}
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -67,6 +67,12 @@ export default function LandingPage({ leadStory }: LandingPageProps) {
               {COPY.landing.colophonLink}
             </Link>
             <Link
+              href="/methodology"
+              className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline"
+            >
+              Methodology
+            </Link>
+            <Link
               href="/privacy"
               className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline"
             >

--- a/components/outlet/OutletDossier.tsx
+++ b/components/outlet/OutletDossier.tsx
@@ -290,11 +290,12 @@ export default function OutletDossier({
           >
             <span aria-hidden>←</span> Back to Sift
           </Link>
-          {/* Methodology link: queued for Phase 2.D. Until that route exists,
-              we render the hint as plain text rather than a broken link. */}
-          <span className="font-body text-meta text-[var(--text-muted)] italic">
+          <Link
+            href="/methodology"
+            className="font-body text-meta text-[var(--text-muted)] italic no-underline hover:text-[var(--accent)] hover:not-italic transition-colors"
+          >
             {COPY.dossier.methodologyHint}
-          </span>
+          </Link>
         </div>
       </main>
     </div>

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -114,6 +114,70 @@ export const COPY = {
     // Section header inside the expanded primer when there are key terms.
     termsLabel: "Key terms",
   },
+  methodology: {
+    eyebrow: "Methodology",
+    title: "How Sift sources the news",
+    lede:
+      "Sift reads from a hand-curated set of news outlets, surfaces ownership and funding for each, and links every bias and factual-reporting rating to its public source. The methodology is the product as much as the feature — here's exactly how it works.",
+    sections: {
+      includes: {
+        kicker: "What Sift reads",
+        body:
+          "Around 50 outlets, hand-picked to balance the political spectrum (AllSides Left → Center → Right), span sector specialties (finance, tech, science, climate, health), and clear a factual-reporting bar. Each outlet has a dossier with ownership, funding model, and external rating links — click any name below.",
+        bucketLabels: {
+          left: "Left",
+          center: "Center",
+          right: "Right",
+          unrated: "Unrated or specialty",
+        },
+        unratedNote:
+          "Outlets without an AllSides rating are typically peer-reviewed scientific journals (Nature, Science) or sector specialists (Carbon Brief, STAT News) where political-lean isn't the relevant axis. MBFC factual-reporting ratings still apply.",
+      },
+      excludes: {
+        kicker: "What Sift excludes",
+        body: "Some categories of source never enter the pipeline:",
+        items: [
+          "Aggregators (Google News, Yahoo News, MSN) — no original reporting.",
+          "AI-content farms — synthetic articles without identifiable bylines.",
+          "Outlets MBFC rates Low Factual or Very Low Factual — regardless of political lean.",
+          "Sites without identifiable bylines, mastheads, or corrections policies.",
+          "Crypto / health-supplement sites that brand themselves as news.",
+        ],
+      },
+      bias: {
+        kicker: "Where bias ratings come from",
+        body:
+          "Sift surfaces AllSides' political-lean rating for each outlet. AllSides classifies outlets into six buckets — Left, Lean Left, Center, Lean Right, Right, Mixed — based on a methodology that combines blind bias surveys, editorial reviews, and reader feedback. Sift never computes its own bias rating; we cite AllSides verbatim with a link to the source page on every dossier.",
+        cite: "AllSides — methodology and ratings (allsides.com)",
+        citeUrl: "https://www.allsides.com/media-bias/media-bias-rating-methods",
+      },
+      factual: {
+        kicker: "Where factual-reporting ratings come from",
+        body:
+          "For factual reporting, Sift surfaces Media Bias/Fact Check (MBFC) ratings on a six-tier scale — Very High, High, Mostly Factual, Mixed, Low, Very Low. MBFC's methodology weighs sourcing standards, fact-check track record, corrections policy, and frequency of false claims. Same rule as bias ratings: we cite verbatim, never compute our own, and link to MBFC for verification.",
+        cite: "Media Bias/Fact Check — methodology (mediabiasfactcheck.com)",
+        citeUrl: "https://mediabiasfactcheck.com/methodology/",
+      },
+      symmetric: {
+        kicker: "Symmetric application",
+        body:
+          "Every outlet gets the same treatment regardless of which side of the spectrum it sits on. Fox News and MSNBC are both shown with their AllSides ratings and MBFC factual-reporting tiers. National Review and The Nation get identical dossier shapes. Sift does not editorialize about which side is more or less reliable — that's the reader's call, with the data in front of them.",
+      },
+      cadence: {
+        kicker: "Refresh cadence",
+        body:
+          "AllSides + MBFC ratings drift over time as outlets shift editorial direction, get acquired, or change sourcing standards. Sift hand-reviews every rating quarterly and stores a last-verified date alongside each one — it's the small mono caption under each rating on the dossier page. Outlet additions happen on demand when readers flag gaps; the inclusion criteria above are the only filter.",
+      },
+      suggest: {
+        kicker: "Suggest an addition or correction",
+        body:
+          "If an outlet is missing, a rating looks stale, or anything in this methodology reads wrong, open an issue on GitHub or send a note. Sift is a portfolio project — corrections land fast.",
+        github: "kristenmartino/sift on GitHub",
+        githubUrl: "https://github.com/kristenmartino/sift/issues/new",
+      },
+    },
+    backLink: "Back to Sift",
+  },
   dossier: {
     // Eyebrow shown above the outlet name.
     eyebrow: "Outlet dossier",

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -505,6 +505,39 @@ export function _resetOutletCacheForTesting(): void {
   outletCacheInflight = null;
 }
 
+// ─── Methodology page (Phase 2.D) ──────────────────────
+
+/**
+ * Fetch every curated outlet, sorted alphabetically by name. Used by the
+ * methodology page to render the live list of outlets Sift reads from.
+ *
+ * Returns [] when outlet_profiles doesn't exist (graceful degradation —
+ * the methodology page falls back to its prose explanation without the
+ * outlet list).
+ */
+export async function getAllOutletProfiles(): Promise<OutletProfile[]> {
+  try {
+    const result = await pool.query<DbOutletProfileRow>(
+      `SELECT slug, name, parent_company, parent_company_url, founded_year,
+              funding_model, allsides_rating, allsides_url, allsides_last_checked,
+              mbfc_factual, mbfc_url, mbfc_last_checked,
+              major_funders, external_links, notes
+       FROM outlet_profiles
+       ORDER BY LOWER(name)`
+    );
+    const out: OutletProfile[] = [];
+    for (const row of result.rows) {
+      const profile = parseDbOutletProfile(row);
+      if (profile) out.push(profile);
+    }
+    return out;
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("does not exist")) return [];
+    throw err;
+  }
+}
+
 // ─── Outlet Dossier (Phase 2.C.1) ──────────────────────
 
 /**


### PR DESCRIPTION
## Summary
Adds **`/methodology`** — Sift's public-facing source-curation policy. Closes the Phase 2 civic-literacy feature loop.

## What ships
| File | Change |
|---|---|
| `app/methodology/page.tsx` (new) | Server-rendered, ISR=600s; live outlet list grouped by L/C/R/Unrated, plus exclusions / AllSides + MBFC explainers / symmetric-application rule / refresh cadence / suggest-a-change link |
| `lib/db.ts` | `getAllOutletProfiles()` — sorted by `LOWER(name)`, tolerates missing tables |
| `lib/copy.ts` | `COPY.methodology` block — all section copy in one place, voice-doc applied |
| `components/outlet/OutletDossier.tsx` | "Read the methodology" hint becomes a real `Link href="/methodology"` (was placeholder text in 2.C.1) |
| `components/LandingPage.tsx` | Methodology link added to footer column between Colophon and Privacy |

## Page sections
1. **What Sift reads** — live outlet list grouped by AllSides bucket (Left / Center / Right / Unrated). Every name links to the dossier (Phase 2.C.1). Footnote explains why specialty + science-journal outlets cluster under "Unrated."
2. **What Sift excludes** — bullet list (aggregators, AI farms, Low-Factual outlets, no-byline sites, crypto/supplement-as-news)
3. **Where bias ratings come from** — AllSides methodology explainer + cite link
4. **Where factual-reporting ratings come from** — MBFC methodology explainer + cite link
5. **Symmetric application** — every outlet gets identical treatment regardless of side
6. **Refresh cadence** — quarterly hand-review, last-verified dates on every rating
7. **Suggest an addition or correction** — GitHub issues link

## Voice
Reads as a patient-teacher manifesto, not an FAQ. Active voice, contractions, no jargon, never partisan. Same voice doc as the rest of the product.

## Tests
- 8 suites / 151 tests pass; `tsc --noEmit` clean
- No new tests — the page is mostly static; the new `getAllOutletProfiles` helper follows the same pattern as `getOutletBySlug` from Phase 2.C.1

## Graceful degradation
- `getAllOutletProfiles` catches "relation does not exist" → returns `[]` → "What Sift reads" section renders an italic "list will appear once seeded" placeholder; everything else (the prose) reads fine
- All external citation links (AllSides, MBFC, GitHub) open in new tabs with `rel="noopener noreferrer"`

## Phase 2 status
With this merged, all of Phase 2 is shipped:
- ✅ 2.A.1 schema + migrations ([sift-api #24](https://github.com/kristenmartino/sift-api/pull/24))
- ✅ 2.A.2 AllSides + MBFC seed CSV ([sift-api #25](https://github.com/kristenmartino/sift-api/pull/25))
- ✅ 2.B outlet badges in feed cards ([#76](https://github.com/kristenmartino/sift/pull/76))
- ✅ 2.C.1 outlet dossier route ([#77](https://github.com/kristenmartino/sift/pull/77))
- ✅ 2.C.2 cross-spectrum framings view ([#78](https://github.com/kristenmartino/sift/pull/78))
- 🆕 2.D `/methodology` page

Still queued: **2.A.3** (alias audit + seed) — gated on Railway redeploy + `seed_outlet_profiles.py` run in prod.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 151 passing
- [ ] Visual: dev preview `/methodology` once `outlet_profiles` is seeded; outlet list groups correctly into L/C/R/Unrated buckets
- [ ] Visual: Unrated bucket footnote renders only when there's at least one Unrated outlet
- [ ] Click-through: outlet name → `/outlet/[slug]` dossier
- [ ] Footer: methodology link in landing footer + dossier footer both navigate correctly
- [ ] External cite links (AllSides, MBFC, GitHub issues) open in new tabs
- [ ] Light + dark mode parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)