### PR TITLE
feat: civic-literacy MVP Phase 3.I — civic dossier index at /civic

### DIFF
--- a/app/civic/page.tsx
+++ b/app/civic/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+
+import CivicIndex from "@/components/civic/CivicIndex";
+import {
+  listAllBillsLite,
+  listAllOrgsLite,
+  listAllPoliticiansLite,
+} from "@/lib/db";
+import type { PoliticianChamber } from "@/lib/types";
+
+// ISR — committee/dossier metadata changes slowly (politician roster ~6mo,
+// org curation ~quarterly, bills as we add them). 10-minute cache keeps the
+// page snappy without staleness mattering at this cadence.
+export const revalidate = 600;
+
+export const metadata: Metadata = {
+  title: "Civic dossiers — Sift",
+  description:
+    "Browse Sift's curated politician, organization, and bill dossiers. 536 sitting members of Congress, the major think-tanks shaping policy, and landmark bills.",
+};
+
+interface CivicPageProps {
+  searchParams: Promise<{ chamber?: string }>;
+}
+
+export default async function CivicPage({ searchParams }: CivicPageProps) {
+  const params = await searchParams;
+  const chamberFilter: PoliticianChamber | null =
+    params.chamber === "senate" || params.chamber === "house"
+      ? params.chamber
+      : null;
+
+  const [politicians, orgs, bills] = await Promise.all([
+    listAllPoliticiansLite(),
+    listAllOrgsLite(),
+    listAllBillsLite(),
+  ]);
+
+  return (
+    <CivicIndex
+      politicians={politicians}
+      orgs={orgs}
+      bills={bills}
+      chamberFilter={chamberFilter}
+    />
+  );
+}

--- a/components/civic/CivicIndex.tsx
+++ b/components/civic/CivicIndex.tsx
@@ -1,0 +1,319 @@
+import Link from "next/link";
+
+import LandingMasthead from "@/components/landing/LandingMasthead";
+import { COPY } from "@/lib/copy";
+import {
+  groupByState,
+  groupByType,
+  filterByChamber,
+  orgLeanLabel,
+  orgTypeLabel,
+  stateName,
+} from "@/lib/civic";
+import type {
+  BillListItem,
+  OrgListItem,
+  PoliticianChamber,
+  PoliticianListItem,
+} from "@/lib/types";
+
+interface CivicIndexProps {
+  politicians: PoliticianListItem[];
+  orgs: OrgListItem[];
+  bills: BillListItem[];
+  chamberFilter: PoliticianChamber | null;
+}
+
+/**
+ * Server-rendered civic-dossier index — civic-literacy MVP Phase 3.I.
+ *
+ * Single editorial-style page that surfaces every curated dossier so users
+ * can discover them without typing slugs. Mirrors the visual register of
+ * the dossier pages themselves (eyebrows, hairline rules, mono labels,
+ * Fraunces display, max-w-800).
+ *
+ * Three sections:
+ *   1. Politicians — grouped by state, chamber-filterable via URL.
+ *   2. Organizations — grouped by type, lean shown inline.
+ *   3. Bills — flat list with congress + status.
+ *
+ * No search, no sortable tables, no pagination — the political surface is
+ * naturally finite (536 sitting members, ~10 orgs, a handful of bills),
+ * and a flat alphabetical list reads better than a search-only page.
+ */
+export default function CivicIndex({
+  politicians,
+  orgs,
+  bills,
+  chamberFilter,
+}: CivicIndexProps) {
+  const c = COPY.civicIndex;
+
+  const filteredPoliticians = filterByChamber(politicians, chamberFilter);
+  const stateGroups = groupByState(filteredPoliticians);
+  const orgTypeGroups = groupByType(orgs);
+
+  return (
+    <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
+      <LandingMasthead />
+
+      <main
+        id="main-content"
+        className="max-w-[800px] mx-auto px-6 pt-12 pb-24"
+      >
+        {/* Eyebrow + headline */}
+        <header className="mb-9">
+          <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3 flex items-center">
+            <span
+              aria-hidden
+              className="inline-block w-7 h-px bg-[var(--border)] mr-3"
+            />
+            {c.eyebrow}
+          </p>
+          <h1 className="font-heading text-[36px] md:text-[44px] font-bold leading-[1.05] tracking-tight text-[var(--text)]">
+            {c.headline}
+          </h1>
+          <p className="font-body text-[16px] text-[var(--text-secondary)] mt-3 max-w-[60ch] leading-relaxed">
+            {c.lede}
+          </p>
+        </header>
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* ─── Politicians ────────────────────────────────────── */}
+        <section className="mb-14" aria-labelledby="politicians-heading">
+          <header className="mb-6">
+            <p
+              id="politicians-heading"
+              className="font-body text-kicker uppercase text-[var(--text-muted)] mb-2"
+            >
+              {c.politiciansEyebrow(politicians.length)}
+            </p>
+            <h2 className="font-heading text-[26px] md:text-[28px] font-semibold leading-[1.15] tracking-tight text-[var(--text)]">
+              {c.politiciansHeading}
+            </h2>
+          </header>
+
+          {/* Chamber filter — a 3-link nav. Active state in --accent ink. */}
+          <nav
+            aria-label="Filter politicians by chamber"
+            className="mb-7 flex items-center gap-x-5 font-body text-outlet uppercase tracking-wider"
+          >
+            <ChamberFilterLink
+              label={c.filterAll}
+              href="/civic"
+              active={chamberFilter === null}
+            />
+            <ChamberFilterLink
+              label={c.filterSenate}
+              href="/civic?chamber=senate"
+              active={chamberFilter === "senate"}
+            />
+            <ChamberFilterLink
+              label={c.filterHouse}
+              href="/civic?chamber=house"
+              active={chamberFilter === "house"}
+            />
+            <span className="font-body text-[13px] tracking-normal text-[var(--text-muted)] ml-auto normal-case">
+              {filteredPoliticians.length === politicians.length
+                ? c.showingAll(filteredPoliticians.length)
+                : c.showingFiltered(filteredPoliticians.length, politicians.length)}
+            </span>
+          </nav>
+
+          {/* State-grouped list */}
+          {stateGroups.length === 0 ? (
+            <p className="font-body text-[14px] text-[var(--text-muted)] italic max-w-[60ch] leading-relaxed">
+              {c.emptyPoliticians}
+            </p>
+          ) : (
+            <ul className="space-y-6">
+              {stateGroups.map(([code, members]) => (
+                <li key={code}>
+                  <p className="font-mono text-[12px] uppercase tracking-[0.14em] text-[var(--text-muted)] mb-1.5">
+                    {stateName(code)}
+                  </p>
+                  <ul className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed">
+                    {members.map((p, idx) => (
+                      <li key={p.bioguideId} className="inline">
+                        <Link
+                          href={`/politician/${p.bioguideId}`}
+                          className="text-[var(--text)] no-underline hover:underline hover:text-[var(--accent)]"
+                        >
+                          {p.name}
+                        </Link>
+                        {p.party && (
+                          <span className="text-[var(--text-muted)]">
+                            {" "}
+                            ({p.party}
+                            {p.chamber === "senate"
+                              ? "-Sen."
+                              : p.chamber === "house"
+                                ? "-Rep."
+                                : ""}
+                            )
+                          </span>
+                        )}
+                        {idx < members.length - 1 && (
+                          <span className="text-[var(--text-muted)] mx-1.5">
+                            ·
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* ─── Organizations ──────────────────────────────────── */}
+        <section className="mb-14" aria-labelledby="orgs-heading">
+          <header className="mb-6">
+            <p
+              id="orgs-heading"
+              className="font-body text-kicker uppercase text-[var(--text-muted)] mb-2"
+            >
+              {c.orgsEyebrow(orgs.length)}
+            </p>
+            <h2 className="font-heading text-[26px] md:text-[28px] font-semibold leading-[1.15] tracking-tight text-[var(--text)]">
+              {c.orgsHeading}
+            </h2>
+          </header>
+
+          {orgTypeGroups.length === 0 ? (
+            <p className="font-body text-[14px] text-[var(--text-muted)] italic max-w-[60ch] leading-relaxed">
+              {c.emptyOrgs}
+            </p>
+          ) : (
+            <ul className="space-y-6">
+              {orgTypeGroups.map(([type, items]) => (
+                <li key={type}>
+                  <p className="font-mono text-[12px] uppercase tracking-[0.14em] text-[var(--text-muted)] mb-1.5">
+                    {orgTypeLabel(type === "other" ? null : type)}
+                  </p>
+                  <ul className="space-y-1.5">
+                    {items.map((o) => (
+                      <li
+                        key={o.slug}
+                        className="font-body text-[15px] text-[var(--text-secondary)]"
+                      >
+                        <Link
+                          href={`/org/${o.slug}`}
+                          className="text-[var(--text)] no-underline hover:underline hover:text-[var(--accent)]"
+                        >
+                          {o.name}
+                        </Link>
+                        {o.politicalLean && (
+                          <span className="text-[var(--text-muted)]">
+                            {" "}
+                            ({orgLeanLabel(o.politicalLean)})
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* ─── Bills ──────────────────────────────────────────── */}
+        <section className="mb-14" aria-labelledby="bills-heading">
+          <header className="mb-6">
+            <p
+              id="bills-heading"
+              className="font-body text-kicker uppercase text-[var(--text-muted)] mb-2"
+            >
+              {c.billsEyebrow(bills.length)}
+            </p>
+            <h2 className="font-heading text-[26px] md:text-[28px] font-semibold leading-[1.15] tracking-tight text-[var(--text)]">
+              {c.billsHeading}
+            </h2>
+          </header>
+
+          {bills.length === 0 ? (
+            <p className="font-body text-[14px] text-[var(--text-muted)] italic max-w-[60ch] leading-relaxed">
+              {c.emptyBills}
+            </p>
+          ) : (
+            <ul className="space-y-1.5">
+              {bills.map((b) => (
+                <li
+                  key={b.billId}
+                  className="font-body text-[15px] text-[var(--text-secondary)] leading-relaxed"
+                >
+                  <Link
+                    href={`/bill/${b.billId}`}
+                    className="text-[var(--text)] no-underline hover:underline hover:text-[var(--accent)] font-semibold"
+                  >
+                    {b.shortTitle ?? b.billId}
+                  </Link>
+                  <span className="text-[var(--text-muted)]">
+                    {" "}
+                    · {b.congress}th Congress
+                  </span>
+                  {b.status && (
+                    <span className="text-[var(--text-muted)]">
+                      {" "}
+                      · {b.status}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {bills.length > 0 && bills.length < 5 && (
+            <p className="font-body text-[14px] text-[var(--text-muted)] italic max-w-[60ch] leading-relaxed mt-6">
+              {c.billsMoreSoon}
+            </p>
+          )}
+        </section>
+
+        <hr className="border-0 border-t border-[var(--border)] my-10" />
+
+        {/* Footer: back to home + methodology hint */}
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <Link
+            href="/"
+            className="font-body text-outlet uppercase tracking-wider text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline inline-flex items-center gap-1.5"
+          >
+            ← {c.backLink}
+          </Link>
+          <p className="font-body text-[12px] text-[var(--text-muted)] italic">
+            {c.methodologyHint}
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+interface ChamberFilterLinkProps {
+  label: string;
+  href: string;
+  active: boolean;
+}
+
+function ChamberFilterLink({ label, href, active }: ChamberFilterLinkProps) {
+  return (
+    <Link
+      href={href}
+      className={
+        active
+          ? "text-[var(--accent)] no-underline border-b border-[var(--accent)] pb-0.5"
+          : "text-[var(--text-muted)] no-underline hover:text-[var(--text)]"
+      }
+      aria-current={active ? "page" : undefined}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/components/landing/LandingMasthead.tsx
+++ b/components/landing/LandingMasthead.tsx
@@ -53,6 +53,13 @@ export default function LandingMasthead() {
                 {darkMode ? "Newsprint" : "Late Edition"}
               </button>
             )}
+            <span className="text-[var(--text-muted)] hidden sm:inline">·</span>
+            <Link
+              href="/civic"
+              className="font-body text-outlet uppercase tracking-wider text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline hidden sm:inline"
+            >
+              Civic ↗
+            </Link>
             <span className="text-[var(--text-muted)]">·</span>
             <Link
               href="/news"

--- a/lib/civic.ts
+++ b/lib/civic.ts
@@ -1,0 +1,122 @@
+// ─── Civic dossier index helpers ─────────────────────────
+// Pure presentation helpers for the `/civic` route. State-name lookup +
+// grouping. No DB reads here — the page passes pre-loaded lists in.
+
+import type {
+  OrgListItem,
+  OrgPoliticalLean,
+  OrgType,
+  PoliticianChamber,
+  PoliticianListItem,
+} from "./types";
+
+/**
+ * USPS code → full state name. Includes DC and the five inhabited
+ * territories so non-state-state members (delegates, resident commissioner)
+ * still get a header. If a code falls through (it shouldn't), we render
+ * the raw code as the heading.
+ */
+export const STATE_NAMES: Record<string, string> = {
+  AL: "Alabama", AK: "Alaska", AZ: "Arizona", AR: "Arkansas",
+  CA: "California", CO: "Colorado", CT: "Connecticut", DE: "Delaware",
+  FL: "Florida", GA: "Georgia", HI: "Hawaii", ID: "Idaho",
+  IL: "Illinois", IN: "Indiana", IA: "Iowa", KS: "Kansas",
+  KY: "Kentucky", LA: "Louisiana", ME: "Maine", MD: "Maryland",
+  MA: "Massachusetts", MI: "Michigan", MN: "Minnesota", MS: "Mississippi",
+  MO: "Missouri", MT: "Montana", NE: "Nebraska", NV: "Nevada",
+  NH: "New Hampshire", NJ: "New Jersey", NM: "New Mexico", NY: "New York",
+  NC: "North Carolina", ND: "North Dakota", OH: "Ohio", OK: "Oklahoma",
+  OR: "Oregon", PA: "Pennsylvania", RI: "Rhode Island", SC: "South Carolina",
+  SD: "South Dakota", TN: "Tennessee", TX: "Texas", UT: "Utah",
+  VT: "Vermont", VA: "Virginia", WA: "Washington", WV: "West Virginia",
+  WI: "Wisconsin", WY: "Wyoming",
+  DC: "District of Columbia",
+  AS: "American Samoa", GU: "Guam", MP: "Northern Mariana Islands",
+  PR: "Puerto Rico", VI: "U.S. Virgin Islands",
+};
+
+export function stateName(code: string | null | undefined): string {
+  if (!code) return "Unknown";
+  return STATE_NAMES[code.toUpperCase()] ?? code;
+}
+
+/** Filter politicians by chamber. `null` returns everyone. */
+export function filterByChamber(
+  politicians: PoliticianListItem[],
+  chamber: PoliticianChamber | null,
+): PoliticianListItem[] {
+  if (!chamber) return politicians;
+  return politicians.filter((p) => p.chamber === chamber);
+}
+
+/**
+ * Group politicians by state, preserving incoming sort order within each
+ * group (the DB query orders by state then name, so a forward iteration
+ * captures alphabetical groups in alphabetical state order).
+ *
+ * Returns a list of `[state code, members]` tuples rather than a Map so
+ * Server Components can serialize it cleanly to the wire.
+ */
+export function groupByState(
+  politicians: PoliticianListItem[],
+): Array<[string, PoliticianListItem[]]> {
+  const groups = new Map<string, PoliticianListItem[]>();
+  for (const p of politicians) {
+    const key = p.state ?? "—";
+    const arr = groups.get(key);
+    if (arr) arr.push(p);
+    else groups.set(key, [p]);
+  }
+  return Array.from(groups.entries());
+}
+
+/** Pretty-printed type label for the org-index section heading. */
+export const ORG_TYPE_LABELS: Record<OrgType, string> = {
+  "think-tank": "Think tanks",
+  "advocacy": "Advocacy",
+  "union": "Unions",
+  "pac": "PACs",
+  "super-pac": "Super PACs",
+  "foundation": "Foundations",
+  "industry-group": "Industry groups",
+  "other": "Other",
+};
+
+export function orgTypeLabel(type: OrgType | null | undefined): string {
+  if (!type) return "Other";
+  return ORG_TYPE_LABELS[type] ?? "Other";
+}
+
+/** Pretty-printed lean label for sub-sorted listing inside type groups. */
+export const ORG_LEAN_LABELS: Record<OrgPoliticalLean, string> = {
+  "left": "Left",
+  "lean-left": "Lean left",
+  "center": "Center",
+  "lean-right": "Lean right",
+  "right": "Right",
+  "mixed": "Mixed",
+  "nonpartisan": "Nonpartisan",
+};
+
+export function orgLeanLabel(lean: OrgPoliticalLean | null | undefined): string {
+  if (!lean) return "—";
+  return ORG_LEAN_LABELS[lean] ?? "—";
+}
+
+/**
+ * Group orgs by `type`, preserving incoming sort order within each group.
+ * DB query orders by type then name, so a forward iteration captures
+ * alphabetical-by-name groups in alphabetical-by-type order.
+ */
+export function groupByType(
+  orgs: OrgListItem[],
+): Array<[OrgType | "other", OrgListItem[]]> {
+  const groups = new Map<OrgType | "other", OrgListItem[]>();
+  for (const o of orgs) {
+    const key: OrgType | "other" = o.type ?? "other";
+    const arr = groups.get(key);
+    if (arr) arr.push(o);
+    else groups.set(key, [o]);
+  }
+  return Array.from(groups.entries());
+}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -338,4 +338,28 @@ export const COPY = {
     // Footer colophon link.
     colophonLink: "Colophon",
   },
+  civicIndex: {
+    eyebrow: "Civic dossiers",
+    headline: "Civic dossiers",
+    lede: "Curated context on the people, organizations, and bills that shape U.S. policy. Every dossier is sourced from public records \u2014 GovTrack, OpenSecrets, ProPublica's Nonprofit Explorer \u2014 with citations on every page.",
+    politiciansEyebrow: (count: number) => `Politicians \u00b7 ${count}`,
+    politiciansHeading: "Sitting members of Congress",
+    orgsEyebrow: (count: number) => `Organizations \u00b7 ${count}`,
+    orgsHeading: "Think tanks, advocacy groups, and PACs",
+    billsEyebrow: (count: number) => `Bills \u00b7 ${count}`,
+    billsHeading: "Landmark legislation",
+    filterAll: "All",
+    filterSenate: "Senate",
+    filterHouse: "House",
+    showingAll: (n: number) => `${n.toLocaleString("en-US")} total`,
+    showingFiltered: (shown: number, total: number) =>
+      `${shown.toLocaleString("en-US")} of ${total.toLocaleString("en-US")}`,
+    emptyPoliticians:
+      "No politicians match this filter. Try Senate, House, or All.",
+    emptyOrgs: "No organizations curated yet.",
+    emptyBills: "No bills curated yet.",
+    billsMoreSoon: "More bills as they're curated.",
+    backLink: "Back to Sift",
+    methodologyHint: "Data comes from public records. Read the methodology.",
+  },
 } as const;

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -7,7 +7,15 @@ import {
   parseDbPoliticianProfile,
   type DbPoliticianProfileRow,
 } from "./politician";
-import type { BillProfile, OrgProfile, OutletProfile, PoliticianProfile } from "./types";
+import type {
+  BillListItem,
+  BillProfile,
+  OrgListItem,
+  OrgProfile,
+  OutletProfile,
+  PoliticianListItem,
+  PoliticianProfile,
+} from "./types";
 
 if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL environment variable is not set");
@@ -670,6 +678,104 @@ export async function getBillById(billId: string): Promise<BillProfile | null> {
   } catch (err) {
     const msg = String(err);
     if (msg.includes("does not exist")) return null;
+    throw err;
+  }
+}
+
+// ─── Civic dossier index (`/civic`) ────────────────────
+
+/**
+ * Lite list of every curated politician for the civic index page. Pulls
+ * only the five fields the index actually renders (no committees / industries
+ * / etc.) so 536 rows fit in a small payload.
+ *
+ * Sorted by state then name so the index can group by state without a
+ * second sort pass on the client.
+ *
+ * Tolerates missing tables (returns []).
+ */
+export async function listAllPoliticiansLite(): Promise<PoliticianListItem[]> {
+  try {
+    const result = await pool.query<{
+      bioguide_id: string;
+      name: string;
+      party: string | null;
+      state: string | null;
+      chamber: string | null;
+    }>(
+      `SELECT bioguide_id, name, party, state, chamber
+       FROM politician_profiles
+       ORDER BY state ASC NULLS LAST, name ASC`,
+    );
+    return result.rows.map((r) => ({
+      bioguideId: r.bioguide_id,
+      name: r.name,
+      party: r.party?.trim() || null,
+      state: r.state?.trim() || null,
+      chamber: (r.chamber as PoliticianListItem["chamber"]) ?? null,
+    }));
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("does not exist")) return [];
+    throw err;
+  }
+}
+
+/**
+ * Lite list of every curated org for the civic index page. Sorted by type
+ * then name so the index can group by type without re-sorting client-side.
+ */
+export async function listAllOrgsLite(): Promise<OrgListItem[]> {
+  try {
+    const result = await pool.query<{
+      slug: string;
+      name: string;
+      type: string | null;
+      political_lean: string | null;
+    }>(
+      `SELECT slug, name, type, political_lean
+       FROM org_profiles
+       ORDER BY type ASC NULLS LAST, name ASC`,
+    );
+    return result.rows.map((r) => ({
+      slug: r.slug,
+      name: r.name,
+      type: (r.type as OrgListItem["type"]) ?? null,
+      politicalLean: (r.political_lean as OrgListItem["politicalLean"]) ?? null,
+    }));
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("does not exist")) return [];
+    throw err;
+  }
+}
+
+/**
+ * Lite list of every curated bill for the civic index page. Currently only
+ * one bill (HR 5376-117 / IRA) — sorted newest-introduced-first to age well
+ * as more land.
+ */
+export async function listAllBillsLite(): Promise<BillListItem[]> {
+  try {
+    const result = await pool.query<{
+      bill_id: string;
+      congress: number;
+      short_title: string | null;
+      status: string | null;
+    }>(
+      `SELECT bill_id, congress, short_title, status
+       FROM bill_profiles
+       ORDER BY introduced_date DESC NULLS LAST, bill_id ASC`,
+    );
+    return result.rows.map((r) => ({
+      billId: r.bill_id,
+      congress: r.congress,
+      shortTitle: r.short_title?.trim() || null,
+      status: (r.status as BillListItem["status"]) ?? null,
+    }));
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("does not exist")) return [];
     throw err;
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -307,6 +307,40 @@ export interface PoliticianProfile {
 }
 
 /**
+ * Lite shape used by the civic index page (`/civic`). Just enough to render
+ * the grouped-by-state list — full PoliticianProfile isn't worth pulling for
+ * 536 rows when only five fields render. The query is `lib/db.ts`'s
+ * `listAllPoliticiansLite`.
+ */
+export interface PoliticianListItem {
+  bioguideId: string;
+  name: string;
+  party: string | null;
+  state: string | null;
+  chamber: PoliticianChamber | null;
+}
+
+/**
+ * Lite shape for orgs on the civic index. Subset of OrgProfile.
+ */
+export interface OrgListItem {
+  slug: string;
+  name: string;
+  type: OrgType | null;
+  politicalLean: OrgPoliticalLean | null;
+}
+
+/**
+ * Lite shape for bills on the civic index. Subset of BillProfile.
+ */
+export interface BillListItem {
+  billId: string;
+  congress: number;
+  shortTitle: string | null;
+  status: BillStatus | null;
+}
+
+/**
  * Curated outlet metadata, mirrored from `outlet_profiles` in Postgres.
  * Hand-maintained quarterly. The dossier page (Phase 2.C) renders the full
  * shape; OutletBadge in feed cards renders only `name` + `allSidesRating`.


### PR DESCRIPTION
## Summary
Adds a single editorial-style index at \`/civic\` so users can **discover** the politician/org/bill dossiers without typing slugs. Currently the only discovery path is the \`InlineGlossaryTooltip\` from #83 — fires only when an article happens to mention a curated entity. Direct discovery was missing.

## Page structure
Three sections in one server-rendered page:

1. **Politicians (536)** — grouped by state, alphabetical within each group. Chamber filter via URL: \`/civic\` · \`/civic?chamber=senate\` · \`/civic?chamber=house\`. Active filter shown as accent-colored underline.
2. **Organizations (10)** — grouped by type (\"Think tanks\", \"Advocacy\"). Each entry shows political lean inline: \"Brookings (Center)\".
3. **Bills (1, IRA)** — flat list with congress + status. Hint below: \"More bills as they're curated.\"

No search, no sortable tables, no pagination — the political surface is naturally finite (536 sitting members), and a flat alphabetical list reads better than a search-only page. State groupings give scannable structure.

## Nav entry
Added \"Civic ↗\" to the masthead dateline strip between the dark-mode toggle and \"Open Sift →\". Hidden below \`sm:\` to avoid crowding mobile.

## Files
**New:**
- \`app/civic/page.tsx\` — server component, parallel-fetches three lite lists, ISR 600s.
- \`components/civic/CivicIndex.tsx\` — editorial-register render (Fraunces, hairline rules, mono labels, max-w-800).
- \`lib/civic.ts\` — pure helpers (STATE_NAMES map, label lookups, group + filter functions).

**Modified:**
- \`lib/db.ts\` — three new lite list queries that pull only render-needed fields. Tolerate missing tables with \`[]\`.
- \`lib/types.ts\` — three Lite item types alongside the existing full profiles.
- \`lib/copy.ts\` — \`civicIndex\` section with all strings (eyebrows, headings, filter labels, empty states, count formatters).
- \`components/landing/LandingMasthead.tsx\` — \"Civic ↗\" link.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx jest\` — 270 pass (no test changes needed; new code is render-only)
- [ ] CI \`Type Check & Test\` green
- [ ] Vercel preview: hit \`/civic\`, verify all 3 sections render with real prod data
- [ ] Verify chamber filter: \`/civic?chamber=senate\` shows ~100 politicians, \`/civic?chamber=house\` shows ~436
- [ ] Verify a state group: scroll to NEW YORK, click Schumer, lands on his dossier
- [ ] Verify masthead: \"Civic ↗\" appears next to \"Open Sift →\" on desktop

## Related
- sift #83 (InlineGlossaryTooltip — the existing discovery path)
- sift-api #36 (the data load this index now exposes)
- sift #80, #81, #82 (the dossier routes this links to)

🤖 Generated with [Claude Code](https://claude.com/claude-code)