### PR TITLE
feat: civic-context tooltips on EntityLinksList chips (Phase 3.G.3)

### DIFF
--- a/__tests__/civicContext.test.ts
+++ b/__tests__/civicContext.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the JSONB parser shared by `lib/civicContext` and the
+ * politician dossier route (Phase 3.G.3 enrichment).
+ *
+ * The bulk of `enrichLinksWithContext` is a DB batch query; the only
+ * non-trivial pure logic is the JSONB parser (`asTopIndustries`), which
+ * has to tolerate malformed rows without crashing the feed. Cover that
+ * here. The DB code path is covered by tsc + live verification.
+ */
+import { asTopIndustries as parseTopIndustries } from "@/lib/politician";
+
+describe("asTopIndustries (civic-context parser)", () => {
+  it("returns empty array for null/undefined", () => {
+    expect(parseTopIndustries(null)).toEqual([]);
+    expect(parseTopIndustries(undefined)).toEqual([]);
+  });
+
+  it("returns empty array when not an array", () => {
+    expect(parseTopIndustries("not-an-array")).toEqual([]);
+    expect(parseTopIndustries({ industry: "x" })).toEqual([]);
+    expect(parseTopIndustries(42)).toEqual([]);
+  });
+
+  it("parses a valid array of {industry, amount_usd}", () => {
+    const out = parseTopIndustries([
+      { industry: "Attorneys & law firms", amount_usd: 573700 },
+      { industry: "Democratic leadership PAC", amount_usd: 193900 },
+    ]);
+    expect(out).toEqual([
+      { industry: "Attorneys & law firms", amount_usd: 573700 },
+      { industry: "Democratic leadership PAC", amount_usd: 193900 },
+    ]);
+  });
+
+  it("preserves null amount_usd", () => {
+    const out = parseTopIndustries([
+      { industry: "Some industry", amount_usd: null },
+    ]);
+    expect(out).toEqual([
+      { industry: "Some industry", amount_usd: null },
+    ]);
+  });
+
+  it("treats missing amount_usd as null", () => {
+    const out = parseTopIndustries([{ industry: "Some industry" }]);
+    expect(out).toEqual([{ industry: "Some industry", amount_usd: null }]);
+  });
+
+  it("treats non-numeric amount_usd as null", () => {
+    const out = parseTopIndustries([
+      { industry: "Some industry", amount_usd: "lots" },
+    ]);
+    expect(out[0].amount_usd).toBeNull();
+  });
+
+  it("treats NaN/Infinity amount_usd as null", () => {
+    const out = parseTopIndustries([
+      { industry: "A", amount_usd: NaN },
+      { industry: "B", amount_usd: Infinity },
+    ]);
+    expect(out[0].amount_usd).toBeNull();
+    expect(out[1].amount_usd).toBeNull();
+  });
+
+  it("drops entries with non-string industry", () => {
+    const out = parseTopIndustries([
+      { industry: 42, amount_usd: 1000 },
+      { industry: "Valid", amount_usd: 2000 },
+    ]);
+    expect(out).toEqual([{ industry: "Valid", amount_usd: 2000 }]);
+  });
+
+  it("drops entries with empty/whitespace-only industry", () => {
+    const out = parseTopIndustries([
+      { industry: "", amount_usd: 1000 },
+      { industry: "   ", amount_usd: 1000 },
+      { industry: "Valid", amount_usd: 2000 },
+    ]);
+    expect(out).toEqual([{ industry: "Valid", amount_usd: 2000 }]);
+  });
+
+  it("drops non-object entries gracefully", () => {
+    const out = parseTopIndustries([
+      null,
+      "not-an-object",
+      42,
+      { industry: "Valid", amount_usd: 1000 },
+    ]);
+    expect(out).toEqual([{ industry: "Valid", amount_usd: 1000 }]);
+  });
+});

--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/db";
 import { parseContextPrimer } from "@/lib/primer";
 import { parseEntityLinks } from "@/lib/entityLinks";
+import { enrichLinksWithContext } from "@/lib/civicContext";
 import type { Article, CategoryId } from "@/lib/types";
 import { checkCsrf } from "@/lib/security";
 
@@ -58,6 +59,18 @@ export async function GET(request: NextRequest) {
           ...(entityLinks.length > 0 ? { entityLinks } : {}),
         };
       });
+      // Phase 3.G.3 — enrich politician chips with top-PAC-industry
+      // tooltips. Mutates the EntityLink references in place so
+      // articles[].entityLinks pick up civicContext without re-mapping.
+      // Tolerant of failures (chips still navigate without tooltip).
+      const allLinks = articles.flatMap((a) => a.entityLinks ?? []);
+      if (allLinks.length > 0) {
+        try {
+          await enrichLinksWithContext(allLinks);
+        } catch (err) {
+          console.warn("civicContext enrichment failed:", err);
+        }
+      }
       return NextResponse.json({ articles });
     }
 

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/db";
 import { parseContextPrimer } from "@/lib/primer";
 import { parseEntityLinks } from "@/lib/entityLinks";
+import { enrichLinksWithContext } from "@/lib/civicContext";
 import { stripHtml, sanitizeUrl } from "@/lib/sanitize";
 import type { CategoryId, Article, Story, StoryFraming, EntitySet, NewsApiResponse, NewsApiError } from "@/lib/types";
 
@@ -123,6 +124,9 @@ export async function GET(request: NextRequest) {
         };
       });
 
+      // (entity-link enrichment runs once across all articles below,
+      // before the response is returned — see `enrichLinksWithContext`.)
+
       // Parse JSONB framings (validate types, sanitize external text)
       const rawFramings = Array.isArray(s.framings) ? s.framings : [];
       const framings: StoryFraming[] = (rawFramings as unknown[])
@@ -164,6 +168,27 @@ export async function GET(request: NextRequest) {
         articles: childArticles,
       };
     });
+
+    // Phase 3.G.3 — civic-context tooltip enrichment.
+    // One batched query across every politician chip on the page (typical
+    // homepage: 0-30 chips; we de-dupe by canonical_id inside). Mutates
+    // the EntityLink[] references in place so the article objects pick up
+    // `civicContext` without us needing to re-thread anything. Tolerant
+    // of missing tables (returns silently) — chips still navigate to the
+    // right dossier even when enrichment is unavailable.
+    const allLinks = [
+      ...articles.flatMap((a) => a.entityLinks ?? []),
+      ...stories.flatMap((s) => s.articles.flatMap((a) => a.entityLinks ?? [])),
+    ];
+    if (allLinks.length > 0) {
+      try {
+        await enrichLinksWithContext(allLinks);
+      } catch (err) {
+        // Don't break the feed if enrichment fails — chips just render
+        // without tooltips.
+        console.warn("civicContext enrichment failed:", err);
+      }
+    }
 
     return NextResponse.json<NewsApiResponse>({
       articles,

--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/db";
 import { parseContextPrimer } from "@/lib/primer";
 import { parseEntityLinks } from "@/lib/entityLinks";
+import { enrichLinksWithContext } from "@/lib/civicContext";
 import { stableHash, estimateReadTime } from "@/lib/utils";
 import { stripHtml, sanitizeUrl } from "@/lib/sanitize";
 import type { Article, CategoryId } from "@/lib/types";
@@ -224,6 +225,18 @@ export async function GET(request: NextRequest) {
             ...(entityLinks.length > 0 ? { entityLinks } : {}),
           };
         });
+
+        // Phase 3.G.3 — civic-context tooltip enrichment for the chips
+        // we're about to stream. Tolerant of failures (chips still
+        // navigate; tooltip just doesn't render).
+        const allLinks = articles.flatMap((a) => a.entityLinks ?? []);
+        if (allLinks.length > 0) {
+          try {
+            await enrichLinksWithContext(allLinks);
+          } catch (err) {
+            console.warn("civicContext enrichment failed:", err);
+          }
+        }
 
         // 4. Stream vector results immediately
         if (articles.length > 0) {

--- a/components/glossary/EntityChipTooltip.tsx
+++ b/components/glossary/EntityChipTooltip.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { COPY } from "@/lib/copy";
+import type { CivicContext } from "@/lib/types";
+import { formatUsdCompact } from "@/lib/utils";
+
+interface EntityChipTooltipProps {
+  context: CivicContext;
+}
+
+/**
+ * Tooltip preview attached to an EntityLinksList chip — Phase 3.G.3.
+ *
+ * Reveals on `:hover` of the parent `<li class="group">` and on
+ * `:focus-within` (keyboard tab onto the chip's `<Link>`). The chip
+ * itself stays clickable; the tooltip is purely a preview hint.
+ *
+ * Mobile note: tap on the chip focuses the `<Link>` briefly before
+ * navigating, so the tooltip flashes rather than parking. We don't try
+ * to fight that — mobile users get the full dossier on tap, which is
+ * the better experience anyway. The tooltip is a desktop affordance.
+ *
+ * Visibility uses Tailwind's `group-hover` / `group-focus-within`
+ * utilities so we ship no client JS for the show/hide. The tooltip is
+ * positioned `absolute bottom-full` so it renders above the chip,
+ * pinned to the chip's left edge with a small gap.
+ */
+export default function EntityChipTooltip({ context }: EntityChipTooltipProps) {
+  if (context.type !== "politician") return null;
+  const { topIndustries } = context;
+
+  return (
+    <span
+      role="tooltip"
+      // The presentational layer. Hidden by default, revealed when the
+      // wrapping <li class="group"> is hovered or contains focus.
+      className="invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 transition-opacity duration-150 pointer-events-none absolute bottom-[calc(100%+6px)] left-0 z-[20] w-[300px] max-w-[calc(100vw-2rem)] bg-[var(--card-bg)] border border-[var(--border)] rounded-md shadow-lg p-3 text-left"
+    >
+      <p className="text-kicker font-bold uppercase text-[var(--text-muted)] mb-2 leading-tight">
+        {COPY.glossary.tooltip.politicianTopIndustries}
+      </p>
+      {topIndustries.length === 0 ? (
+        <p className="text-[12px] text-[var(--text-secondary)] italic">
+          {COPY.glossary.tooltip.noPacData}
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {topIndustries.map((entry) => (
+            <li
+              key={entry.industry}
+              className="grid grid-cols-[1fr_auto] gap-x-3 items-baseline border-b border-[var(--border-subtle)] last:border-b-0 pb-1 last:pb-0"
+            >
+              <span className="text-[12px] text-[var(--text-secondary)] truncate">
+                {entry.industry}
+              </span>
+              {entry.amount_usd != null && (
+                <span className="font-mono text-[11px] tabular-nums text-[var(--text-muted)]">
+                  {formatUsdCompact(entry.amount_usd)}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      <p className="text-outlet uppercase tracking-wider text-[var(--text-muted)] mt-2 pt-2 border-t border-[var(--border-subtle)]">
+        {COPY.glossary.tooltip.openDossierHint}
+      </p>
+    </span>
+  );
+}

--- a/components/glossary/EntityLinksList.tsx
+++ b/components/glossary/EntityLinksList.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { COPY } from "@/lib/copy";
 import { entityHref, entityTypeLabel } from "@/lib/entityLinks";
 import type { EntityLink } from "@/lib/types";
+import EntityChipTooltip from "./EntityChipTooltip";
 
 interface EntityLinksListProps {
   links: EntityLink[] | undefined;
@@ -48,7 +49,14 @@ export default function EntityLinksList({ links }: EntityLinksListProps) {
         {links.map((link) => {
           const glyph = COPY.glossary.typeGlyphs[link.type];
           return (
-            <li key={`${link.type}:${link.canonicalId}`}>
+            // `relative group` is the anchor for the EntityChipTooltip's
+            // `group-hover:` / `group-focus-within:` reveal. The Tailwind
+            // group utility scopes the hover to this single chip, not
+            // the whole list, so other chips in the row don't flash.
+            <li
+              key={`${link.type}:${link.canonicalId}`}
+              className="relative group"
+            >
               <Link
                 href={entityHref(link)}
                 onClick={(e) => e.stopPropagation()}
@@ -65,6 +73,9 @@ export default function EntityLinksList({ links }: EntityLinksListProps) {
                 )}
                 <span className="font-medium">{link.surfaceForm}</span>
               </Link>
+              {link.civicContext && (
+                <EntityChipTooltip context={link.civicContext} />
+              )}
             </li>
           );
         })}

--- a/lib/civicContext.ts
+++ b/lib/civicContext.ts
@@ -1,0 +1,83 @@
+/**
+ * Civic-context enrichment for EntityLink chips — Phase 3.G.3.
+ *
+ * The entity-linker pipeline node attaches resolved (type, canonicalId,
+ * surfaceForm) tuples to every article. That's enough to make the chip
+ * navigate to the right dossier, but the chip itself is opaque — a reader
+ * sees "Chuck Schumer" without any civic context unless they click in.
+ *
+ * This module batches a single SQL query per page render to attach a small
+ * `civicContext` payload to each chip. For politician chips, it's the top
+ * 3 PAC industries by 2022-cycle dollar amount. EntityChipTooltip renders
+ * those inline on hover/focus so the connection between "story" and
+ * "civic context" is tactile without leaving the feed.
+ *
+ * Why server-enrichment vs client-fetch:
+ * - One batched query per page render vs N round-trips on hover.
+ * - Tooltip is instant — no loading state on hover.
+ * - The data is small (~3 industries × ~30 chars = ~150 bytes/chip).
+ *
+ * Tolerant of missing tables/columns the same way `lib/db.ts` is — returns
+ * silently without enrichment so the chip still navigates correctly even
+ * when prod is mid-migration.
+ */
+import pool from "./db";
+import { asTopIndustries } from "./politician";
+import type { EntityLink, IndustryDonation } from "./types";
+
+interface PoliticianContextRow {
+  bioguide_id: string;
+  top_industries_current_cycle: unknown;
+}
+
+/**
+ * In-place enrichment: scans `links` for politician chips, batches one
+ * SQL query, attaches `civicContext` where data exists.
+ *
+ * Mutates `links` rather than returning new objects so callers don't have
+ * to thread the result through their existing object-spread mappers. The
+ * function returns void on purpose.
+ */
+export async function enrichLinksWithContext(
+  links: EntityLink[],
+): Promise<void> {
+  if (links.length === 0) return;
+
+  const politicianIds = Array.from(
+    new Set(
+      links.filter((l) => l.type === "politician").map((l) => l.canonicalId),
+    ),
+  );
+  if (politicianIds.length === 0) return;
+
+  let rows: PoliticianContextRow[];
+  try {
+    const result = await pool.query<PoliticianContextRow>(
+      `SELECT bioguide_id, top_industries_current_cycle
+         FROM politician_profiles
+        WHERE bioguide_id = ANY($1::text[])`,
+      [politicianIds],
+    );
+    rows = result.rows;
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("does not exist")) return; // pre-Phase-3.A prod
+    throw err;
+  }
+
+  const byBioguide = new Map<string, IndustryDonation[]>();
+  for (const row of rows) {
+    const industries = asTopIndustries(row.top_industries_current_cycle);
+    if (industries.length > 0) {
+      byBioguide.set(row.bioguide_id, industries.slice(0, 3));
+    }
+  }
+
+  for (const link of links) {
+    if (link.type !== "politician") continue;
+    const industries = byBioguide.get(link.canonicalId);
+    if (industries && industries.length > 0) {
+      link.civicContext = { type: "politician", topIndustries: industries };
+    }
+  }
+}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -126,6 +126,13 @@ export const COPY = {
       bill: "▸",
       outlet: "▣",
     } as Record<string, string>,
+    // Phase 3.G.3 — chip tooltip preview, shown on hover/focus.
+    tooltip: {
+      politicianTopIndustries: "Top industries by PAC contributions (2022 cycle)",
+      noPacData: "No PAC data on file for the 2022 cycle.",
+      // Click-through hint at the foot of the tooltip.
+      openDossierHint: "Open dossier →",
+    },
   },
   primer: {
     // Eyebrow shown above the collapsed/expanded primer panel.

--- a/lib/politician.ts
+++ b/lib/politician.ts
@@ -126,7 +126,7 @@ function asCommittees(v: unknown): string[] {
     .filter((entry) => entry.length > 0);
 }
 
-function asTopIndustries(v: unknown): IndustryDonation[] {
+export function asTopIndustries(v: unknown): IndustryDonation[] {
   if (!Array.isArray(v)) return [];
   const out: IndustryDonation[] = [];
   for (const entry of v) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -217,12 +217,39 @@ export type EntityLinkType = "outlet" | "politician" | "org" | "bill";
  * `surfaceForm` preserves the original casing from the article text so
  * the InlineGlossaryTooltip can render the matched span verbatim
  * ("CHUCK SCHUMER said today" → tooltip shows "CHUCK SCHUMER").
+ *
+ * `civicContext` is server-attached (not stored in `entity_links` JSONB):
+ * the API route enriches each politician chip with the politician's top
+ * PAC industries so the EntityLinksList chip-tooltip can show inline
+ * civic context without a per-hover round trip. Optional — articles whose
+ * chips don't resolve (or whose politicians have no industry data) render
+ * the chip without a tooltip preview, just navigating to the full dossier
+ * on click.
  */
 export interface EntityLink {
   type: EntityLinkType;
   canonicalId: string;
   surfaceForm: string;
+  civicContext?: CivicContext;
 }
+
+/**
+ * Inline civic context shown in the tooltip preview on an EntityLinksList
+ * chip. Server-enriched at API-route time from `politician_profiles` (and,
+ * later, `org_profiles` / `bill_profiles` / `outlet_profiles`). Lives on
+ * the wire; never persisted in DB.
+ *
+ * Schema is intentionally a flat union by `type` so the renderer can do a
+ * single discriminated switch rather than juggling four nullable shapes.
+ */
+export type CivicContext =
+  | {
+      type: "politician";
+      // Up to 3 top PAC industries by 2022-cycle amount, descending.
+      // Empty when the politician is in the roster but has no PAC data
+      // (off-cycle senators, post-2022 specials).
+      topIndustries: IndustryDonation[];
+    };
 
 /**
  * Curated bill metadata, mirrored from `bill_profiles` in Postgres.


### PR DESCRIPTION
## Summary
Surfaces a small civic-context preview on chip hover/focus so the connection between **story** and **civic context** is tactile without leaving the feed. For politician chips: **top 3 PAC industries (2022 cycle)** by dollar amount, with the same compact \$574K formatting we built in PR #85.

\`\`\`
Schumer says action urgent
  [◉ Chuck Schumer]   ← hover →
  ┌────────────────────────────────────────┐
  │ TOP INDUSTRIES BY PAC CONTRIBUTIONS    │
  │ (2022 cycle)                           │
  │ ─────────────────────────────          │
  │ Attorneys & law firms        \$574K    │
  │ Democratic leadership PAC    \$194K    │
  │ Corporate lawyers & law firms \$121K   │
  │ ─────────────────────────────          │
  │ OPEN DOSSIER →                         │
  └────────────────────────────────────────┘
\`\`\`

## Architecture (server-enriched, not on-hover-fetched)

| Step | Where | What |
|---|---|---|
| 1 | DB | \`articles.entity_links\` JSONB stored by sift-api pipeline |
| 2 | API route | \`parseEntityLinks\` → \`EntityLink[]\` (no civicContext yet) |
| 3 | API route | **\`enrichLinksWithContext(allLinks)\`** — one batched SQL query, mutates in place |
| 4 | JSON | civicContext shipped to client on the same response |
| 5 | EntityLinksList | renders \`<EntityChipTooltip>\` when \`civicContext\` is present |

**Why server-enrichment over on-hover fetch:**
- One batched query per page render vs N round-trips on hover
- Tooltip is instant — no spinner state
- Data is tiny (~150 bytes/chip)

## Accessibility
Tooltip shows on \`:hover\` and \`:focus-within\` (keyboard tab onto the chip reveals it). Pure Tailwind utilities — zero client JS for show/hide. Mobile tap navigates to dossier (better UX than a parked tooltip on a small screen).

## Files
**New:**
- \`lib/civicContext.ts\` — \`enrichLinksWithContext\` (mutates in place, tolerant of missing tables)
- \`components/glossary/EntityChipTooltip.tsx\` — pure Tailwind tooltip
- \`__tests__/civicContext.test.ts\` — 10 parser tests (null, non-array, missing/malformed fields, NaN/Infinity, etc.)

**Modified:**
- \`lib/types.ts\` — discriminated \`CivicContext\` union; \`EntityLink\` gets optional \`civicContext\`
- \`lib/politician.ts\` — exports \`asTopIndustries\` (was internal) so civicContext reuses the same defensive parser
- \`lib/copy.ts\` — new \`glossary.tooltip\` block
- \`components/glossary/EntityLinksList.tsx\` — wraps each pill in \`relative group\`; renders tooltip when civicContext present
- \`app/api/news/route.ts\` — single enrichment call across all chips on the page
- \`app/api/bookmarks/route.ts\` — same for saved articles
- \`app/api/news/topic/route.ts\` — same for custom-topic vector-search results

## Tests
280 pass (+10 new). tsc clean.

## Out of scope (clear extensions)
Org chips (political_lean + top funder), bill chips (status), and outlet chips (AllSides bias rating). The discriminated \`CivicContext\` type leaves a clean slot for each — add when there's user signal that the tooltip is read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)