### PR TITLE
feat: civic-literacy MVP Phase 3.D — org dossier route

### DIFF
--- a/__tests__/org.test.ts
+++ b/__tests__/org.test.ts
@@ -1,0 +1,286 @@
+import {
+  formatBudgetUsd,
+  formatOrgLeanLabel,
+  formatOrgTypeLabel,
+  parseDbOrgProfile,
+  type DbOrgProfileRow,
+} from "@/lib/org";
+
+// ─── Fixtures ──────────────────────────────────────────────
+
+const fullRow: DbOrgProfileRow = {
+  slug: "brookings-institution",
+  name: "Brookings Institution",
+  type: "think-tank",
+  political_lean: "center",
+  founded_year: 1916,
+  annual_budget_usd: 120_000_000,
+  major_funders: [
+    "Hutchins Family",
+    "Rockefeller Foundation",
+    "Bloomberg Philanthropies",
+  ],
+  fara_registered: true,
+  fara_countries: ["Qatar"],
+  external_links: {
+    propublica: "https://projects.propublica.org/nonprofits/organizations/530196577",
+    official: "https://www.brookings.edu",
+    wikipedia: "https://en.wikipedia.org/wiki/Brookings_Institution",
+  },
+  notes: "Centrist policy think tank. Qatar funding (Brookings Doha Center) is publicly disclosed.",
+};
+
+// ─── formatOrgTypeLabel ──────────────────────────────────
+
+describe("formatOrgTypeLabel", () => {
+  it("formats every valid org type", () => {
+    expect(formatOrgTypeLabel("think-tank")).toBe("Think tank");
+    expect(formatOrgTypeLabel("advocacy")).toBe("Advocacy organization");
+    expect(formatOrgTypeLabel("union")).toBe("Labor union");
+    expect(formatOrgTypeLabel("pac")).toBe("Political action committee");
+    expect(formatOrgTypeLabel("super-pac")).toBe("Super PAC");
+    expect(formatOrgTypeLabel("foundation")).toBe("Foundation");
+    expect(formatOrgTypeLabel("industry-group")).toBe("Industry group");
+    expect(formatOrgTypeLabel("other")).toBe("Organization");
+  });
+
+  it("returns null for null/undefined", () => {
+    expect(formatOrgTypeLabel(null)).toBeNull();
+    expect(formatOrgTypeLabel(undefined)).toBeNull();
+  });
+});
+
+// ─── formatOrgLeanLabel ──────────────────────────────────
+
+describe("formatOrgLeanLabel", () => {
+  it("formats every valid lean (incl. nonpartisan)", () => {
+    expect(formatOrgLeanLabel("left")).toBe("Left");
+    expect(formatOrgLeanLabel("lean-left")).toBe("Lean Left");
+    expect(formatOrgLeanLabel("center")).toBe("Center");
+    expect(formatOrgLeanLabel("lean-right")).toBe("Lean Right");
+    expect(formatOrgLeanLabel("right")).toBe("Right");
+    expect(formatOrgLeanLabel("mixed")).toBe("Mixed");
+    expect(formatOrgLeanLabel("nonpartisan")).toBe("Nonpartisan");
+  });
+
+  it("returns null for null/undefined", () => {
+    expect(formatOrgLeanLabel(null)).toBeNull();
+    expect(formatOrgLeanLabel(undefined)).toBeNull();
+  });
+});
+
+// ─── formatBudgetUsd ─────────────────────────────────────
+
+describe("formatBudgetUsd", () => {
+  it("formats billions with 1 decimal unless whole", () => {
+    expect(formatBudgetUsd(1_000_000_000)).toBe("$1B");
+    expect(formatBudgetUsd(2_500_000_000)).toBe("$2.5B");
+  });
+
+  it("formats millions with 1 decimal unless whole", () => {
+    expect(formatBudgetUsd(120_000_000)).toBe("$120M");
+    expect(formatBudgetUsd(9_000_000)).toBe("$9M");
+    expect(formatBudgetUsd(1_200_000)).toBe("$1.2M");
+  });
+
+  it("formats thousands with 1 decimal unless whole", () => {
+    expect(formatBudgetUsd(500_000)).toBe("$500K");
+    expect(formatBudgetUsd(9_000)).toBe("$9K");
+    expect(formatBudgetUsd(1_500)).toBe("$1.5K");
+  });
+
+  it("falls through to plain locale string under $1k", () => {
+    expect(formatBudgetUsd(500)).toBe("$500");
+    expect(formatBudgetUsd(0)).toBe("$0");
+  });
+
+  it("handles negative values for completeness", () => {
+    // Not expected in practice, but the function shouldn't crash.
+    expect(formatBudgetUsd(-1_500_000)).toBe("$-1.5M");
+  });
+
+  it("returns null for null/undefined/non-finite", () => {
+    expect(formatBudgetUsd(null)).toBeNull();
+    expect(formatBudgetUsd(undefined)).toBeNull();
+    expect(formatBudgetUsd(NaN)).toBeNull();
+    expect(formatBudgetUsd(Infinity)).toBeNull();
+  });
+});
+
+// ─── parseDbOrgProfile ───────────────────────────────────
+
+describe("parseDbOrgProfile", () => {
+  describe("happy path", () => {
+    it("maps a fully populated row to OrgProfile shape", () => {
+      const profile = parseDbOrgProfile(fullRow);
+      expect(profile).toEqual({
+        slug: "brookings-institution",
+        name: "Brookings Institution",
+        type: "think-tank",
+        politicalLean: "center",
+        foundedYear: 1916,
+        annualBudgetUsd: 120_000_000,
+        majorFunders: [
+          "Hutchins Family",
+          "Rockefeller Foundation",
+          "Bloomberg Philanthropies",
+        ],
+        faraRegistered: true,
+        faraCountries: ["Qatar"],
+        externalLinks: {
+          propublica: "https://projects.propublica.org/nonprofits/organizations/530196577",
+          official: "https://www.brookings.edu",
+          wikipedia: "https://en.wikipedia.org/wiki/Brookings_Institution",
+        },
+        notes: "Centrist policy think tank. Qatar funding (Brookings Doha Center) is publicly disclosed.",
+      });
+    });
+
+    it("lowercases the slug for stable URL routing", () => {
+      const profile = parseDbOrgProfile({
+        ...fullRow,
+        slug: "BROOKINGS-INSTITUTION",
+      });
+      expect(profile?.slug).toBe("brookings-institution");
+    });
+
+    it("trims whitespace on identity fields", () => {
+      const profile = parseDbOrgProfile({
+        ...fullRow,
+        slug: "  brookings-institution  ",
+        name: "  Brookings Institution  ",
+      });
+      expect(profile?.slug).toBe("brookings-institution");
+      expect(profile?.name).toBe("Brookings Institution");
+    });
+  });
+
+  describe("null-returning inputs", () => {
+    it("returns null for null/undefined", () => {
+      expect(parseDbOrgProfile(null)).toBeNull();
+      expect(parseDbOrgProfile(undefined)).toBeNull();
+    });
+
+    it("returns null when slug or name missing", () => {
+      expect(parseDbOrgProfile({ ...fullRow, slug: "" })).toBeNull();
+      expect(parseDbOrgProfile({ ...fullRow, name: "   " })).toBeNull();
+    });
+  });
+
+  describe("graceful degradation on malformed rows", () => {
+    it("nulls out unknown type values", () => {
+      const profile = parseDbOrgProfile({ ...fullRow, type: "rogue-type" });
+      expect(profile?.type).toBeNull();
+    });
+
+    it("nulls out unknown political_lean values", () => {
+      const profile = parseDbOrgProfile({
+        ...fullRow,
+        political_lean: "very-left",
+      });
+      expect(profile?.politicalLean).toBeNull();
+    });
+
+    it("normalizes empty-string optional fields to null", () => {
+      const profile = parseDbOrgProfile({
+        ...fullRow,
+        notes: "  ",
+      });
+      expect(profile?.notes).toBeNull();
+    });
+
+    it("treats non-true fara_registered as false", () => {
+      // pg returns Postgres BOOLEAN as true/false/null; we want false default.
+      expect(parseDbOrgProfile({ ...fullRow, fara_registered: false })?.faraRegistered).toBe(false);
+      expect(parseDbOrgProfile({ ...fullRow, fara_registered: null })?.faraRegistered).toBe(false);
+    });
+  });
+
+  describe("annual_budget_usd type coercion", () => {
+    it("accepts numeric input as-is", () => {
+      const profile = parseDbOrgProfile({ ...fullRow, annual_budget_usd: 9_000_000 });
+      expect(profile?.annualBudgetUsd).toBe(9_000_000);
+    });
+
+    it("accepts pg's NUMERIC string representation", () => {
+      const profile = parseDbOrgProfile({
+        ...fullRow,
+        annual_budget_usd: "120000000.00",
+      });
+      expect(profile?.annualBudgetUsd).toBe(120_000_000);
+    });
+
+    it("returns null for null", () => {
+      const profile = parseDbOrgProfile({ ...fullRow, annual_budget_usd: null });
+      expect(profile?.annualBudgetUsd).toBeNull();
+    });
+
+    it("returns null for unparseable strings", () => {
+      const profile = parseDbOrgProfile({
+        ...fullRow,
+        annual_budget_usd: "lots and lots",
+      });
+      expect(profile?.annualBudgetUsd).toBeNull();
+    });
+
+    it("returns null for non-finite numbers", () => {
+      const profile = parseDbOrgProfile({ ...fullRow, annual_budget_usd: NaN });
+      expect(profile?.annualBudgetUsd).toBeNull();
+    });
+  });
+
+  describe("JSONB validation", () => {
+    it("accepts string arrays for major_funders + fara_countries", () => {
+      const profile = parseDbOrgProfile({
+        ...fullRow,
+        major_funders: ["MacArthur", "Knight"],
+        fara_countries: ["Qatar", "Saudi Arabia"],
+      });
+      expect(profile?.majorFunders).toEqual(["MacArthur", "Knight"]);
+      expect(profile?.faraCountries).toEqual(["Qatar", "Saudi Arabia"]);
+    });
+
+    it("filters non-string + empty entries from list fields", () => {
+      const profile = parseDbOrgProfile({
+        ...fullRow,
+        major_funders: ["MacArthur", 42, null, "  Knight  ", "", "   "],
+      });
+      expect(profile?.majorFunders).toEqual(["MacArthur", "Knight"]);
+    });
+
+    it("returns [] for non-array list fields", () => {
+      const profile = parseDbOrgProfile({
+        ...fullRow,
+        major_funders: "MacArthur, Knight",
+      });
+      expect(profile?.majorFunders).toEqual([]);
+    });
+
+    it("accepts an object with string values for external_links", () => {
+      const profile = parseDbOrgProfile({
+        ...fullRow,
+        external_links: { propublica: "https://...", official: "https://..." },
+      });
+      expect(profile?.externalLinks).toEqual({
+        propublica: "https://...",
+        official: "https://...",
+      });
+    });
+
+    it("drops non-string values from external_links", () => {
+      const profile = parseDbOrgProfile({
+        ...fullRow,
+        external_links: { propublica: "https://...", weird: 42 },
+      });
+      expect(profile?.externalLinks).toEqual({ propublica: "https://..." });
+    });
+
+    it("returns {} for an array passed as external_links", () => {
+      const profile = parseDbOrgProfile({
+        ...fullRow,
+        external_links: ["a", "b"],
+      });
+      expect(profile?.externalLinks).toEqual({});
+    });
+  });
+});

--- a/app/org/[slug]/page.tsx
+++ b/app/org/[slug]/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import OrgDossier from "@/components/org/OrgDossier";
+import { getOrgBySlug } from "@/lib/db";
+
+// ISR — same heartbeat as the landing + outlet/politician dossiers.
+// Org metadata changes slowly (annual budgets refresh on 990 cycles,
+// FARA registrations are sporadic), so 600s is well-matched.
+export const revalidate = 600;
+
+interface OrgRouteProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: OrgRouteProps): Promise<Metadata> {
+  const { slug } = await params;
+  const org = await getOrgBySlug(slug);
+  if (!org) return { title: "Organization not found" };
+  return {
+    title: `${org.name} — Org dossier`,
+    description: `Type, funding, political lean, and FARA disclosure for ${org.name} on Sift.`,
+  };
+}
+
+export default async function OrgDossierPage({ params }: OrgRouteProps) {
+  const { slug } = await params;
+  const org = await getOrgBySlug(slug);
+  if (!org) notFound();
+  return <OrgDossier org={org} />;
+}

--- a/components/org/OrgDossier.tsx
+++ b/components/org/OrgDossier.tsx
@@ -1,0 +1,226 @@
+import Link from "next/link";
+
+import LandingMasthead from "@/components/landing/LandingMasthead";
+import { COPY } from "@/lib/copy";
+import {
+  formatBudgetUsd,
+  formatOrgLeanLabel,
+  formatOrgTypeLabel,
+} from "@/lib/org";
+import type { OrgProfile } from "@/lib/types";
+
+interface OrgDossierProps {
+  org: OrgProfile;
+}
+
+/**
+ * Server-rendered org dossier — civic-literacy MVP Phase 3.D.
+ *
+ * Mirrors the editorial register of OutletDossier (2.C.1) and
+ * PoliticianDossier (3.C): kicker eyebrows, hairline rules, mono labels,
+ * Fraunces display type, max-w-800 single column.
+ *
+ * The headline disclosure is FARA. When `faraRegistered` is true, a
+ * dedicated section calls out the registration with the country list,
+ * cited and linkable. Symmetric across the political spectrum — same
+ * panel for Brookings (Qatar) as for any other registered org.
+ */
+export default function OrgDossier({ org }: OrgDossierProps) {
+  const c = COPY.orgDossier;
+  const typeLabel = formatOrgTypeLabel(org.type);
+  const leanLabel = formatOrgLeanLabel(org.politicalLean);
+  const budgetLabel = formatBudgetUsd(org.annualBudgetUsd);
+
+  // Lede bits: "{type} · Founded {year} · Annual budget ~{budget}"
+  // Political lean is its own section heading below; not in the lede.
+  const ledeBits: string[] = [];
+  if (typeLabel) ledeBits.push(typeLabel);
+  if (org.foundedYear) ledeBits.push(c.foundedYearLabel(org.foundedYear));
+  if (budgetLabel) ledeBits.push(c.annualBudgetLabel(budgetLabel));
+
+  // External links: stable order; forward-compat for unknown keys.
+  const linkOrder: Array<keyof typeof c.externalLinkLabels> = [
+    "propublica",
+    "irs_990",
+    "fara",
+    "official",
+    "wikipedia",
+  ];
+  const externalLinkEntries = linkOrder
+    .map((key) => {
+      const url = org.externalLinks[key];
+      return url ? { key, url, label: c.externalLinkLabels[key] } : null;
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null);
+  for (const [key, url] of Object.entries(org.externalLinks)) {
+    if (!linkOrder.includes(key as typeof linkOrder[number]) && url) {
+      externalLinkEntries.push({
+        key,
+        url,
+        label: c.externalLinkLabels[key] ?? key,
+      });
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
+      <LandingMasthead />
+
+      <main
+        id="main-content"
+        className="max-w-[800px] mx-auto px-6 pt-12 pb-24"
+      >
+        {/* Eyebrow + headline */}
+        <header className="mb-9">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3 flex items-center">
+            <span
+              aria-hidden
+              className="inline-block w-7 h-px bg-[var(--border)] mr-3"
+            />
+            {c.eyebrow}
+          </p>
+          <h1 className="font-heading text-[36px] md:text-[44px] font-bold leading-[1.05] tracking-tight text-[var(--text)]">
+            {org.name}
+          </h1>
+          {ledeBits.length > 0 && (
+            <p className="font-body text-[16px] text-[var(--text-secondary)] mt-3 max-w-[60ch] leading-relaxed">
+              {ledeBits.join(" · ")}
+            </p>
+          )}
+        </header>
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* Political lean — Fraunces display, citation muted below */}
+        {leanLabel && (
+          <section className="mb-12">
+            <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+              {c.sections.politicalLean}
+            </p>
+            <p className="font-heading text-[26px] font-semibold text-[var(--text)] leading-tight">
+              {leanLabel}
+            </p>
+          </section>
+        )}
+
+        {/* FARA disclosure — headline civic-literacy reveal. Symmetric:
+            same panel + tone for any registered org regardless of which
+            country, with a link to FARA filings when available. */}
+        {org.faraRegistered && (
+          <section className="mb-12">
+            <p className="font-body text-kicker uppercase text-[var(--accent)] mb-3">
+              {c.sections.fara}
+            </p>
+            <p className="font-heading text-[20px] font-semibold text-[var(--text)] leading-snug mb-3">
+              {c.faraRegisteredHeader}
+            </p>
+            <p className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed max-w-[60ch] mb-3">
+              {c.faraRegisteredBody(org.faraCountries)}
+            </p>
+            {org.externalLinks.fara && (
+              <a
+                href={org.externalLinks.fara}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-body text-meta text-[var(--text-muted)] no-underline hover:underline hover:text-[var(--accent)]"
+              >
+                Source: FARA filings (justice.gov) <span aria-hidden>↗</span>
+              </a>
+            )}
+          </section>
+        )}
+
+        {/* Major funders */}
+        {org.majorFunders.length > 0 && (
+          <section className="mb-10">
+            <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+              {c.sections.majorFunders}
+            </p>
+            <ul className="space-y-1.5">
+              {org.majorFunders.map((funder) => (
+                <li
+                  key={funder}
+                  className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed"
+                >
+                  {funder}
+                </li>
+              ))}
+            </ul>
+            {org.externalLinks.propublica && (
+              <p className="font-body text-meta text-[var(--text-muted)] mt-3">
+                <a
+                  href={org.externalLinks.propublica}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[var(--text-muted)] no-underline hover:underline hover:text-[var(--accent)]"
+                >
+                  Source: ProPublica Nonprofit Explorer (latest 990){" "}
+                  <span aria-hidden>↗</span>
+                </a>
+              </p>
+            )}
+          </section>
+        )}
+
+        {/* External links — public-record citations */}
+        {externalLinkEntries.length > 0 && (
+          <section className="mb-10">
+            <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+              {c.sections.links}
+            </p>
+            <ul className="space-y-2.5">
+              {externalLinkEntries.map(({ key, url, label }) => (
+                <li
+                  key={key}
+                  className="grid grid-cols-[200px_1fr] gap-x-6 items-baseline border-b border-[var(--border-subtle)] pb-2.5"
+                >
+                  <span className="font-body text-outlet uppercase tracking-wider text-[var(--text-muted)]">
+                    {label}
+                  </span>
+                  <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-body text-[14px] text-[var(--text-secondary)] no-underline hover:underline hover:text-[var(--accent)] truncate"
+                  >
+                    {url} <span aria-hidden>↗</span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* Free-form notes (curator commentary) */}
+        {org.notes && (
+          <section className="mb-10">
+            <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">
+              {c.sections.notes}
+            </p>
+            <p className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed max-w-[60ch] italic">
+              {org.notes}
+            </p>
+          </section>
+        )}
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* Footer: methodology link + back to Sift */}
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <Link
+            href="/"
+            className="font-body text-outlet uppercase tracking-wider text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline inline-flex items-center gap-1.5"
+          >
+            <span aria-hidden>←</span> Back to Sift
+          </Link>
+          <Link
+            href="/methodology"
+            className="font-body text-meta text-[var(--text-muted)] italic no-underline hover:text-[var(--accent)] hover:not-italic transition-colors"
+          >
+            {c.methodologyHint}
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -204,6 +204,38 @@ export const COPY = {
     industriesEmpty: "No donor-industry data yet for this cycle.",
     ratingsEmpty: "No interest-group ratings yet recorded.",
   },
+  orgDossier: {
+    eyebrow: "Org dossier",
+    sections: {
+      politicalLean: "Political lean",
+      finances: "Finances",
+      majorFunders: "Major funders",
+      fara: "Foreign-agent registration (FARA)",
+      links: "Where to read more",
+      notes: "Notes",
+    },
+    // External-link labels in stable display order.
+    externalLinkLabels: {
+      propublica: "ProPublica Nonprofit Explorer",
+      irs_990: "IRS Form 990",
+      fara: "FARA filings",
+      official: "Official site",
+      wikipedia: "Wikipedia",
+    } as Record<string, string>,
+    // FARA disclosure copy. Symmetric — same wording regardless of which
+    // country the org is registered to represent.
+    faraRegisteredHeader: "Registered as a foreign agent",
+    faraRegisteredBody: (countries: string[]) =>
+      countries.length === 0
+        ? "This organization is registered with the U.S. Department of Justice under FARA."
+        : countries.length === 1
+          ? `This organization is registered with the U.S. Department of Justice under FARA on behalf of ${countries[0]}.`
+          : `This organization is registered with the U.S. Department of Justice under FARA on behalf of: ${countries.join(", ")}.`,
+    // Single-line lede builder bits.
+    foundedYearLabel: (year: number) => `Founded ${year}`,
+    annualBudgetLabel: (budget: string) => `Annual budget ~${budget}`,
+    methodologyHint: "Funding data comes from IRS 990s and FARA. Read the methodology.",
+  },
   dossier: {
     // Eyebrow shown above the outlet name.
     eyebrow: "Outlet dossier",

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,11 +1,12 @@
 import { Pool } from "pg";
 
+import { parseDbOrgProfile, type DbOrgProfileRow } from "./org";
 import { parseDbOutletProfile, type DbOutletProfileRow } from "./outlet";
 import {
   parseDbPoliticianProfile,
   type DbPoliticianProfileRow,
 } from "./politician";
-import type { OutletProfile, PoliticianProfile } from "./types";
+import type { OrgProfile, OutletProfile, PoliticianProfile } from "./types";
 
 if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL environment variable is not set");
@@ -569,6 +570,37 @@ export async function getPoliticianByBioguide(
     );
     if (result.rows.length === 0) return null;
     return parseDbPoliticianProfile(result.rows[0]);
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("does not exist")) return null;
+    throw err;
+  }
+}
+
+// ─── Org Dossier (Phase 3.D) ───────────────────────────
+
+/**
+ * Fetch a single org profile by slug (e.g. 'brookings-institution').
+ * Returns null when the slug isn't curated (caller should call
+ * notFound() for the dossier route) or when the org_profiles table
+ * doesn't exist yet.
+ */
+export async function getOrgBySlug(slug: string): Promise<OrgProfile | null> {
+  const trimmed = slug.trim().toLowerCase();
+  if (!trimmed) return null;
+
+  try {
+    const result = await pool.query<DbOrgProfileRow>(
+      `SELECT slug, name, type, political_lean, founded_year,
+              annual_budget_usd, major_funders, fara_registered,
+              fara_countries, external_links, notes
+       FROM org_profiles
+       WHERE slug = $1
+       LIMIT 1`,
+      [trimmed]
+    );
+    if (result.rows.length === 0) return null;
+    return parseDbOrgProfile(result.rows[0]);
   } catch (err) {
     const msg = String(err);
     if (msg.includes("does not exist")) return null;

--- a/lib/org.ts
+++ b/lib/org.ts
@@ -1,0 +1,203 @@
+// Org-provenance helpers — civic-literacy MVP Phase 3.D.
+//
+// Parses curated rows from `org_profiles` into the typed `OrgProfile` shape
+// the UI consumes, plus label formatters for type / political-lean / funding
+// budget. Pure functions only; trivially unit-testable.
+
+import type {
+  OrgExternalLinks,
+  OrgPoliticalLean,
+  OrgProfile,
+  OrgType,
+} from "./types";
+
+// ─── Enums (in sync with sift-api/scripts/seed_org_profiles.py) ──────
+
+const ORG_TYPES: ReadonlySet<string> = new Set([
+  "think-tank",
+  "advocacy",
+  "union",
+  "pac",
+  "super-pac",
+  "foundation",
+  "industry-group",
+  "other",
+]);
+
+const ORG_LEAN_VALUES: ReadonlySet<string> = new Set([
+  "left",
+  "lean-left",
+  "center",
+  "lean-right",
+  "right",
+  "mixed",
+  "nonpartisan",
+]);
+
+// ─── Display labels ───────────────────────────────────────────────────
+
+const ORG_TYPE_LABELS: Record<OrgType, string> = {
+  "think-tank": "Think tank",
+  advocacy: "Advocacy organization",
+  union: "Labor union",
+  pac: "Political action committee",
+  "super-pac": "Super PAC",
+  foundation: "Foundation",
+  "industry-group": "Industry group",
+  other: "Organization",
+};
+
+/** Human label for an org-type enum value, e.g. `"think-tank"` → `"Think tank"`. */
+export function formatOrgTypeLabel(
+  type: OrgType | null | undefined,
+): string | null {
+  if (!type) return null;
+  return ORG_TYPE_LABELS[type] ?? null;
+}
+
+const ORG_LEAN_LABELS: Record<OrgPoliticalLean, string> = {
+  left: "Left",
+  "lean-left": "Lean Left",
+  center: "Center",
+  "lean-right": "Lean Right",
+  right: "Right",
+  mixed: "Mixed",
+  nonpartisan: "Nonpartisan",
+};
+
+/** Human label for an org political-lean enum, e.g. `"lean-left"` → `"Lean Left"`. */
+export function formatOrgLeanLabel(
+  lean: OrgPoliticalLean | null | undefined,
+): string | null {
+  if (!lean) return null;
+  return ORG_LEAN_LABELS[lean] ?? null;
+}
+
+/**
+ * Compact USD formatter for org budgets.
+ *   1_200_000_000 → "$1.2B"
+ *   120_000_000   → "$120M"
+ *   9_000_000     → "$9M"
+ *   500_000       → "$500K"
+ *   9_000         → "$9K"
+ *   500           → "$500"
+ *
+ * Returns null for null/undefined or non-finite numbers.
+ */
+export function formatBudgetUsd(amount: number | null | undefined): string | null {
+  if (amount == null || !Number.isFinite(amount)) return null;
+  const a = Math.abs(amount);
+  if (a >= 1_000_000_000) {
+    const v = amount / 1_000_000_000;
+    return `$${v % 1 === 0 ? v.toFixed(0) : v.toFixed(1)}B`;
+  }
+  if (a >= 1_000_000) {
+    const v = amount / 1_000_000;
+    return `$${v % 1 === 0 ? v.toFixed(0) : v.toFixed(1)}M`;
+  }
+  if (a >= 1_000) {
+    const v = amount / 1_000;
+    return `$${v % 1 === 0 ? v.toFixed(0) : v.toFixed(1)}K`;
+  }
+  return `$${amount.toLocaleString("en-US")}`;
+}
+
+// ─── DB-row parsing ───────────────────────────────────────────────────
+
+/**
+ * Shape of a row from `org_profiles`. Numerics arrive as JS numbers from
+ * `pg`; JSONB columns arrive parsed; we re-validate everything.
+ *
+ * `updated_at` is internal-only and intentionally omitted.
+ */
+export interface DbOrgProfileRow {
+  slug: string;
+  name: string;
+  type: string | null;
+  political_lean: string | null;
+  founded_year: number | null;
+  annual_budget_usd: number | string | null;  // pg returns NUMERIC as string sometimes
+  major_funders: unknown;  // expected: string[]
+  fara_registered: boolean | null;
+  fara_countries: unknown;  // expected: string[]
+  external_links: unknown;  // expected: OrgExternalLinks
+  notes: string | null;
+}
+
+function asOrgType(v: string | null): OrgType | null {
+  if (!v) return null;
+  const lower = v.toLowerCase();
+  return ORG_TYPES.has(lower) ? (lower as OrgType) : null;
+}
+
+function asOrgLean(v: string | null): OrgPoliticalLean | null {
+  if (!v) return null;
+  const lower = v.toLowerCase();
+  return ORG_LEAN_VALUES.has(lower) ? (lower as OrgPoliticalLean) : null;
+}
+
+/**
+ * Coerce pg's NUMERIC representation (often returned as string to preserve
+ * precision) into a JS number. Returns null for invalid inputs rather than
+ * NaN — the dossier conditionally skips the budget section on null.
+ */
+function asNumeric(v: number | string | null | undefined): number | null {
+  if (v == null) return null;
+  if (typeof v === "number") return Number.isFinite(v) ? v : null;
+  const trimmed = v.trim();
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : null;
+}
+
+function asStringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function asExternalLinks(v: unknown): OrgExternalLinks {
+  if (!v || typeof v !== "object" || Array.isArray(v)) return {};
+  const out: OrgExternalLinks = {};
+  for (const [key, value] of Object.entries(v as Record<string, unknown>)) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      out[key] = value.trim();
+    }
+  }
+  return out;
+}
+
+/**
+ * Validate + shape a raw `org_profiles` row. Returns null when the
+ * required identity fields (slug, name) are missing. Unknown enum values
+ * null out (UI tolerates absence rather than rendering bad labels).
+ * Malformed JSONB degrades to empty list/object so the dossier renders
+ * partial sections cleanly.
+ */
+export function parseDbOrgProfile(
+  row: DbOrgProfileRow | null | undefined,
+): OrgProfile | null {
+  if (!row) return null;
+  const slug = (row.slug ?? "").trim().toLowerCase();
+  const name = (row.name ?? "").trim();
+  if (!slug || !name) return null;
+
+  return {
+    slug,
+    name,
+    type: asOrgType(row.type),
+    politicalLean: asOrgLean(row.political_lean),
+    foundedYear:
+      typeof row.founded_year === "number" && Number.isFinite(row.founded_year)
+        ? row.founded_year
+        : null,
+    annualBudgetUsd: asNumeric(row.annual_budget_usd),
+    majorFunders: asStringArray(row.major_funders),
+    faraRegistered: row.fara_registered === true,
+    faraCountries: asStringArray(row.fara_countries),
+    externalLinks: asExternalLinks(row.external_links),
+    notes: row.notes?.trim() || null,
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -92,6 +92,78 @@ export interface OutletExternalLinks {
   [key: string]: string | undefined;
 }
 
+// ─── Org Provenance (Phase 3.D) ────────────────────────
+
+/**
+ * Curated org-type taxonomy. Mirrors the values stored in
+ * `org_profiles.type`; the seed scripts validate against this set.
+ */
+export type OrgType =
+  | "think-tank"
+  | "advocacy"
+  | "union"
+  | "pac"
+  | "super-pac"
+  | "foundation"
+  | "industry-group"
+  | "other";
+
+/**
+ * Org political-lean buckets. Same six AllSides-aligned buckets that
+ * `OutletAllSidesRating` uses, plus `nonpartisan` for orgs that take no
+ * position (some industry groups, some foundations). The bucketize helper
+ * in lib/crossSpectrum.ts treats `nonpartisan` like `mixed` — neither
+ * lands in a L/C/R column.
+ */
+export type OrgPoliticalLean =
+  | "left"
+  | "lean-left"
+  | "center"
+  | "lean-right"
+  | "right"
+  | "mixed"
+  | "nonpartisan";
+
+/**
+ * External-source links rendered as the citation footer of the org
+ * dossier. ProPublica Nonprofit Explorer for 990s; FARA filings for
+ * registered foreign agents; Wikipedia + the official site for context.
+ * Open-ended for forward compatibility.
+ */
+export interface OrgExternalLinks {
+  propublica?: string;
+  irs_990?: string;
+  fara?: string;
+  wikipedia?: string;
+  official?: string;
+  [key: string]: string | undefined;
+}
+
+/**
+ * Curated org metadata, mirrored from `org_profiles` in Postgres. Phase
+ * 3.A seeded a small sample (10 think tanks + advocacy orgs spanning
+ * the political spectrum); a follow-up curation pass grows this to
+ * ~200 entries for production coverage.
+ *
+ * `faraRegistered` is the headline disclosure: orgs registered as
+ * foreign agents under FARA get a prominent callout with the country
+ * list. The methodology page documents that this is symmetric — every
+ * registered org gets the same treatment regardless of which country.
+ */
+export interface OrgProfile {
+  slug: string;
+  name: string;
+  type: OrgType | null;
+  politicalLean: OrgPoliticalLean | null;
+  foundedYear: number | null;
+  annualBudgetUsd: number | null;
+  majorFunders: string[];
+  faraRegistered: boolean;
+  faraCountries: string[];
+  externalLinks: OrgExternalLinks;
+  notes: string | null;
+}
+
 // ─── Politician Provenance (Phase 3.C) ─────────────────
 
 /**


### PR DESCRIPTION
## Summary
Adds **`/org/[slug]`** — server-rendered editorial dossier for any curated think tank, advocacy org, union, PAC, foundation, or industry group. Mirrors `/outlet/[slug]` (2.C.1) and `/politician/[bioguide]` (3.C); reads from the `org_profiles` table seeded by [sift-api #26](https://github.com/kristenmartino/sift-api/pull/26).

The headline civic-literacy reveal here is **FARA**: when an org is registered as a foreign agent under the Foreign Agents Registration Act, the dossier renders a dedicated `--accent`-colored section with the country list and a link to FARA filings. Symmetric application across the political spectrum is the methodology — same panel and tone for Brookings (Qatar) as for any other registered org regardless of which country.

## What ships
| Layer | File | Change |
|---|---|---|
| Types | `lib/types.ts` | `OrgType`, `OrgPoliticalLean` (adds `nonpartisan`), `OrgExternalLinks`, `OrgProfile` |
| Helpers | `lib/org.ts` (new) | `parseDbOrgProfile`, `formatOrgTypeLabel`, `formatOrgLeanLabel`, `formatBudgetUsd` |
| DB | `lib/db.ts` | `getOrgBySlug()` — single-row fetch, slug lowercased, missing-table tolerant |
| Route | `app/org/[slug]/page.tsx` (new) | Async server component, `revalidate=600`, `notFound()` on miss, SEO metadata |
| Component | `components/org/OrgDossier.tsx` (new) | One-column max-w-800 layout, FARA-headline section when registered |
| Copy | `lib/copy.ts` | `COPY.orgDossier` block, symmetric FARA body copy |
| Tests | `__tests__/org.test.ts` (new) | +30 tests covering formatters, parser, JSONB validation, NUMERIC coercion |

## Visual register
- **Header**: `Org dossier` kicker → name in Fraunces 36-44 → lede `Think tank · Founded 1916 · Annual budget ~$120M`
- **Political lean**: Fraunces 26 display value (`Center` / `Lean Left` / etc.)
- **FARA section** (when registered): `--accent`-colored kicker, `Registered as a foreign agent` headline in Fraunces 20, body copy with country substitution, citation link to `justice.gov`
- **Major funders**: bullet list with ProPublica Nonprofit Explorer citation footer
- **External links**: 200/1fr grid (ProPublica → IRS 990 → FARA → Official → Wikipedia, then any forward-compat keys)
- **Notes**: italicized curator commentary
- **Footer**: methodology link + back to Sift

## FARA copy — symmetry by construction
```ts
faraRegisteredBody: (countries: string[]) =>
  countries.length === 0
    ? "This organization is registered with the U.S. Department of Justice under FARA."
    : countries.length === 1
      ? `…on behalf of ${countries[0]}.`
      : `…on behalf of: ${countries.join(", ")}.`
```
Same template for any country list. Never editorializes.

## Tests
- 10 suites / 216 tests pass; `tsc --noEmit` clean
- New tests exercise: every org type + lean label, budget formatter (B/M/K scaling, whole-vs-decimal, negatives, NaN/Infinity), parser happy path + slug lowercasing + identity trimming, null-returning inputs, graceful enum + empty-string normalization, `fara_registered` null-vs-false default, NUMERIC type coercion (number / pg's NUMERIC string / null / unparseable), JSONB validation (string arrays, mixed types, non-array rejection, external_links object/array rejection)

## Graceful degradation
- `getOrgBySlug` catches `relation does not exist` → returns `null` → `notFound()` renders the existing global 404 page
- Sample seed has Brookings flagged FARA-registered (Qatar) per public record, so the FARA section gets exercised end-to-end against `/org/brookings-institution`
- Until #26 is seeded in prod, every `/org/[slug]` lands on a 404 — no broken half-state

## Out of scope
A separate operational curation pass (not code) grows `data/org_profiles.csv` from the current 10 sample orgs to ~200 hand-curated entries before the inline-glossary feature ships in 3.H. The schema, parser, route, and component are all sized for that growth.

## Phase 3 status
- ✅ **3.A** schema + seed tooling
- ✅ **3.B** GovTrack scrape — 536 sitting Congress members
- ✅ **3.C** politician dossier route
- 🆕 **3.D** org dossier route (this PR)
- 🚧 **3.E** `/bill/[id]` dossier
- 🚧 **3.F** OpenSecrets daily refresh + Vote Smart enrichment
- 🚧 **3.G** entity-linking LangGraph node + `articles.entity_links`
- 🚧 **3.H** `InlineGlossaryTooltip` + ArticleCard integration

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 216 passing
- [ ] Visual: dev preview `/org/brookings-institution` once `org_profiles` is seeded; FARA section renders with the Qatar callout
- [ ] Visual: `/org/heritage-foundation` renders with `Right` political lean, no FARA section, major funders + external links populated
- [ ] Visual: `/org/does-not-exist` returns the global 404 page
- [ ] Visual: light + dark mode parity; mobile narrow-viewport reflow
- [ ] Click-through: ProPublica / FARA / Wikipedia links open in new tabs with `rel="noopener noreferrer"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)