### PR TITLE
feat: civic-literacy MVP Phase 3.C — politician dossier route

### DIFF
--- a/__tests__/politician.test.ts
+++ b/__tests__/politician.test.ts
@@ -1,0 +1,351 @@
+import {
+  formatChamberLabel,
+  formatPartyLabel,
+  formatPoliticianLede,
+  parseDbPoliticianProfile,
+  type DbPoliticianProfileRow,
+} from "@/lib/politician";
+
+// ─── Fixtures ──────────────────────────────────────────────
+
+const fullRow: DbPoliticianProfileRow = {
+  bioguide_id: "S000148",
+  name: "Charles E. Schumer",
+  party: "D",
+  state: "NY",
+  chamber: "senate",
+  committees: ["Finance", "Judiciary", "Rules and Administration"],
+  top_industries_current_cycle: [
+    { industry: "Securities & investment", amount_usd: 1_200_000 },
+    { industry: "Real estate", amount_usd: 620_000 },
+  ],
+  interest_group_ratings: { LCV: 92, "AFL-CIO": 100, NRA: "F" },
+  external_links: {
+    govtrack: "https://www.govtrack.us/congress/members/charles_schumer/300087",
+    opensecrets: "https://www.opensecrets.org/members-of-congress/charles-schumer/summary",
+    wikipedia: "https://en.wikipedia.org/wiki/Chuck_Schumer",
+  },
+  notes: "Senate Majority Leader (119th Congress).",
+};
+
+// ─── formatPartyLabel ────────────────────────────────────
+
+describe("formatPartyLabel", () => {
+  it("expands the three primary single-letter codes", () => {
+    expect(formatPartyLabel("D")).toBe("Democrat");
+    expect(formatPartyLabel("R")).toBe("Republican");
+    expect(formatPartyLabel("I")).toBe("Independent");
+  });
+
+  it("normalizes case", () => {
+    expect(formatPartyLabel("d")).toBe("Democrat");
+    expect(formatPartyLabel("  R  ")).toBe("Republican");
+  });
+
+  it("returns the input verbatim for unknown codes (forward-compat)", () => {
+    // L (Libertarian), G (Green), DFL (Minnesota's branch of D), etc.
+    expect(formatPartyLabel("L")).toBe("L");
+    expect(formatPartyLabel("DFL")).toBe("DFL");
+  });
+
+  it("returns null for null/undefined/empty", () => {
+    expect(formatPartyLabel(null)).toBeNull();
+    expect(formatPartyLabel(undefined)).toBeNull();
+    expect(formatPartyLabel("")).toBeNull();
+    expect(formatPartyLabel("   ")).toBeNull();
+  });
+});
+
+// ─── formatChamberLabel ──────────────────────────────────
+
+describe("formatChamberLabel", () => {
+  it("formats every valid chamber", () => {
+    expect(formatChamberLabel("senate")).toBe("U.S. Senate");
+    expect(formatChamberLabel("house")).toBe("U.S. House of Representatives");
+    expect(formatChamberLabel("former")).toBe("Former member of Congress");
+    expect(formatChamberLabel("executive")).toBe("Executive branch");
+  });
+
+  it("returns null for null/undefined", () => {
+    expect(formatChamberLabel(null)).toBeNull();
+    expect(formatChamberLabel(undefined)).toBeNull();
+  });
+});
+
+// ─── formatPoliticianLede ────────────────────────────────
+
+describe("formatPoliticianLede", () => {
+  it("builds the canonical 'Senator (D-NY)' shape", () => {
+    expect(formatPoliticianLede("senate", "D", "NY")).toBe("Senator (D-NY)");
+  });
+
+  it("uses 'Representative' for House members", () => {
+    expect(formatPoliticianLede("house", "R", "LA")).toBe("Representative (R-LA)");
+  });
+
+  it("falls back to role-only when party/state are absent", () => {
+    expect(formatPoliticianLede("senate", null, null)).toBe("Senator");
+  });
+
+  it("falls back to party/state-only when chamber is absent", () => {
+    expect(formatPoliticianLede(null, "D", "NY")).toBe("(D-NY)");
+  });
+
+  it("renders party-only or state-only correctly when one is missing", () => {
+    expect(formatPoliticianLede(null, "D", null)).toBe("(D)");
+    expect(formatPoliticianLede(null, null, "NY")).toBe("(NY)");
+  });
+
+  it("returns null when chamber/party/state are all absent", () => {
+    expect(formatPoliticianLede(null, null, null)).toBeNull();
+    expect(formatPoliticianLede(undefined, undefined, undefined)).toBeNull();
+  });
+
+  it("trims whitespace on party/state", () => {
+    expect(formatPoliticianLede("senate", " D ", " NY ")).toBe("Senator (D-NY)");
+  });
+
+  it("uses the right role for non-Congress chambers", () => {
+    expect(formatPoliticianLede("former", "D", "VT")).toBe(
+      "Former member of Congress (D-VT)",
+    );
+    expect(formatPoliticianLede("executive", "R", null)).toBe(
+      "Executive branch official (R)",
+    );
+  });
+});
+
+// ─── parseDbPoliticianProfile ────────────────────────────
+
+describe("parseDbPoliticianProfile", () => {
+  describe("happy path", () => {
+    it("maps a fully populated row to PoliticianProfile shape", () => {
+      const profile = parseDbPoliticianProfile(fullRow);
+      expect(profile).toEqual({
+        bioguideId: "S000148",
+        name: "Charles E. Schumer",
+        party: "D",
+        state: "NY",
+        chamber: "senate",
+        committees: ["Finance", "Judiciary", "Rules and Administration"],
+        topIndustriesCurrentCycle: [
+          { industry: "Securities & investment", amount_usd: 1_200_000 },
+          { industry: "Real estate", amount_usd: 620_000 },
+        ],
+        interestGroupRatings: { LCV: 92, "AFL-CIO": 100, NRA: "F" },
+        externalLinks: {
+          govtrack: "https://www.govtrack.us/congress/members/charles_schumer/300087",
+          opensecrets: "https://www.opensecrets.org/members-of-congress/charles-schumer/summary",
+          wikipedia: "https://en.wikipedia.org/wiki/Chuck_Schumer",
+        },
+        notes: "Senate Majority Leader (119th Congress).",
+      });
+    });
+
+    it("trims whitespace on identity fields", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        bioguide_id: "  S000148  ",
+        name: "  Charles E. Schumer  ",
+      });
+      expect(profile?.bioguideId).toBe("S000148");
+      expect(profile?.name).toBe("Charles E. Schumer");
+    });
+  });
+
+  describe("null-returning inputs", () => {
+    it("returns null for null/undefined", () => {
+      expect(parseDbPoliticianProfile(null)).toBeNull();
+      expect(parseDbPoliticianProfile(undefined)).toBeNull();
+    });
+
+    it("returns null when bioguide_id is missing or empty", () => {
+      expect(parseDbPoliticianProfile({ ...fullRow, bioguide_id: "" })).toBeNull();
+      expect(parseDbPoliticianProfile({ ...fullRow, bioguide_id: "   " })).toBeNull();
+    });
+
+    it("returns null when name is missing or empty", () => {
+      expect(parseDbPoliticianProfile({ ...fullRow, name: "" })).toBeNull();
+    });
+  });
+
+  describe("graceful degradation on partial / malformed rows", () => {
+    it("nulls out unknown chamber values", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        chamber: "lobbyist",
+      });
+      expect(profile?.chamber).toBeNull();
+    });
+
+    it("normalizes empty-string optional fields to null", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        party: "",
+        state: "   ",
+        notes: "",
+      });
+      expect(profile?.party).toBeNull();
+      expect(profile?.state).toBeNull();
+      expect(profile?.notes).toBeNull();
+    });
+
+    it("returns [] for non-array committees", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        committees: "Finance",
+      });
+      expect(profile?.committees).toEqual([]);
+    });
+
+    it("filters non-string entries from committees", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        committees: ["Finance", 42, null, "Judiciary"],
+      });
+      expect(profile?.committees).toEqual(["Finance", "Judiciary"]);
+    });
+
+    it("trims and drops empty strings from committees", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        committees: ["  Finance  ", "", "   ", "Judiciary"],
+      });
+      expect(profile?.committees).toEqual(["Finance", "Judiciary"]);
+    });
+  });
+
+  describe("top_industries_current_cycle JSONB validation", () => {
+    it("accepts well-formed industry entries", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        top_industries_current_cycle: [
+          { industry: "Securities", amount_usd: 1000 },
+          { industry: "Real estate", amount_usd: 500 },
+        ],
+      });
+      expect(profile?.topIndustriesCurrentCycle).toEqual([
+        { industry: "Securities", amount_usd: 1000 },
+        { industry: "Real estate", amount_usd: 500 },
+      ]);
+    });
+
+    it("preserves null amount_usd when absent or non-numeric", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        top_industries_current_cycle: [
+          { industry: "Tech", amount_usd: null },
+          { industry: "Pharma", amount_usd: "lots" },
+          { industry: "Defense" }, // no amount_usd at all
+        ],
+      });
+      expect(profile?.topIndustriesCurrentCycle).toEqual([
+        { industry: "Tech", amount_usd: null },
+        { industry: "Pharma", amount_usd: null },
+        { industry: "Defense", amount_usd: null },
+      ]);
+    });
+
+    it("drops entries without an industry name", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        top_industries_current_cycle: [
+          { industry: "", amount_usd: 1000 },
+          { industry: "   ", amount_usd: 1000 },
+          { amount_usd: 1000 },
+          { industry: "Real industry", amount_usd: 1000 },
+        ],
+      });
+      expect(profile?.topIndustriesCurrentCycle).toEqual([
+        { industry: "Real industry", amount_usd: 1000 },
+      ]);
+    });
+
+    it("returns [] for non-array input", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        top_industries_current_cycle: "Securities",
+      });
+      expect(profile?.topIndustriesCurrentCycle).toEqual([]);
+    });
+  });
+
+  describe("interest_group_ratings JSONB validation", () => {
+    it("accepts numeric scores and string letter-grades side by side", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        interest_group_ratings: { LCV: 92, NRA: "F", ADA: 88 },
+      });
+      expect(profile?.interestGroupRatings).toEqual({ LCV: 92, NRA: "F", ADA: 88 });
+    });
+
+    it("drops null / boolean / non-finite values", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        interest_group_ratings: {
+          LCV: 92,
+          BAD_BOOL: true,
+          BAD_NULL: null,
+          BAD_NAN: NaN,
+          BAD_INF: Infinity,
+          NRA: "F",
+        },
+      });
+      expect(profile?.interestGroupRatings).toEqual({ LCV: 92, NRA: "F" });
+    });
+
+    it("drops empty-string values", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        interest_group_ratings: { LCV: 92, EMPTY: "  ", NRA: "F" },
+      });
+      expect(profile?.interestGroupRatings).toEqual({ LCV: 92, NRA: "F" });
+    });
+
+    it("returns {} for an array passed as ratings", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        interest_group_ratings: ["LCV", "NRA"],
+      });
+      expect(profile?.interestGroupRatings).toEqual({});
+    });
+  });
+
+  describe("external_links JSONB validation", () => {
+    it("accepts string URLs and trims whitespace", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        external_links: {
+          govtrack: "  https://govtrack.us/...  ",
+          wikipedia: "https://en.wikipedia.org/...",
+        },
+      });
+      expect(profile?.externalLinks).toEqual({
+        govtrack: "https://govtrack.us/...",
+        wikipedia: "https://en.wikipedia.org/...",
+      });
+    });
+
+    it("drops non-string values", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        external_links: {
+          govtrack: "https://govtrack.us/...",
+          weird: 42,
+          nested: { foo: "bar" },
+        },
+      });
+      expect(profile?.externalLinks).toEqual({
+        govtrack: "https://govtrack.us/...",
+      });
+    });
+
+    it("returns {} for an array passed as external_links", () => {
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        external_links: ["a", "b"],
+      });
+      expect(profile?.externalLinks).toEqual({});
+    });
+  });
+});

--- a/app/politician/[bioguide]/page.tsx
+++ b/app/politician/[bioguide]/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import PoliticianDossier from "@/components/politician/PoliticianDossier";
+import { getPoliticianByBioguide } from "@/lib/db";
+
+// ISR — same heartbeat as the landing + outlet dossier (10 minutes).
+// Politician metadata changes slowly (committees shift quarterly,
+// donor/voting data updates daily via the Phase 3.E refresh job), so a
+// 600s edge cache is well-matched on both sides.
+export const revalidate = 600;
+
+interface PoliticianRouteProps {
+  params: Promise<{ bioguide: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PoliticianRouteProps): Promise<Metadata> {
+  const { bioguide } = await params;
+  const politician = await getPoliticianByBioguide(bioguide);
+  if (!politician) return { title: "Politician not found" };
+  return {
+    title: `${politician.name} — Politician dossier`,
+    description: `Committees, donor industries, and voting context for ${politician.name} on Sift.`,
+  };
+}
+
+export default async function PoliticianDossierPage({
+  params,
+}: PoliticianRouteProps) {
+  const { bioguide } = await params;
+  const politician = await getPoliticianByBioguide(bioguide);
+  if (!politician) notFound();
+  return <PoliticianDossier politician={politician} />;
+}

--- a/components/politician/PoliticianDossier.tsx
+++ b/components/politician/PoliticianDossier.tsx
@@ -1,0 +1,248 @@
+import Link from "next/link";
+
+import LandingMasthead from "@/components/landing/LandingMasthead";
+import { COPY } from "@/lib/copy";
+import { formatPoliticianLede } from "@/lib/politician";
+import type { PoliticianProfile } from "@/lib/types";
+
+interface PoliticianDossierProps {
+  politician: PoliticianProfile;
+}
+
+/**
+ * Server-rendered politician dossier — civic-literacy MVP Phase 3.C.
+ *
+ * Mirrors the editorial visual register of `OutletDossier` and
+ * `/colophon`: kicker eyebrows, hairline rules, mono labels, Fraunces
+ * display type, max-width 800. Outlet data was the proof; this is the
+ * ambitious extension into politicians.
+ *
+ * Sections render conditionally based on populated data — Phase 3.A's
+ * sample seed has committees + external_links + notes for the curated
+ * 8 members, but `top_industries_current_cycle` and
+ * `interest_group_ratings` are empty until sift-api Phase 3.E enrichment
+ * runs (OpenSecrets daily refresh + Vote Smart batch). When both are
+ * empty, a single "not yet enriched" caption explains the absence.
+ */
+export default function PoliticianDossier({
+  politician,
+}: PoliticianDossierProps) {
+  const c = COPY.politicianDossier;
+  const lede = formatPoliticianLede(
+    politician.chamber,
+    politician.party,
+    politician.state,
+  );
+
+  // Money formatter for donor industries — compact 1.2M-style for tight
+  // column widths, falls back to plain locale string under $10k.
+  const fmtUsd = (amount: number | null): string => {
+    if (amount == null) return "";
+    if (amount >= 10_000) {
+      return `$${(amount / 1_000_000).toFixed(amount >= 1_000_000 ? 1 : 0)}${
+        amount >= 1_000_000 ? "M" : "K"
+      }`.replace("0M", "0M").replace(".0M", "M");
+    }
+    return `$${amount.toLocaleString("en-US")}`;
+  };
+
+  // Stable display order for external links. Govt records first
+  // (GovTrack, OpenSecrets, Vote Smart), then encyclopedia refs.
+  const linkOrder: Array<keyof typeof c.externalLinkLabels> = [
+    "govtrack",
+    "opensecrets",
+    "votesmart",
+    "ballotpedia",
+    "wikipedia",
+  ];
+  const externalLinkEntries = linkOrder
+    .map((key) => {
+      const url = politician.externalLinks[key];
+      return url ? { key, url, label: c.externalLinkLabels[key] } : null;
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null);
+  // Forward-compat: include any keys not in our pre-labeled list.
+  for (const [key, url] of Object.entries(politician.externalLinks)) {
+    if (!linkOrder.includes(key as typeof linkOrder[number]) && url) {
+      externalLinkEntries.push({
+        key,
+        url,
+        label: c.externalLinkLabels[key] ?? key,
+      });
+    }
+  }
+
+  const ratingsEntries = Object.entries(politician.interestGroupRatings);
+  const industriesEmpty = politician.topIndustriesCurrentCycle.length === 0;
+  const ratingsEmpty = ratingsEntries.length === 0;
+  const showNotYetEnriched = industriesEmpty && ratingsEmpty;
+
+  return (
+    <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
+      <LandingMasthead />
+
+      <main
+        id="main-content"
+        className="max-w-[800px] mx-auto px-6 pt-12 pb-24"
+      >
+        {/* Eyebrow + headline */}
+        <header className="mb-9">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3 flex items-center">
+            <span
+              aria-hidden
+              className="inline-block w-7 h-px bg-[var(--border)] mr-3"
+            />
+            {c.eyebrow}
+          </p>
+          <h1 className="font-heading text-[36px] md:text-[44px] font-bold leading-[1.05] tracking-tight text-[var(--text)]">
+            {politician.name}
+          </h1>
+          {lede && (
+            <p className="font-body text-[16px] text-[var(--text-secondary)] mt-3 max-w-[60ch] leading-relaxed">
+              {lede}
+            </p>
+          )}
+        </header>
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* Committees */}
+        {politician.committees.length > 0 && (
+          <section className="mb-10">
+            <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+              {c.sections.committees}
+            </p>
+            <ul className="space-y-1.5">
+              {politician.committees.map((committee) => (
+                <li
+                  key={committee}
+                  className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed"
+                >
+                  {committee}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* Top donor industries (current cycle) */}
+        {!industriesEmpty && (
+          <section className="mb-10">
+            <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+              {c.sections.topIndustries}
+            </p>
+            <ul className="space-y-2">
+              {politician.topIndustriesCurrentCycle.map((entry) => (
+                <li
+                  key={entry.industry}
+                  className="grid grid-cols-[1fr_auto] gap-x-6 items-baseline border-b border-[var(--border-subtle)] pb-2"
+                >
+                  <span className="font-body text-[15px] text-[var(--text-secondary)]">
+                    {entry.industry}
+                  </span>
+                  {entry.amount_usd != null && (
+                    <span className="font-mono text-[13px] tabular-nums text-[var(--text-muted)]">
+                      {fmtUsd(entry.amount_usd)}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* Interest-group ratings */}
+        {!ratingsEmpty && (
+          <section className="mb-10">
+            <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+              {c.sections.interestGroupRatings}
+            </p>
+            <ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-1.5">
+              {ratingsEntries.map(([group, rating]) => (
+                <li
+                  key={group}
+                  className="grid grid-cols-[1fr_auto] gap-x-3 items-baseline border-b border-[var(--border-subtle)] pb-1.5"
+                >
+                  <span className="font-body text-outlet uppercase tracking-wider text-[var(--text-muted)]">
+                    {group}
+                  </span>
+                  <span className="font-mono text-[13px] tabular-nums text-[var(--text-secondary)]">
+                    {typeof rating === "number" ? `${rating}%` : rating}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* "Not yet enriched" caption when both donor + rating sections
+            absent — common case before sift-api Phase 3.E refresh runs. */}
+        {showNotYetEnriched && (
+          <section className="mb-10">
+            <p className="font-body text-[14px] text-[var(--text-muted)] italic max-w-[60ch] leading-relaxed">
+              {c.notYetEnriched}
+            </p>
+          </section>
+        )}
+
+        {/* External links — public-record citations */}
+        {externalLinkEntries.length > 0 && (
+          <section className="mb-10">
+            <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+              {c.sections.links}
+            </p>
+            <ul className="space-y-2.5">
+              {externalLinkEntries.map(({ key, url, label }) => (
+                <li
+                  key={key}
+                  className="grid grid-cols-[160px_1fr] gap-x-6 items-baseline border-b border-[var(--border-subtle)] pb-2.5"
+                >
+                  <span className="font-body text-outlet uppercase tracking-wider text-[var(--text-muted)]">
+                    {label}
+                  </span>
+                  <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-body text-[14px] text-[var(--text-secondary)] no-underline hover:underline hover:text-[var(--accent)] truncate"
+                  >
+                    {url} <span aria-hidden>↗</span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* Free-form notes (curator commentary) */}
+        {politician.notes && (
+          <section className="mb-10">
+            <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+              {c.sections.notes}
+            </p>
+            <p className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed max-w-[60ch] italic">
+              {politician.notes}
+            </p>
+          </section>
+        )}
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* Footer: methodology hint placeholder + back link */}
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <Link
+            href="/"
+            className="font-body text-outlet uppercase tracking-wider text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline inline-flex items-center gap-1.5"
+          >
+            <span aria-hidden>←</span> Back to Sift
+          </Link>
+          {/* Methodology link goes live with Phase 2.D (PR #79). Until that
+              merges, render the hint as plain text rather than a 404 link. */}
+          <span className="font-body text-meta text-[var(--text-muted)] italic">
+            {c.methodologyHint}
+          </span>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -178,6 +178,32 @@ export const COPY = {
     },
     backLink: "Back to Sift",
   },
+  politicianDossier: {
+    eyebrow: "Politician dossier",
+    sections: {
+      committees: "Committee assignments",
+      topIndustries: "Top donor industries this cycle",
+      interestGroupRatings: "Interest-group ratings",
+      links: "Where to read more",
+      notes: "Notes",
+    },
+    // External-link labels in stable display order.
+    externalLinkLabels: {
+      govtrack: "GovTrack",
+      opensecrets: "OpenSecrets",
+      votesmart: "Vote Smart",
+      ballotpedia: "Ballotpedia",
+      wikipedia: "Wikipedia",
+    } as Record<string, string>,
+    // Footer note shown when donor and rating data are both absent \u2014 the
+    // common case before sift-api Phase 3.E enrichment runs in prod.
+    notYetEnriched:
+      "Donor and voting data populates from OpenSecrets and GovTrack on the next refresh. Until then, this dossier shows curated metadata only.",
+    methodologyHint: "Data comes from public records. Read the methodology.",
+    // Empty-state when industries/ratings are partially populated.
+    industriesEmpty: "No donor-industry data yet for this cycle.",
+    ratingsEmpty: "No interest-group ratings yet recorded.",
+  },
   dossier: {
     // Eyebrow shown above the outlet name.
     eyebrow: "Outlet dossier",

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,7 +1,11 @@
 import { Pool } from "pg";
 
 import { parseDbOutletProfile, type DbOutletProfileRow } from "./outlet";
-import type { OutletProfile } from "./types";
+import {
+  parseDbPoliticianProfile,
+  type DbPoliticianProfileRow,
+} from "./politician";
+import type { OutletProfile, PoliticianProfile } from "./types";
 
 if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL environment variable is not set");
@@ -534,6 +538,40 @@ export async function getAllOutletProfiles(): Promise<OutletProfile[]> {
   } catch (err) {
     const msg = String(err);
     if (msg.includes("does not exist")) return [];
+    throw err;
+  }
+}
+
+// ─── Politician Dossier (Phase 3.C) ────────────────────
+
+/**
+ * Fetch a single politician profile by bioguide_id (Congress.gov canonical
+ * identifier, e.g. 'S000148' for Schumer). Returns null when the bioguide
+ * isn't curated (caller should call notFound() for the dossier route) or
+ * when the politician_profiles table doesn't exist yet (graceful for
+ * pre-Phase-3.A-merge prod).
+ */
+export async function getPoliticianByBioguide(
+  bioguideId: string,
+): Promise<PoliticianProfile | null> {
+  const trimmed = bioguideId.trim().toUpperCase();
+  if (!trimmed) return null;
+
+  try {
+    const result = await pool.query<DbPoliticianProfileRow>(
+      `SELECT bioguide_id, name, party, state, chamber,
+              committees, top_industries_current_cycle, interest_group_ratings,
+              external_links, notes
+       FROM politician_profiles
+       WHERE bioguide_id = $1
+       LIMIT 1`,
+      [trimmed]
+    );
+    if (result.rows.length === 0) return null;
+    return parseDbPoliticianProfile(result.rows[0]);
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("does not exist")) return null;
     throw err;
   }
 }

--- a/lib/politician.ts
+++ b/lib/politician.ts
@@ -1,0 +1,200 @@
+// Politician-provenance helpers — civic-literacy MVP Phase 3.C.
+//
+// Parses curated rows from `politician_profiles` into the typed
+// `PoliticianProfile` shape the UI consumes, plus label formatters for
+// party / chamber / role-from-chamber. Pure functions only — trivially
+// unit-testable; no React or DB coupling.
+
+import type {
+  IndustryDonation,
+  PoliticianChamber,
+  PoliticianExternalLinks,
+  PoliticianProfile,
+} from "./types";
+
+// ─── Enums (kept in sync with sift-api/scripts/seed_politician_profiles.py) ──
+
+const CHAMBER_VALUES: ReadonlySet<string> = new Set([
+  "senate",
+  "house",
+  "former",
+  "executive",
+]);
+
+// ─── Display labels ───────────────────────────────────────────────────
+
+const PARTY_LABELS: Record<string, string> = {
+  D: "Democrat",
+  R: "Republican",
+  I: "Independent",
+};
+
+/**
+ * Human label for a single-letter party code, e.g. "D" → "Democrat".
+ * Returns the input verbatim when it isn't a known code (covers minor
+ * parties like "L" / "G" / "DFL" without the UI rendering empty).
+ * Returns null only for empty / null inputs.
+ */
+export function formatPartyLabel(party: string | null | undefined): string | null {
+  if (!party) return null;
+  const trimmed = party.trim();
+  if (!trimmed) return null;
+  return PARTY_LABELS[trimmed.toUpperCase()] ?? trimmed;
+}
+
+const CHAMBER_LABELS: Record<PoliticianChamber, string> = {
+  senate: "U.S. Senate",
+  house: "U.S. House of Representatives",
+  former: "Former member of Congress",
+  executive: "Executive branch",
+};
+
+/** Human label for a chamber enum, e.g. "senate" → "U.S. Senate". */
+export function formatChamberLabel(
+  chamber: PoliticianChamber | null | undefined,
+): string | null {
+  if (!chamber) return null;
+  return CHAMBER_LABELS[chamber] ?? null;
+}
+
+const ROLE_FROM_CHAMBER: Record<PoliticianChamber, string> = {
+  senate: "Senator",
+  house: "Representative",
+  former: "Former member of Congress",
+  executive: "Executive branch official",
+};
+
+/**
+ * Compact role title used in the dossier lede, e.g.
+ *   { chamber: "senate", party: "D", state: "NY" } → "Senator (D-NY)"
+ *   { chamber: "house",  party: "R", state: "LA" } → "Representative (R-LA)"
+ *   { chamber: null,     party: null, state: null } → null
+ */
+export function formatPoliticianLede(
+  chamber: PoliticianChamber | null | undefined,
+  party: string | null | undefined,
+  state: string | null | undefined,
+): string | null {
+  const role = chamber ? ROLE_FROM_CHAMBER[chamber] : null;
+  const partyTrimmed = party?.trim() || null;
+  const stateTrimmed = state?.trim() || null;
+  const partyState =
+    partyTrimmed && stateTrimmed
+      ? `(${partyTrimmed}-${stateTrimmed})`
+      : partyTrimmed
+        ? `(${partyTrimmed})`
+        : stateTrimmed
+          ? `(${stateTrimmed})`
+          : null;
+  if (role && partyState) return `${role} ${partyState}`;
+  if (role) return role;
+  return partyState;
+}
+
+// ─── DB-row parsing ───────────────────────────────────────────────────
+
+/**
+ * Shape of a row from `politician_profiles`. JSONB columns arrive parsed by
+ * `pg`; we re-validate here because the contents are untrusted (CSV-seeded,
+ * later API-scraped). Date-stamped timestamps (`refreshed_at`, `updated_at`)
+ * are intentionally omitted — they're operational metadata, not surfaced.
+ */
+export interface DbPoliticianProfileRow {
+  bioguide_id: string;
+  name: string;
+  party: string | null;
+  state: string | null;
+  chamber: string | null;
+  committees: unknown;                    // expected: string[]
+  top_industries_current_cycle: unknown;  // expected: IndustryDonation[]
+  interest_group_ratings: unknown;        // expected: Record<string, number | string>
+  external_links: unknown;                // expected: PoliticianExternalLinks
+  notes: string | null;
+}
+
+function asChamber(v: string | null): PoliticianChamber | null {
+  if (!v) return null;
+  const lower = v.toLowerCase();
+  return CHAMBER_VALUES.has(lower) ? (lower as PoliticianChamber) : null;
+}
+
+function asCommittees(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function asTopIndustries(v: unknown): IndustryDonation[] {
+  if (!Array.isArray(v)) return [];
+  const out: IndustryDonation[] = [];
+  for (const entry of v) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    const industry = typeof e.industry === "string" ? e.industry.trim() : "";
+    if (!industry) continue;
+    const amount =
+      typeof e.amount_usd === "number" && Number.isFinite(e.amount_usd)
+        ? e.amount_usd
+        : null;
+    out.push({ industry, amount_usd: amount });
+  }
+  return out;
+}
+
+function asInterestGroupRatings(v: unknown): Record<string, number | string> {
+  if (!v || typeof v !== "object" || Array.isArray(v)) return {};
+  const out: Record<string, number | string> = {};
+  for (const [key, value] of Object.entries(v as Record<string, unknown>)) {
+    const trimmedKey = key.trim();
+    if (!trimmedKey) continue;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      out[trimmedKey] = value;
+    } else if (typeof value === "string" && value.trim().length > 0) {
+      out[trimmedKey] = value.trim();
+    }
+  }
+  return out;
+}
+
+function asExternalLinks(v: unknown): PoliticianExternalLinks {
+  if (!v || typeof v !== "object" || Array.isArray(v)) return {};
+  const out: PoliticianExternalLinks = {};
+  for (const [key, value] of Object.entries(v as Record<string, unknown>)) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      out[key] = value.trim();
+    }
+  }
+  return out;
+}
+
+/**
+ * Validate + shape a raw `politician_profiles` row. Returns null if the
+ * required identity fields (bioguide_id, name) are missing. Unknown
+ * `chamber` values null out (UI tolerates absence rather than rendering
+ * a bad enum). JSONB columns degrade to empty list/object on malformed
+ * input — the dossier conditionally renders sections only when they
+ * have content, so empty inputs result in clean partial dossiers.
+ */
+export function parseDbPoliticianProfile(
+  row: DbPoliticianProfileRow | null | undefined,
+): PoliticianProfile | null {
+  if (!row) return null;
+  const bioguide = (row.bioguide_id ?? "").trim();
+  const name = (row.name ?? "").trim();
+  if (!bioguide || !name) return null;
+
+  return {
+    bioguideId: bioguide,
+    name,
+    party: row.party?.trim() || null,
+    state: row.state?.trim() || null,
+    chamber: asChamber(row.chamber),
+    committees: asCommittees(row.committees),
+    topIndustriesCurrentCycle: asTopIndustries(row.top_industries_current_cycle),
+    interestGroupRatings: asInterestGroupRatings(row.interest_group_ratings),
+    externalLinks: asExternalLinks(row.external_links),
+    notes: row.notes?.trim() || null,
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -92,6 +92,63 @@ export interface OutletExternalLinks {
   [key: string]: string | undefined;
 }
 
+// ─── Politician Provenance (Phase 3.C) ─────────────────
+
+/**
+ * Chambers a curated politician can sit in. Mirrors the values stored in
+ * `politician_profiles.chamber`; the seed scripts validate against this set.
+ */
+export type PoliticianChamber = "senate" | "house" | "former" | "executive";
+
+/**
+ * Single donor-industry entry under
+ * `politician_profiles.top_industries_current_cycle`. amount_usd is the
+ * cycle-to-date cash from individuals + PACs in this industry per
+ * OpenSecrets. Null when the industry surfaced but the dollar amount didn't.
+ */
+export interface IndustryDonation {
+  industry: string;
+  amount_usd: number | null;
+}
+
+/**
+ * External-source links rendered as the citation footer of every dossier
+ * section. All keys optional; the dossier renders only the ones it knows
+ * about, plus any extras under their raw key. Same forward-compat shape as
+ * `OutletExternalLinks`.
+ */
+export interface PoliticianExternalLinks {
+  govtrack?: string;
+  opensecrets?: string;
+  votesmart?: string;
+  ballotpedia?: string;
+  wikipedia?: string;
+  [key: string]: string | undefined;
+}
+
+/**
+ * Curated politician metadata, mirrored from `politician_profiles` in
+ * Postgres. Phase 3.A seeded a small sample; Phase 3.B fills out all 535
+ * sitting Congress members via a GovTrack scrape; Phase 3.E enriches with
+ * OpenSecrets donor data + Vote Smart interest-group ratings.
+ *
+ * `interestGroupRatings` is an open dictionary because rating-org acronyms
+ * change over time (LCV, NRA, ADA, ACU, NEA, AFL-CIO, etc.). The UI renders
+ * them as a key/value list without assuming any particular keys exist.
+ */
+export interface PoliticianProfile {
+  bioguideId: string;
+  name: string;
+  party: string | null;             // 'D' | 'R' | 'I' | other (kept as raw string)
+  state: string | null;             // USPS code, e.g. 'NY'
+  chamber: PoliticianChamber | null;
+  committees: string[];
+  topIndustriesCurrentCycle: IndustryDonation[];
+  interestGroupRatings: Record<string, number | string>;
+  externalLinks: PoliticianExternalLinks;
+  notes: string | null;
+}
+
 /**
  * Curated outlet metadata, mirrored from `outlet_profiles` in Postgres.
  * Hand-maintained quarterly. The dossier page (Phase 2.C) renders the full


### PR DESCRIPTION
## Summary
Adds **`/politician/[bioguide]`** — a server-rendered editorial dossier for any curated member of Congress. Mirrors the visual register of `/outlet/[slug]` (Phase 2.C.1) and reads from the `politician_profiles` table seeded by [sift-api PR #26](https://github.com/kristenmartino/sift-api/pull/26).

Once #26 merges + Railway redeploys + `seed_politician_profiles.py` runs against prod, `/politician/S000148` (Schumer), `/politician/M000355` (McConnell), `/politician/J000295` (Jeffries), `/politician/J000296` (Mike Johnson), `/politician/S001191` (Sanders), `/politician/W000817` (Warren), `/politician/C001098` (Cruz), `/politician/M001183` (Murkowski) all light up.

## What ships
| Layer | File | Change |
|---|---|---|
| Types | `lib/types.ts` | `PoliticianChamber`, `IndustryDonation`, `PoliticianExternalLinks`, `PoliticianProfile` |
| Helpers | `lib/politician.ts` (new) | `parseDbPoliticianProfile`, `formatPartyLabel`, `formatChamberLabel`, `formatPoliticianLede` |
| DB | `lib/db.ts` | `getPoliticianByBioguide()` — single-row fetch, normalizes bioguide to upper-case, tolerates missing table |
| Route | `app/politician/[bioguide]/page.tsx` (new) | Async server component, `revalidate=600`, `notFound()` on miss, SEO metadata |
| Component | `components/politician/PoliticianDossier.tsx` (new) | One-column max-w-800 layout, conditional sections, "not yet enriched" empty state |
| Copy | `lib/copy.ts` | `COPY.politicianDossier` block |
| Tests | `__tests__/politician.test.ts` (new) | +35 tests for formatters, parser, JSONB validation |

## Visual register
- **Header**: `Politician dossier` kicker → `name` in Fraunces 36-44 → lede line `Senator (D-NY)`
- **Committee assignments**: bullet list
- **Top donor industries this cycle**: 1fr/auto grid with industry name + compact USD (`$1.2M`, `$620K`, fallback to plain locale string under $10k)
- **Interest-group ratings**: 2-/3-col grid; mono `tabular-nums` cell (`LCV 92%`, `NRA F`, `ADA 88%`); accepts numeric scores + string letter grades side by side
- **External links**: same `160/1fr` grid as `/colophon` and `/outlet/[slug]`; stable display order GovTrack → OpenSecrets → Vote Smart → Ballotpedia → Wikipedia
- **Notes**: italicized prose (curator commentary)
- **"Not yet enriched"**: italicized caption when both donor + rating sections are absent (the common case before Phase 3.E enrichment runs in prod)
- **Footer**: back-to-Sift + methodology hint placeholder

## Tests
- 9 suites / 186 tests pass; `tsc --noEmit` clean
- New tests exercise: party label coverage + forward-compat (L/G/DFL pass through), chamber + lede formatting (every chamber/role variant + partial-data fallbacks), parser happy path + null-returning inputs, JSONB validation for committees / top_industries / ratings / external_links

## Graceful degradation
- `getPoliticianByBioguide` catches `relation does not exist` → returns `null` → `notFound()` renders the existing global 404 page
- Sample seed has committees + external_links + notes for the curated 8; donor + voting data is empty until sift-api Phase 3.E runs (OpenSecrets daily refresh + Vote Smart batch). The "Not yet enriched" caption explains the absence; nothing renders broken.
- Until #26 merges, every `/politician/[bioguide]` lands on a 404 — no broken half-state

## Phase 3 roadmap
- ✅ **3.A** schema + seed tooling ([sift-api #26](https://github.com/kristenmartino/sift-api/pull/26))
- 🆕 **3.C** politician dossier route (this PR)
- 🚧 **3.B** GovTrack scrape → all 535 sitting members
- 🚧 **3.D** ~200 hand-curated `org_profiles` + `/org/[slug]` dossier
- 🚧 **3.E** `/bill/[id]` dossier
- 🚧 **3.F** OpenSecrets daily refresh + Vote Smart enrichment
- 🚧 **3.G** entity-linking LangGraph node + `articles.entity_links`
- 🚧 **3.H** `InlineGlossaryTooltip` + ArticleCard integration

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 186 passing
- [ ] Visual: dev preview `/politician/S000148` (Schumer) once `politician_profiles` is seeded; sections render conditionally; "Not yet enriched" caption visible until Phase 3.E
- [ ] Visual: `/politician/does-not-exist` returns the global 404 page
- [ ] Visual: light + dark mode parity; mobile narrow-viewport reflow
- [ ] Click-through: external links (GovTrack, OpenSecrets, Wikipedia, etc.) open in new tabs with `rel="noopener noreferrer"`
- [ ] Bioguide normalization: `/politician/s000148` (lowercase) and `/politician/S000148` both resolve to Schumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)