### PR TITLE
chore: global error boundary + Vercel Analytics page-view tracking

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+
+import { COPY } from "@/lib/copy";
+
+/**
+ * Global error boundary — catches uncaught throws below the root layout.
+ *
+ * Next.js App Router requires this be a Client Component because the runtime
+ * passes the caught error into a React state hook (`reset`). We use it as a
+ * graceful fallback for the dossier routes (politicians/orgs/bills/civic):
+ * if a downstream component or DB read panics, the user sees this card
+ * instead of Next.js's stock dev/prod error UI.
+ *
+ * Visual register matches `app/not-found.tsx` for consistency. Speed Insights
+ * + Vercel Analytics in `layout.tsx` will still log the navigation; no
+ * additional client-side event reporting here (Vercel reports unhandled
+ * errors automatically in the runtime telemetry).
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Surface to the browser console for dev visibility. In prod this is a
+    // best-effort log — Vercel's runtime telemetry already captured it
+    // server-side with full stack + digest.
+    console.error("sift error boundary:", error);
+  }, [error]);
+
+  return (
+    <main
+      id="main-content"
+      className="min-h-screen flex items-center justify-center px-5"
+      style={{ background: "var(--bg)", color: "var(--text)" }}
+    >
+      <div className="text-center max-w-[400px]">
+        <div
+          className="text-[80px] leading-none mb-6 text-[var(--accent)]"
+          style={{ opacity: 0.15 }}
+          aria-hidden
+        >
+          &#x25C6;
+        </div>
+        <p className="font-heading text-xl font-bold text-[var(--text-secondary)] mb-2">
+          {COPY.errorBoundary.title}
+        </p>
+        <p className="text-sm text-[var(--text-muted)] leading-relaxed mb-6">
+          {COPY.errorBoundary.body}
+        </p>
+        {error.digest && (
+          <p className="font-mono text-[11px] text-[var(--text-muted)] mb-6">
+            id: {error.digest}
+          </p>
+        )}
+        <div className="flex items-center justify-center gap-3 flex-wrap">
+          <button
+            onClick={reset}
+            className="inline-block bg-[var(--accent)] text-white px-7 py-2.5 rounded-full text-sm font-semibold font-body hover:opacity-90 transition-opacity"
+          >
+            {COPY.errorBoundary.retry}
+          </button>
+          <Link
+            href="/"
+            className="inline-block px-7 py-2.5 rounded-full text-sm font-semibold font-body border border-[var(--border)] text-[var(--text-secondary)] hover:text-[var(--accent)] hover:border-[var(--accent)] transition-colors no-underline"
+          >
+            {COPY.errorBoundary.home}
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Playfair_Display, Source_Sans_3 } from "next/font/google";
 import "./globals.css";
@@ -82,6 +83,10 @@ export default function RootLayout({
         </a>
         {children}
         <SpeedInsights />
+        {/* Vercel Analytics: privacy-friendly page-view counts (no cookies,
+            no cross-site tracking, GDPR/CCPA-clean by default). Free hobby
+            tier covers ~25k events/mo. */}
+        <Analytics />
       </body>
     </html>
   );

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -89,6 +89,15 @@ export const COPY = {
     body: "We looked everywhere \u2014 even had the AI search for it. Let\u2019s get you back to the stories.",
     button: "Back to Sift",
   },
+  // Global error boundary (`app/error.tsx`). Triggers on any uncaught throw
+  // in a server or client component below the root layout. The not-found
+  // copy is intentionally playful; the error copy is intentionally plain.
+  errorBoundary: {
+    title: "Something broke on our end",
+    body: "Try reloading. If it keeps happening, the stories on the home page should still load.",
+    retry: "Try again",
+    home: "Back to Sift",
+  },
   topics: {
     modalTitle: "What do you want to track?",
     modalPlaceholder: "e.g. Florida utilities, AI in healthcare, Series A funding",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.80.0",
         "@clerk/nextjs": "^7.0.7",
+        "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "next": "^15.1.0",
         "pg": "^8.20.0",
@@ -3113,6 +3114,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vercel/speed-insights": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
     "@clerk/nextjs": "^7.0.7",
+    "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "next": "^15.1.0",
     "pg": "^8.20.0",


### PR DESCRIPTION
## Summary
Operational-hygiene pass after the Phase 3.F + civic-index ship. Two complementary additions:

### 1. `app/error.tsx` (NEW) — global error boundary
Previously, an uncaught throw in any server/client component fell through to Next's stock dev/prod error UI — jarring on a polished editorial site. Same visual register as \`app/not-found.tsx\` (centered card, ◆ accent glyph, rounded buttons). Two actions:
- **Try again** → calls \`reset()\` to retry the failed segment
- **Back to Sift** → \`href=\"/\"\`

Error digest (Next.js's hash for matching server logs) surfaces in mono when present, so users + future-me can correlate user reports with Vercel runtime telemetry.

### 2. \`<Analytics />\` in \`app/layout.tsx\` — page-view tracking
Adds \`@vercel/analytics\` alongside the existing \`<SpeedInsights />\`. Privacy-friendly: no cookies, no cross-site tracking, GDPR/CCPA-clean. Free hobby tier covers ~25k events/mo — well above MVP traffic. Unblocks the \"is anyone hitting \`/civic\`, \`/politician/*\`, \`/org/*\`, \`/bill/*\`?\" question.

### 3. New copy strings (\`lib/copy.ts\`)
\`errorBoundary\` block (title/body/retry/home) in the same voice as \`notFound\`. Plain rather than playful — a broken page deserves directness.

## Verification
- \`npx tsc --noEmit\` clean
- \`npx jest\` — 270 tests pass
- Manual prod 404 spot-check: \`/politician/INVALID\`, \`/org/nonexistent-org\`, \`/bill/fake-bill-id\` all 404 cleanly via existing \`not-found.tsx\` (no regression)
- Manual: \`/civic?chamber=xyz\` falls through to \"all\" gracefully

## Out of scope (follow-up task)
Found 4 dead RSS feeds in Railway logs during scan:
- AP News (\`apnews.com/world-news.rss\` → 404)
- Sports Illustrated (404)
- Reuters via openrss.org (empty)
- Washington Post \`feeds.washingtonpost.com/rss/national\` (empty)

Upstream data-source rot, not new from this audit. Pipeline correctly logs warnings + skips. Worth a sift-api task to swap or drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)