### PR TITLE
fix(dossier): correct fmtUsd K-branch — was returning '$0K' for $10K-$999K

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -3,6 +3,7 @@ import {
   timeAgo,
   extractSourceDomain,
   stableHash,
+  formatUsdCompact,
 } from "@/lib/utils";
 
 // ─── estimateReadTime ───────────────────────────────────
@@ -116,5 +117,50 @@ describe("stableHash", () => {
 
   it("handles empty string", () => {
     expect(stableHash("")).toBe("0");
+  });
+});
+
+// ─── formatUsdCompact ────────────────────────────────────
+
+describe("formatUsdCompact", () => {
+  it("returns empty string for null/undefined", () => {
+    expect(formatUsdCompact(null)).toBe("");
+    expect(formatUsdCompact(undefined)).toBe("");
+  });
+
+  it("returns empty string for non-finite or negative", () => {
+    expect(formatUsdCompact(NaN)).toBe("");
+    expect(formatUsdCompact(Infinity)).toBe("");
+    expect(formatUsdCompact(-100)).toBe("");
+  });
+
+  it("formats sub-$10K with locale commas", () => {
+    expect(formatUsdCompact(0)).toBe("$0");
+    expect(formatUsdCompact(500)).toBe("$500");
+    expect(formatUsdCompact(7_470)).toBe("$7,470");
+    expect(formatUsdCompact(9_999)).toBe("$9,999");
+  });
+
+  // Regression: previously returned "$0K" for any amount in $10K-$999K
+  // because the K-branch divided by 1_000_000 instead of 1_000.
+  it("formats $10K through <$1M as rounded thousands", () => {
+    expect(formatUsdCompact(10_000)).toBe("$10K");
+    expect(formatUsdCompact(82_837)).toBe("$83K");
+    expect(formatUsdCompact(108_000)).toBe("$108K");
+    expect(formatUsdCompact(193_900)).toBe("$194K");
+    expect(formatUsdCompact(573_700)).toBe("$574K");
+    expect(formatUsdCompact(950_000)).toBe("$950K");
+    expect(formatUsdCompact(999_000)).toBe("$999K");
+  });
+
+  it("promotes $999.5K+ to $1M to avoid '$1000K'", () => {
+    expect(formatUsdCompact(999_500)).toBe("$1M");
+    expect(formatUsdCompact(999_999)).toBe("$1M");
+  });
+
+  it("formats $1M and up as rounded millions", () => {
+    expect(formatUsdCompact(1_000_000)).toBe("$1M");
+    expect(formatUsdCompact(1_500_000)).toBe("$1.5M");
+    expect(formatUsdCompact(2_300_000)).toBe("$2.3M");
   });
 });

--- a/components/politician/PoliticianDossier.tsx
+++ b/components/politician/PoliticianDossier.tsx
@@ -4,6 +4,7 @@ import LandingMasthead from "@/components/landing/LandingMasthead";
 import { COPY } from "@/lib/copy";
 import { formatPoliticianLede } from "@/lib/politician";
 import type { PoliticianProfile } from "@/lib/types";
+import { formatUsdCompact } from "@/lib/utils";
 
 interface PoliticianDossierProps {
   politician: PoliticianProfile;
@@ -33,18 +34,6 @@ export default function PoliticianDossier({
     politician.party,
     politician.state,
   );
-
-  // Money formatter for donor industries — compact 1.2M-style for tight
-  // column widths, falls back to plain locale string under $10k.
-  const fmtUsd = (amount: number | null): string => {
-    if (amount == null) return "";
-    if (amount >= 10_000) {
-      return `$${(amount / 1_000_000).toFixed(amount >= 1_000_000 ? 1 : 0)}${
-        amount >= 1_000_000 ? "M" : "K"
-      }`.replace("0M", "0M").replace(".0M", "M");
-    }
-    return `$${amount.toLocaleString("en-US")}`;
-  };
 
   // Stable display order for external links. Govt records first
   // (GovTrack, OpenSecrets, Vote Smart), then encyclopedia refs.
@@ -142,7 +131,7 @@ export default function PoliticianDossier({
                   </span>
                   {entry.amount_usd != null && (
                     <span className="font-mono text-[13px] tabular-nums text-[var(--text-muted)]">
-                      {fmtUsd(entry.amount_usd)}
+                      {formatUsdCompact(entry.amount_usd)}
                     </span>
                   )}
                 </li>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -46,3 +46,25 @@ export function stableHash(str: string): string {
   }
   return Math.abs(hash).toString(36);
 }
+
+/**
+ * Format a USD amount compactly for narrow columns: "$574K", "$1.5M".
+ *
+ * - Below $10,000: full locale string with commas, e.g. "$7,470"
+ * - $10K to <$1M: rounded to the nearest thousand, e.g. "$574K"
+ * - $1M and up: rounded to one decimal of millions, e.g. "$1.5M" or "$1M"
+ *
+ * Returns "" for null/undefined, non-finite, or negative input — the
+ * dossier hides the column entirely in those cases anyway.
+ */
+export function formatUsdCompact(amount: number | null | undefined): string {
+  if (amount == null || !Number.isFinite(amount) || amount < 0) return "";
+  if (amount < 10_000) return `$${amount.toLocaleString("en-US")}`;
+  if (amount < 1_000_000) {
+    const k = Math.round(amount / 1_000);
+    // Guard the rounding bump: e.g. $999,750 → 1000K — promote to "$1M"
+    if (k >= 1000) return "$1M";
+    return `$${k}K`;
+  }
+  return `$${(amount / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+}


### PR DESCRIPTION
## Summary
**Live bug** caught during the post-#36 launch-quality audit. Every politician with a top industry between \$10K and \$999K is currently showing \"\$0K\" or wrong amounts in prod.

The inline \`fmtUsd\` helper divided by \`1_000_000\` in *both* the K and M branches, so:
- Schumer's \$573,700 rendered as \"\$1K\" (was \`(573700/1000000).toFixed(0)\` = \"1\")
- Schumer's \$193,900 → \"\$0K\"
- Schumer's \$120,825 → \"\$0K\"
- Kevin Kiley's entire top-5 (\$29K-\$108K each) → all \"\$0K\"
- Sanders' \$7,470 was the only one rendering correctly (sub-\$10K branch)

## Fix
- Extract to \`lib/utils.ts:formatUsdCompact\` — testable, reusable for org/bill dossiers later.
- K-branch divides by **1_000** (not 1_000_000), rounded to nearest integer.
- Rounding bump-guard: \$999,500–\$999,999 promotes to \"\$1M\" instead of \"\$1000K\".
- M-branch strips trailing \".0\" so \$1,000,000 → \"\$1M\" not \"\$1.0M\".
- Null / non-finite / negative input → \"\" (the dossier hides the column).

## Verification
\`\`\`
\$573,700 → \"\$574K\"   (Schumer #1)
\$193,900 → \"\$194K\"   (Schumer #2)
\$ 82,837 → \"\$83K\"    (Schumer #5)
\$108,000 → \"\$108K\"   (Kiley #1)
\$  7,470 → \"\$7,470\"  (Sanders sole entry — sub-\$10K branch)
\$1,500,000 → \"\$1.5M\"
\$1,000,000 → \"\$1M\"
\$999,750  → \"\$1M\"    (rounding bump-guard)
\`\`\`

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx jest __tests__/utils.test.ts\` — 28 pass (8 new cases for formatUsdCompact)
- [x] CI \`Type Check & Test\` green
- [ ] Visual verify on prod: \`/politician/S000148\` shows \"\$574K\" for Attorneys & law firms

🤖 Generated with [Claude Code](https://claude.com/claude-code)