### PR TITLE
chore(dossier): clarify donor industries label as 2022 PAC cycle

### DIFF
--- a/app/politician/[bioguide]/page.tsx
+++ b/app/politician/[bioguide]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({
   if (!politician) return { title: "Politician not found" };
   return {
     title: `${politician.name} — Politician dossier`,
-    description: `Committees, donor industries, and voting context for ${politician.name} on Sift.`,
+    description: `Committees, top industries by PAC contributions, and voting context for ${politician.name} on Sift.`,
   };
 }
 

--- a/components/politician/PoliticianDossier.tsx
+++ b/components/politician/PoliticianDossier.tsx
@@ -125,7 +125,7 @@ export default function PoliticianDossier({
           </section>
         )}
 
-        {/* Top donor industries (current cycle) */}
+        {/* Top industries by PAC contributions (2022 cycle, from OpenSecrets bulk) */}
         {!industriesEmpty && (
           <section className="mb-10">
             <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3">

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -195,7 +195,7 @@ export const COPY = {
     eyebrow: "Politician dossier",
     sections: {
       committees: "Committee assignments",
-      topIndustries: "Top donor industries this cycle",
+      topIndustries: "Top industries by PAC contributions (2022 cycle)",
       interestGroupRatings: "Interest-group ratings",
       links: "Where to read more",
       notes: "Notes",


### PR DESCRIPTION
## Summary
- OpenSecrets discontinued their public API 2025-04-15; donor enrichment now flows through `scripts/import_opensecrets_bulk.py` in sift-api (merged in #35), which loads the 2022 PAC bulk file — the most recent closed cycle in OpenSecrets bulk data.
- The cycle is fixed at 2022 until the next bulk drop, so the existing UI label "Top donor industries this cycle" was misleading. Replace with explicit framing.
- Three one-line touches: section label, page metadata description, code comment.

## Diff
- `lib/copy.ts`: \`topIndustries\` → \`"Top industries by PAC contributions (2022 cycle)"\`
- \`app/politician/[bioguide]/page.tsx\`: page metadata description matches
- \`components/politician/PoliticianDossier.tsx\`: code comment aligns + cites OpenSecrets bulk

## Test plan
- [x] Local \`npx tsc --noEmit\` clean
- [ ] CI \`Lint & Test\` green
- [ ] Spot-check \`/politician/<bioguide>\` in dev — section label reads "Top industries by PAC contributions (2022 cycle)"

## Related
- sift-api #35 (bulk importer that landed this data path)
- sift-api #32 (scheduler refactor that removed the dead daily donor loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)