### PR TITLE
feat: civic-literacy MVP Phase 3.H — InlineGlossaryTooltip + ArticleCard integration

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -18,14 +18,16 @@ const mockGetStoriesWithArticles = jest.fn<
 >();
 const mockGetLastRefreshed = jest.fn<Promise<Date | null>, [string]>();
 
-// Phase 2.B: outlet provenance map. Tests pre-date the lookup, so default to
-// an empty Map (= no curated outlets resolved → API returns articles with
-// outlet absent, which is the graceful-degradation path the UI tolerates).
+// Phase 2.B: outlet provenance map. Phase 3.H: entity_links lookup.
+// Tests pre-date both, so default to empty results (= API returns articles
+// without outlet/entityLinks, which is the graceful-degradation path the UI
+// tolerates).
 jest.mock("@/lib/db", () => ({
   getStoriesWithArticles: (...args: [string]) => mockGetStoriesWithArticles(...args),
   getLastRefreshed: (...args: [string]) => mockGetLastRefreshed(...args),
   getOutletProfilesMap: jest.fn().mockResolvedValue(new Map()),
   resolveOutletForSourceName: jest.fn().mockReturnValue(null),
+  getArticleEntityLinks: jest.fn().mockResolvedValue(new Map()),
 }));
 
 import { GET } from "../app/api/news/route";

--- a/__tests__/entityLinks.test.ts
+++ b/__tests__/entityLinks.test.ts
@@ -1,0 +1,147 @@
+import {
+  entityHref,
+  entityTypeLabel,
+  parseEntityLinks,
+} from "@/lib/entityLinks";
+import type { EntityLink } from "@/lib/types";
+
+// ─── parseEntityLinks ───────────────────────────────────────
+
+describe("parseEntityLinks", () => {
+  describe("happy path", () => {
+    it("parses a well-formed JSONB array into typed EntityLinks", () => {
+      const input = [
+        { type: "politician", canonical_id: "S000148", surface_form: "Chuck Schumer" },
+        { type: "org", canonical_id: "brookings-institution", surface_form: "Brookings Institution" },
+        { type: "bill", canonical_id: "hr-5376-117", surface_form: "Inflation Reduction Act" },
+        { type: "outlet", canonical_id: "reuters", surface_form: "Reuters" },
+      ];
+      expect(parseEntityLinks(input)).toEqual([
+        { type: "politician", canonicalId: "S000148", surfaceForm: "Chuck Schumer" },
+        { type: "org", canonicalId: "brookings-institution", surfaceForm: "Brookings Institution" },
+        { type: "bill", canonicalId: "hr-5376-117", surfaceForm: "Inflation Reduction Act" },
+        { type: "outlet", canonicalId: "reuters", surfaceForm: "Reuters" },
+      ]);
+    });
+
+    it("trims whitespace on canonical_id and surface_form", () => {
+      const input = [
+        { type: "politician", canonical_id: "  S000148  ", surface_form: "  Chuck Schumer  " },
+      ];
+      expect(parseEntityLinks(input)).toEqual([
+        { type: "politician", canonicalId: "S000148", surfaceForm: "Chuck Schumer" },
+      ]);
+    });
+  });
+
+  describe("empty / invalid inputs", () => {
+    it.each([
+      [null],
+      [undefined],
+      [42],
+      ["not an array"],
+      [{ type: "politician" }],  // non-array object
+      [true],
+    ])("returns [] for %p", (input) => {
+      expect(parseEntityLinks(input)).toEqual([]);
+    });
+
+    it("returns [] for an empty array", () => {
+      expect(parseEntityLinks([])).toEqual([]);
+    });
+  });
+
+  describe("entry-level filtering", () => {
+    it("drops entries missing required fields", () => {
+      const input = [
+        { type: "politician", canonical_id: "S000148", surface_form: "Schumer" }, // ok
+        { type: "politician", canonical_id: "S000149" },                            // no surface
+        { type: "politician", surface_form: "Cruz" },                               // no id
+        { canonical_id: "C001", surface_form: "Cruz" },                             // no type
+        {},                                                                         // empty
+      ];
+      expect(parseEntityLinks(input)).toEqual([
+        { type: "politician", canonicalId: "S000148", surfaceForm: "Schumer" },
+      ]);
+    });
+
+    it("drops entries with unknown types", () => {
+      const input = [
+        { type: "politician", canonical_id: "S000148", surface_form: "Schumer" },
+        { type: "celebrity", canonical_id: "C001", surface_form: "Bono" },  // not in enum
+        { type: "outlet", canonical_id: "reuters", surface_form: "Reuters" },
+      ];
+      const out = parseEntityLinks(input);
+      expect(out.map((e) => e.type)).toEqual(["politician", "outlet"]);
+    });
+
+    it("drops entries where canonical_id or surface_form trims to empty", () => {
+      const input = [
+        { type: "politician", canonical_id: "  ", surface_form: "Schumer" },
+        { type: "politician", canonical_id: "S000148", surface_form: "" },
+      ];
+      expect(parseEntityLinks(input)).toEqual([]);
+    });
+
+    it("drops entries with non-string fields", () => {
+      const input = [
+        { type: "politician", canonical_id: 12345, surface_form: "Schumer" },  // numeric id
+        { type: 42, canonical_id: "S000148", surface_form: "Schumer" },        // numeric type
+        { type: "politician", canonical_id: "S000148", surface_form: ["Schumer"] }, // array surface
+      ];
+      expect(parseEntityLinks(input)).toEqual([]);
+    });
+
+    it("preserves valid entries even when others are malformed", () => {
+      const input = [
+        null,
+        { type: "politician", canonical_id: "S000148", surface_form: "Schumer" },  // ok
+        "string",
+        { type: "org", canonical_id: "brookings-institution", surface_form: "Brookings" }, // ok
+        { junk: "field" },
+      ];
+      expect(parseEntityLinks(input)).toEqual([
+        { type: "politician", canonicalId: "S000148", surfaceForm: "Schumer" },
+        { type: "org", canonicalId: "brookings-institution", surfaceForm: "Brookings" },
+      ]);
+    });
+  });
+});
+
+// ─── entityHref ─────────────────────────────────────────────
+
+describe("entityHref", () => {
+  const cases: Array<[EntityLink, string]> = [
+    [
+      { type: "outlet", canonicalId: "reuters", surfaceForm: "Reuters" },
+      "/outlet/reuters",
+    ],
+    [
+      { type: "politician", canonicalId: "S000148", surfaceForm: "Schumer" },
+      "/politician/S000148",
+    ],
+    [
+      { type: "org", canonicalId: "brookings-institution", surfaceForm: "Brookings" },
+      "/org/brookings-institution",
+    ],
+    [
+      { type: "bill", canonicalId: "hr-5376-117", surfaceForm: "IRA" },
+      "/bill/hr-5376-117",
+    ],
+  ];
+
+  it.each(cases)("returns the correct dossier href for %j", (link, expected) => {
+    expect(entityHref(link)).toBe(expected);
+  });
+});
+
+// ─── entityTypeLabel ────────────────────────────────────────
+
+describe("entityTypeLabel", () => {
+  it("returns human labels for each type", () => {
+    expect(entityTypeLabel("outlet")).toBe("Outlet");
+    expect(entityTypeLabel("politician")).toBe("Politician");
+    expect(entityTypeLabel("org")).toBe("Organization");
+    expect(entityTypeLabel("bill")).toBe("Bill");
+  });
+});

--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -8,8 +8,10 @@ import {
   getBookmarkedArticles,
   getOutletProfilesMap,
   resolveOutletForSourceName,
+  getArticleEntityLinks,
 } from "@/lib/db";
 import { parseContextPrimer } from "@/lib/primer";
+import { parseEntityLinks } from "@/lib/entityLinks";
 import type { Article, CategoryId } from "@/lib/types";
 import { checkCsrf } from "@/lib/security";
 
@@ -34,9 +36,11 @@ export async function GET(request: NextRequest) {
         getBookmarkedArticles(userId),
         getOutletProfilesMap(),
       ]);
+      const entityLinksMap = await getArticleEntityLinks(rows.map((r) => r.id));
       const articles: Article[] = rows.map((row) => {
         const primer = parseContextPrimer(row.context_primer);
         const outlet = resolveOutletForSourceName(outletMap, row.source_name);
+        const entityLinks = parseEntityLinks(entityLinksMap.get(row.id));
         return {
           id: row.id,
           title: row.title,
@@ -51,6 +55,7 @@ export async function GET(request: NextRequest) {
           ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
           ...(primer ? { contextPrimer: primer } : {}),
           ...(outlet ? { outlet } : {}),
+          ...(entityLinks.length > 0 ? { entityLinks } : {}),
         };
       });
       return NextResponse.json({ articles });

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -4,8 +4,10 @@ import {
   getLastRefreshed,
   getOutletProfilesMap,
   resolveOutletForSourceName,
+  getArticleEntityLinks,
 } from "@/lib/db";
 import { parseContextPrimer } from "@/lib/primer";
+import { parseEntityLinks } from "@/lib/entityLinks";
 import { stripHtml, sanitizeUrl } from "@/lib/sanitize";
 import type { CategoryId, Article, Story, StoryFraming, EntitySet, NewsApiResponse, NewsApiError } from "@/lib/types";
 
@@ -64,10 +66,20 @@ export async function GET(request: NextRequest) {
         getOutletProfilesMap(),
       ]);
 
+    // Phase 3.H: batch-fetch entity_links JSONB for every article touched
+    // by this request, in one query. Defensive: returns an empty Map if
+    // the column doesn't exist yet (pre-Phase-3.G prod).
+    const allArticleIds = [
+      ...standaloneArticles.map((r) => r.id),
+      ...Object.values(storyArticles).flat().map((r) => r.id),
+    ];
+    const entityLinksMap = await getArticleEntityLinks(allArticleIds);
+
     // Map standalone articles
     const articles: Article[] = standaloneArticles.map((row) => {
       const primer = parseContextPrimer(row.context_primer);
       const outlet = resolveOutletForSourceName(outletMap, row.source_name);
+      const entityLinks = parseEntityLinks(entityLinksMap.get(row.id));
       return {
         id: row.id,
         title: row.title,
@@ -82,6 +94,7 @@ export async function GET(request: NextRequest) {
         ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
         ...(primer ? { contextPrimer: primer } : {}),
         ...(outlet ? { outlet } : {}),
+        ...(entityLinks.length > 0 ? { entityLinks } : {}),
       };
     });
 
@@ -91,6 +104,7 @@ export async function GET(request: NextRequest) {
       const childArticles: Article[] = childRows.map((row) => {
         const primer = parseContextPrimer(row.context_primer);
         const outlet = resolveOutletForSourceName(outletMap, row.source_name);
+        const entityLinks = parseEntityLinks(entityLinksMap.get(row.id));
         return {
           id: row.id,
           title: row.title,
@@ -105,6 +119,7 @@ export async function GET(request: NextRequest) {
           ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
           ...(primer ? { contextPrimer: primer } : {}),
           ...(outlet ? { outlet } : {}),
+          ...(entityLinks.length > 0 ? { entityLinks } : {}),
         };
       });
 

--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -5,8 +5,10 @@ import {
   insertArticle,
   getOutletProfilesMap,
   resolveOutletForSourceName,
+  getArticleEntityLinks,
 } from "@/lib/db";
 import { parseContextPrimer } from "@/lib/primer";
+import { parseEntityLinks } from "@/lib/entityLinks";
 import { stableHash, estimateReadTime } from "@/lib/utils";
 import { stripHtml, sanitizeUrl } from "@/lib/sanitize";
 import type { Article, CategoryId } from "@/lib/types";
@@ -196,11 +198,13 @@ export async function GET(request: NextRequest) {
           searchArticlesByEmbedding(embedding, SIMILARITY_THRESHOLD, MAX_RESULTS),
           getOutletProfilesMap(),
         ]);
+        const entityLinksMap = await getArticleEntityLinks(rows.map((r) => r.id));
 
         // 3. Map DB rows to Article type
         const articles: Article[] = rows.map((row) => {
           const primer = parseContextPrimer(row.context_primer);
           const outlet = resolveOutletForSourceName(outletMap, row.source_name);
+          const entityLinks = parseEntityLinks(entityLinksMap.get(row.id));
           return {
             id: row.id,
             title: row.title,
@@ -217,6 +221,7 @@ export async function GET(request: NextRequest) {
             ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
             ...(primer ? { contextPrimer: primer } : {}),
             ...(outlet ? { outlet } : {}),
+            ...(entityLinks.length > 0 ? { entityLinks } : {}),
           };
         });
 

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -7,6 +7,7 @@ import { timeAgo } from "@/lib/utils";
 import CardImage from "./CardImage";
 import BackgroundPrimer from "./primer/BackgroundPrimer";
 import OutletBadge from "./outlet/OutletBadge";
+import EntityLinksList from "./glossary/EntityLinksList";
 import type { ArticleCardProps } from "@/lib/types";
 
 // Fan-out stagger: even-indexed cards drift from left, odd from right
@@ -208,6 +209,12 @@ export default function ArticleCard({
             defaultExpanded={!!featured}
           />
         )}
+
+        {/* Entity links ("Mentioned in this story") — civic-literacy MVP
+            Phase 3.H. Renders nothing when entityLinks is empty/undefined,
+            so articles predating the entity-linker pipeline degrade
+            cleanly. */}
+        <EntityLinksList links={article.entityLinks} />
 
         {/* Meta */}
         <div className="flex items-center gap-3 mt-auto pt-2 text-xs text-[var(--text-muted)] font-medium flex-wrap">

--- a/components/glossary/EntityLinksList.tsx
+++ b/components/glossary/EntityLinksList.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Link from "next/link";
+
+import { COPY } from "@/lib/copy";
+import { entityHref, entityTypeLabel } from "@/lib/entityLinks";
+import type { EntityLink } from "@/lib/types";
+
+interface EntityLinksListProps {
+  links: EntityLink[] | undefined;
+}
+
+/**
+ * Renders the "Mentioned in this story" pill row at the foot of an
+ * ArticleCard — civic-literacy MVP Phase 3.H.
+ *
+ * Each pill is a clickable chip that navigates to the entity's dossier
+ * route (`/politician/[bioguide]`, `/org/[slug]`, `/bill/[id]`, or
+ * `/outlet/[slug]`). The tiny mono glyph prefix encodes the entity type
+ * at a glance; the surface form preserves the original casing as it
+ * appeared in the article.
+ *
+ * Renders nothing when there are no links (graceful — articles
+ * predating the entity-linker pipeline, or articles with no curated
+ * matches, simply omit this section).
+ *
+ * z-index note: ArticleCard wraps its title in a stretched `<a>`
+ * overlay (`<span class="absolute inset-0 z-[1]">`). Anchors here use
+ * `relative z-[2]` + `e.stopPropagation()` to opt out of that overlay,
+ * mirroring how the bookmark, primer toggle, and OutletBadge already
+ * escape the card-link.
+ */
+export default function EntityLinksList({ links }: EntityLinksListProps) {
+  if (!links || links.length === 0) return null;
+
+  return (
+    <section
+      className="mt-2 flex flex-col gap-1.5"
+      aria-labelledby="entity-list-eyebrow"
+    >
+      <p
+        id="entity-list-eyebrow"
+        className="text-kicker font-bold uppercase text-[var(--text-muted)]"
+      >
+        {COPY.glossary.eyebrow}
+      </p>
+      <ul className="flex flex-wrap gap-1.5">
+        {links.map((link) => {
+          const glyph = COPY.glossary.typeGlyphs[link.type];
+          return (
+            <li key={`${link.type}:${link.canonicalId}`}>
+              <Link
+                href={entityHref(link)}
+                onClick={(e) => e.stopPropagation()}
+                aria-label={`${entityTypeLabel(link.type)}: ${link.surfaceForm}. Open dossier.`}
+                className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[12px] no-underline transition-colors duration-200 relative z-[2] border border-[var(--border)] text-[var(--text-secondary)] bg-[var(--card-bg)] hover:border-[var(--accent)] hover:text-[var(--accent)]"
+              >
+                {glyph && (
+                  <span
+                    aria-hidden
+                    className="font-mono text-[10px] text-[var(--text-muted)]"
+                  >
+                    {glyph}
+                  </span>
+                )}
+                <span className="font-medium">{link.surfaceForm}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -105,6 +105,19 @@ export const COPY = {
     body: "Try different words \u2014 or let the AI surprise you.",
     button: "Browse today\u2019s stories",
   },
+  glossary: {
+    // Eyebrow shown above the inline list of resolved entities at the
+    // foot of an article card. Phase 3.H — civic-literacy MVP.
+    eyebrow: "Mentioned in this story",
+    // Per-type prefix glyphs in the small mono register. Kept short so
+    // the pills don't bloat the meta line.
+    typeGlyphs: {
+      politician: "◉",
+      org: "◆",
+      bill: "▸",
+      outlet: "▣",
+    } as Record<string, string>,
+  },
   primer: {
     // Eyebrow shown above the collapsed/expanded primer panel.
     eyebrow: "What you should know first",

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -543,6 +543,39 @@ export async function getAllOutletProfiles(): Promise<OutletProfile[]> {
   }
 }
 
+// ─── Entity Links (Phase 3.H) ──────────────────────────
+
+/**
+ * Batch-fetch entity_links JSONB for a set of article IDs. Returns a
+ * Map keyed on article id for O(1) lookup at API mapping time.
+ *
+ * Defensive: catches "column entity_links does not exist" so this code
+ * is safe to deploy before sift-api Phase 3.G's migration lands in
+ * prod. Articles whose ids aren't in the result map render with empty
+ * entityLinks (graceful degradation — EntityLinksList renders nothing).
+ */
+export async function getArticleEntityLinks(
+  articleIds: string[],
+): Promise<Map<string, unknown>> {
+  if (articleIds.length === 0) return new Map();
+
+  try {
+    const result = await pool.query<{ id: string; entity_links: unknown }>(
+      `SELECT id, entity_links FROM articles WHERE id = ANY($1::text[])`,
+      [articleIds]
+    );
+    return new Map(result.rows.map((r) => [r.id, r.entity_links]));
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("entity_links") && msg.includes("does not exist")) {
+      // Pre-Phase-3.G prod — column not yet added. Fall through with
+      // empty map; the UI renders no glossary section.
+      return new Map();
+    }
+    throw err;
+  }
+}
+
 // ─── Politician Dossier (Phase 3.C) ────────────────────
 
 /**

--- a/lib/entityLinks.ts
+++ b/lib/entityLinks.ts
@@ -1,0 +1,80 @@
+// Entity-link helpers — civic-literacy MVP Phase 3.H.
+//
+// Validates the JSONB shape produced by the sift-api Phase 3.G
+// entity_linker pipeline node and turns it into typed `EntityLink[]`.
+// Pure-function only.
+
+import type { EntityLink, EntityLinkType } from "./types";
+
+const VALID_TYPES: ReadonlySet<string> = new Set([
+  "outlet",
+  "politician",
+  "org",
+  "bill",
+]);
+
+/**
+ * Parse + validate an `articles.entity_links` JSONB blob into typed
+ * `EntityLink[]`. Returns `[]` for null / non-array / malformed inputs;
+ * the UI renders nothing in those cases (graceful degradation).
+ *
+ * Drops any individual entry that's missing required fields or has an
+ * unknown type, so a partial corruption doesn't break the whole list.
+ *
+ * Maps DB snake_case fields to the typed camelCase shape inline.
+ */
+export function parseEntityLinks(value: unknown): EntityLink[] {
+  if (!Array.isArray(value)) return [];
+  const out: EntityLink[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+
+    const type = typeof e.type === "string" ? e.type : null;
+    const canonicalId = typeof e.canonical_id === "string"
+      ? e.canonical_id.trim()
+      : null;
+    const surfaceForm = typeof e.surface_form === "string"
+      ? e.surface_form.trim()
+      : null;
+
+    if (!type || !canonicalId || !surfaceForm) continue;
+    if (!VALID_TYPES.has(type)) continue;
+
+    out.push({
+      type: type as EntityLinkType,
+      canonicalId,
+      surfaceForm,
+    });
+  }
+  return out;
+}
+
+/**
+ * Map an entity link to its dossier route href. Centralized so the
+ * component layer doesn't sprinkle path templates around.
+ */
+export function entityHref(link: EntityLink): string {
+  switch (link.type) {
+    case "outlet":
+      return `/outlet/${link.canonicalId}`;
+    case "politician":
+      return `/politician/${link.canonicalId}`;
+    case "org":
+      return `/org/${link.canonicalId}`;
+    case "bill":
+      return `/bill/${link.canonicalId}`;
+  }
+}
+
+const TYPE_LABELS: Record<EntityLinkType, string> = {
+  outlet: "Outlet",
+  politician: "Politician",
+  org: "Organization",
+  bill: "Bill",
+};
+
+/** Human label for an entity link type, used as a small subtitle in the list. */
+export function entityTypeLabel(type: EntityLinkType): string {
+  return TYPE_LABELS[type];
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -50,6 +50,16 @@ export interface Article {
    * yet (graceful degradation: OutletBadge renders the plain source name).
    */
   outlet?: OutletProfile | null;
+  /**
+   * Resolved entity references — civic-literacy MVP Phase 3.H. Populated
+   * by the sift-api Phase 3.G entity_linker pipeline node from the
+   * curated profile tables. Empty array when the article hasn't been
+   * processed yet, when no entities were matched, or when the prod DB
+   * predates the entity_links column (graceful: EntityLinksList renders
+   * nothing). Distinct from `outlet` above — that's the article's own
+   * source; `entityLinks` are mentions inside the article text.
+   */
+  entityLinks?: EntityLink[];
 }
 
 // ─── Outlet Provenance ─────────────────────────────────
@@ -162,6 +172,30 @@ export interface OrgProfile {
   faraCountries: string[];
   externalLinks: OrgExternalLinks;
   notes: string | null;
+}
+
+// ─── Entity Links (Phase 3.H) ──────────────────────────
+
+/**
+ * The four entity types Sift can resolve from article text. Mirrors the
+ * `type` field in `articles.entity_links` JSONB rows produced by the
+ * sift-api Phase 3.G entity_linker pipeline node.
+ */
+export type EntityLinkType = "outlet" | "politician" | "org" | "bill";
+
+/**
+ * One resolved entity reference attached to an article. Each link points
+ * at exactly one curated row in `outlet_profiles` / `politician_profiles` /
+ * `org_profiles` / `bill_profiles`.
+ *
+ * `surfaceForm` preserves the original casing from the article text so
+ * the InlineGlossaryTooltip can render the matched span verbatim
+ * ("CHUCK SCHUMER said today" → tooltip shows "CHUCK SCHUMER").
+ */
+export interface EntityLink {
+  type: EntityLinkType;
+  canonicalId: string;
+  surfaceForm: string;
 }
 
 // ─── Politician Provenance (Phase 3.C) ─────────────────


### PR DESCRIPTION
## Summary
The user-visible payoff of Phase 3. Resolved entity references appear at the foot of every article card as a row of clickable pills. Each pill links to the entity's dossier (`/politician/[bioguide]`, `/org/[slug]`, `/bill/[id]`, `/outlet/[slug]`), closing the civic-literacy feature loop:

> article → entity mention → one click to ownership / funding / voting record / FARA disclosure

## What ships
| Layer | File | Change |
|---|---|---|
| Types | `lib/types.ts` | `EntityLinkType`, `EntityLink`, optional `Article.entityLinks` |
| Helpers | `lib/entityLinks.ts` (new) | `parseEntityLinks` (defensive JSONB validator), `entityHref`, `entityTypeLabel` |
| DB | `lib/db.ts` | `getArticleEntityLinks(ids)` — batch lookup with **defensive try/catch on missing column** |
| API | `app/api/news`, `bookmarks`, `news/topic` | All three routes batch-fetch + attach `entityLinks` |
| Component | `components/glossary/EntityLinksList.tsx` (new) | Pill-row with type-glyph prefixes, ARIA-labeled, escapes the card-link overlay |
| Integration | `components/ArticleCard.tsx` | EntityLinksList rendered between BackgroundPrimer and meta line |
| Copy | `lib/copy.ts` | `COPY.glossary` block (eyebrow + type glyphs) |
| Tests | `__tests__/entityLinks.test.ts` (new); `api.test.ts` mock updated | +19 tests |

## Visual register
Eyebrow `MENTIONED IN THIS STORY` (mono kicker) + a flex-wrap row of pills:

| Glyph | Type | Example pill | Click target |
|---|---|---|---|
| `◉` | politician | `◉ Chuck Schumer` | `/politician/S000148` |
| `◆` | org | `◆ Brookings Institution` | `/org/brookings-institution` |
| `▸` | bill | `▸ Inflation Reduction Act` | `/bill/hr-5376-117` |
| `▣` | outlet | `▣ Reuters` | `/outlet/reuters` |

Hover state: border + text shift to `var(--accent)`. Each pill's `aria-label` includes the entity type + surface form for screen readers.

## Defensive layers
Three tolerances stacked:

1. **Pre-Phase-3.G prod (column doesn't exist)** → `getArticleEntityLinks` catches `column entity_links does not exist` and returns empty Map. Articles ship without `entityLinks`. EntityLinksList renders nothing. Feed unchanged.
2. **Phase-3.G shipped, nothing resolved on a given article** → Article ships with `entityLinks` absent. Same outcome.
3. **Phase-3.G shipped, malformed JSONB shapes** → `parseEntityLinks` silently drops invalid entries; valid ones render.

So this PR is **safe to merge before sift-api #29**. The user-visible moment activates the next time the ingest pipeline runs after #29 deploys.

## Tests
- 11 suites / 235 tests pass; `tsc --noEmit` clean
- `parseEntityLinks` covered: happy path + whitespace trim, empty/invalid (null/undefined/number/string/non-array object/bool), entry-level filtering (missing fields, unknown types, empty-after-trim ids, non-string fields), mixed-validity arrays preserve valid entries
- `entityHref`: every type → correct dossier route
- `entityTypeLabel`: every label

## Phase 3 status — feature loop wired
- ✅ **3.A** schema + seed tooling
- ✅ **3.B** GovTrack scrape (536 members)
- ✅ **3.C** politician dossier
- ✅ **3.D** org dossier
- ✅ **3.E** bill dossier ([#82](https://github.com/kristenmartino/sift/pull/82), awaiting merge)
- ✅ **3.G** entity-linking pipeline ([sift-api #29](https://github.com/kristenmartino/sift-api/pull/29), awaiting merge)
- 🆕 **3.H** InlineGlossaryTooltip + ArticleCard integration (this PR)
- 🚧 **3.F** OpenSecrets daily refresh + Vote Smart enrichment (queued, not blocking)

Once `#29` and this PR both merge + Railway redeploys + the next ingest cycle runs, articles resolve to dossiers end-to-end. That's the civic-literacy MVP fully visible.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 235 passing
- [ ] Visual: dev preview, after Phase 3.G deploys + a fresh ingest cycle runs, an article that mentions a curated entity (Schumer / Brookings / IRA / Reuters) renders the pill row at the foot of the card
- [ ] Click-through: each pill type navigates to the correct dossier route
- [ ] Pre-3.G environment: ArticleCard renders identically to today (no glossary section)
- [ ] Light + dark mode parity; mobile narrow-viewport reflow (pills wrap)
- [ ] Hover state: border + text shift to accent without lifting the card
- [ ] Pills don't trigger the card's underlying source-link click (z-[2] + stopPropagation works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)