### PR TITLE
fix(dossier): replace stale 'next refresh' empty-state copy

### DIFF
--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -208,10 +208,15 @@ export const COPY = {
       ballotpedia: "Ballotpedia",
       wikipedia: "Wikipedia",
     } as Record<string, string>,
-    // Footer note shown when donor and rating data are both absent \u2014 the
-    // common case before sift-api Phase 3.E enrichment runs in prod.
+    // Footer note shown when donor and rating data are both absent. Common
+    // for senators not on the 2022 ballot (no PAC contributions during the
+    // cycle) and for politicians without a public OpenSecrets profile.
+    // Sift's PAC industry data comes from OpenSecrets bulk imports \u2014
+    // re-runs cycle-to-cycle, not on a daily refresh (the OpenSecrets API
+    // was discontinued April 2025). Interest-group ratings aren't yet
+    // imported.
     notYetEnriched:
-      "Donor and voting data populates from OpenSecrets and GovTrack on the next refresh. Until then, this dossier shows curated metadata only.",
+      "PAC contribution data isn't on file for the 2022 cycle \u2014 common for senators not on that year's ballot. Interest-group ratings aren't yet imported.",
     methodologyHint: "Data comes from public records. Read the methodology.",
     // Empty-state when industries/ratings are partially populated.
     industriesEmpty: "No donor-industry data yet for this cycle.",
@@ -278,7 +283,7 @@ export const COPY = {
     lobbyingFor: "For",
     lobbyingAgainst: "Against",
     lobbyingNotePending:
-      "Lobbying-spend totals come from OpenSecrets and update on the next refresh.",
+      "Lobbying-spend totals haven't been imported yet.",
     // Status pills are rendered with the same Fraunces 26 register as the
     // outlet dossier's bias/factual ratings.
     methodologyHint: "Data comes from public records. Read the methodology.",


### PR DESCRIPTION
## Summary
**Live copy bug** caught during the post-#36 launch-quality audit. Two empty-state strings promised an automatic refresh that doesn't exist anymore — sift-api PR #32 (daily scheduler) was abandoned when OpenSecrets discontinued their public API on 2025-04-15.

## What ~78 politicians currently see
Senators not on the 2022 ballot (and a few freshmen without OpenSecrets profiles) hit the politician dossier's empty-state footer:

> "Donor and voting data populates from OpenSecrets and GovTrack on **the next refresh**. Until then, this dossier shows curated metadata only."

That's misleading — no cron is scheduled. Honest framing matters for portfolio credibility.

## Diff
1. \`politicianDossier.notYetEnriched\` — explains the actual reason (off-cycle senators, no public OpenSecrets profile) without overpromising future automatic updates.
2. \`billDossier.lobbyingNotePending\` — same fix, even though this string isn't yet wired into BillDossier.tsx (defined-but-unused). Fixed pre-emptively for consistency.
3. Comment above the politician string now documents the actual source (OpenSecrets bulk, cycle-to-cycle manual cadence) for future-me.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] CI \`Type Check & Test\` green (no logic change)
- [ ] After deploy, visual verify on \`/politician/F000485\` (Clay Fuller, both empty) and \`/politician/M001244\` (Ashley Moody, no PAC data)

## Related
- sift-api #32 (abandoned scheduler — explains why \"next refresh\" became inaccurate)
- sift-api PR #37 (refresh-cadence docs in scripts/README.md)
- sift PR #85 (today's fmtUsd \$0K bug — same audit pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)