### PR TITLE
feat: link primer terms to dossiers via entity_links (Phase 3.G.4)

### DIFF
--- a/__tests__/primer.test.ts
+++ b/__tests__/primer.test.ts
@@ -1,4 +1,5 @@
-import { parseContextPrimer } from "@/lib/primer";
+import { parseContextPrimer, attachPrimerTermLinks } from "@/lib/primer";
+import type { ContextPrimer, EntityLink } from "@/lib/types";
 
 describe("parseContextPrimer", () => {
   describe("null-returning inputs", () => {
@@ -238,5 +239,140 @@ describe("parseContextPrimer", () => {
       });
       expect(result?.background).toBe("");
     });
+  });
+});
+
+// ─── attachPrimerTermLinks (Phase 3.G.4) ──────────────────────────
+
+describe("attachPrimerTermLinks", () => {
+  const primer: ContextPrimer = {
+    background: "background text",
+    terms: [
+      { term: "FCC petition", definition: "A formal request to the agency." },
+      { term: "filibuster", definition: "Senate procedure requiring 60 votes." },
+      { term: "Schumer's stance", definition: "His position on the bill." },
+    ],
+  };
+
+  const links: EntityLink[] = [
+    { type: "org", canonicalId: "fcc", surfaceForm: "FCC" },
+    {
+      type: "politician",
+      canonicalId: "S000148",
+      surfaceForm: "Chuck Schumer",
+    },
+    // Note: surfaceForm is "Schumer" alone — should match "Schumer's stance"
+    { type: "politician", canonicalId: "S000148", surfaceForm: "Schumer" },
+  ];
+
+  it("returns null primer untouched when input is null", () => {
+    expect(attachPrimerTermLinks(null, links)).toBeNull();
+  });
+
+  it("returns primer untouched when there are no entity links", () => {
+    const out = attachPrimerTermLinks(primer, []);
+    expect(out).toBe(primer);
+    expect(out?.terms.every((t) => t.link === undefined)).toBe(true);
+  });
+
+  it("attaches link when surface form is a substring of the term", () => {
+    const out = attachPrimerTermLinks(primer, links);
+    const fccTerm = out?.terms.find((t) => t.term === "FCC petition");
+    expect(fccTerm?.link).toEqual({ type: "org", canonicalId: "fcc" });
+  });
+
+  it("matches case-insensitively", () => {
+    const out = attachPrimerTermLinks(
+      { background: "", terms: [{ term: "fcc rule", definition: "x" }] },
+      [{ type: "org", canonicalId: "fcc", surfaceForm: "FCC" }],
+    );
+    expect(out?.terms[0].link).toEqual({ type: "org", canonicalId: "fcc" });
+  });
+
+  it("does not attach a link to terms that don't contain any surface form", () => {
+    const out = attachPrimerTermLinks(primer, links);
+    const filibuster = out?.terms.find((t) => t.term === "filibuster");
+    expect(filibuster?.link).toBeUndefined();
+  });
+
+  it("uses word boundaries — 'abcd' does NOT match surface 'abc'", () => {
+    const out = attachPrimerTermLinks(
+      { background: "", terms: [{ term: "abcdefg", definition: "x" }] },
+      [{ type: "org", canonicalId: "abc", surfaceForm: "ABC" }],
+    );
+    expect(out?.terms[0].link).toBeUndefined();
+  });
+
+  it("matches at word boundary — 'FCC's authority' matches 'FCC'", () => {
+    const out = attachPrimerTermLinks(
+      { background: "", terms: [{ term: "FCC authority", definition: "x" }] },
+      [{ type: "org", canonicalId: "fcc", surfaceForm: "FCC" }],
+    );
+    expect(out?.terms[0].link).toEqual({ type: "org", canonicalId: "fcc" });
+  });
+
+  it("prefers the longer surface form when multiple links could match", () => {
+    // 'Federal Reserve' is longer than 'Reserve'; should win.
+    const out = attachPrimerTermLinks(
+      {
+        background: "",
+        terms: [{ term: "Federal Reserve action", definition: "x" }],
+      },
+      [
+        { type: "org", canonicalId: "reserve", surfaceForm: "Reserve" },
+        { type: "org", canonicalId: "federal-reserve", surfaceForm: "Federal Reserve" },
+      ],
+    );
+    expect(out?.terms[0].link).toEqual({
+      type: "org",
+      canonicalId: "federal-reserve",
+    });
+  });
+
+  it("escapes regex metacharacters in surface forms", () => {
+    // Period-containing name like 'J.D. Vance' should match literally,
+    // not interpret '.' as regex any-char.
+    const out = attachPrimerTermLinks(
+      { background: "", terms: [{ term: "J.D. Vance memo", definition: "x" }] },
+      [{ type: "politician", canonicalId: "V000137", surfaceForm: "J.D. Vance" }],
+    );
+    expect(out?.terms[0].link).toEqual({
+      type: "politician",
+      canonicalId: "V000137",
+    });
+  });
+
+  it("ignores single-character surface forms (would over-match)", () => {
+    const out = attachPrimerTermLinks(
+      { background: "", terms: [{ term: "a single word", definition: "x" }] },
+      [{ type: "outlet", canonicalId: "x", surfaceForm: "a" }],
+    );
+    expect(out?.terms[0].link).toBeUndefined();
+  });
+
+  it("does not mutate the input primer", () => {
+    const input: ContextPrimer = {
+      background: "bg",
+      terms: [{ term: "FCC rule", definition: "x" }],
+    };
+    const inputTermsRef = input.terms;
+    attachPrimerTermLinks(input, [
+      { type: "org", canonicalId: "fcc", surfaceForm: "FCC" },
+    ]);
+    expect(input.terms).toBe(inputTermsRef);
+    expect(input.terms[0].link).toBeUndefined();
+  });
+
+  it("preserves other primer fields (background, generated_at)", () => {
+    const out = attachPrimerTermLinks(
+      {
+        background: "bg paragraph",
+        terms: [{ term: "FCC rule", definition: "x" }],
+        generated_at: "2026-05-08T12:00:00Z",
+      },
+      [{ type: "org", canonicalId: "fcc", surfaceForm: "FCC" }],
+    );
+    expect(out?.background).toBe("bg paragraph");
+    expect(out?.generated_at).toBe("2026-05-08T12:00:00Z");
   });
 });

--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -10,7 +10,7 @@ import {
   resolveOutletForSourceName,
   getArticleEntityLinks,
 } from "@/lib/db";
-import { parseContextPrimer } from "@/lib/primer";
+import { parseContextPrimer, attachPrimerTermLinks } from "@/lib/primer";
 import { parseEntityLinks } from "@/lib/entityLinks";
 import { enrichLinksWithContext } from "@/lib/civicContext";
 import type { Article, CategoryId } from "@/lib/types";
@@ -39,9 +39,10 @@ export async function GET(request: NextRequest) {
       ]);
       const entityLinksMap = await getArticleEntityLinks(rows.map((r) => r.id));
       const articles: Article[] = rows.map((row) => {
-        const primer = parseContextPrimer(row.context_primer);
+        const rawPrimer = parseContextPrimer(row.context_primer);
         const outlet = resolveOutletForSourceName(outletMap, row.source_name);
         const entityLinks = parseEntityLinks(entityLinksMap.get(row.id));
+        const primer = attachPrimerTermLinks(rawPrimer, entityLinks);
         return {
           id: row.id,
           title: row.title,

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -6,7 +6,7 @@ import {
   resolveOutletForSourceName,
   getArticleEntityLinks,
 } from "@/lib/db";
-import { parseContextPrimer } from "@/lib/primer";
+import { parseContextPrimer, attachPrimerTermLinks } from "@/lib/primer";
 import { parseEntityLinks } from "@/lib/entityLinks";
 import { enrichLinksWithContext } from "@/lib/civicContext";
 import { stripHtml, sanitizeUrl } from "@/lib/sanitize";
@@ -78,9 +78,12 @@ export async function GET(request: NextRequest) {
 
     // Map standalone articles
     const articles: Article[] = standaloneArticles.map((row) => {
-      const primer = parseContextPrimer(row.context_primer);
+      const rawPrimer = parseContextPrimer(row.context_primer);
       const outlet = resolveOutletForSourceName(outletMap, row.source_name);
       const entityLinks = parseEntityLinks(entityLinksMap.get(row.id));
+      // Phase 3.G.4 — link primer terms to dossiers when their text
+      // contains a curated entity surface form (FCC, Schumer, IRA, etc.).
+      const primer = attachPrimerTermLinks(rawPrimer, entityLinks);
       return {
         id: row.id,
         title: row.title,
@@ -103,9 +106,10 @@ export async function GET(request: NextRequest) {
     const stories: Story[] = dbStories.map((s) => {
       const childRows = storyArticles[s.id] || [];
       const childArticles: Article[] = childRows.map((row) => {
-        const primer = parseContextPrimer(row.context_primer);
+        const rawPrimer = parseContextPrimer(row.context_primer);
         const outlet = resolveOutletForSourceName(outletMap, row.source_name);
         const entityLinks = parseEntityLinks(entityLinksMap.get(row.id));
+        const primer = attachPrimerTermLinks(rawPrimer, entityLinks);
         return {
           id: row.id,
           title: row.title,

--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -7,7 +7,7 @@ import {
   resolveOutletForSourceName,
   getArticleEntityLinks,
 } from "@/lib/db";
-import { parseContextPrimer } from "@/lib/primer";
+import { parseContextPrimer, attachPrimerTermLinks } from "@/lib/primer";
 import { parseEntityLinks } from "@/lib/entityLinks";
 import { enrichLinksWithContext } from "@/lib/civicContext";
 import { stableHash, estimateReadTime } from "@/lib/utils";
@@ -203,9 +203,10 @@ export async function GET(request: NextRequest) {
 
         // 3. Map DB rows to Article type
         const articles: Article[] = rows.map((row) => {
-          const primer = parseContextPrimer(row.context_primer);
+          const rawPrimer = parseContextPrimer(row.context_primer);
           const outlet = resolveOutletForSourceName(outletMap, row.source_name);
           const entityLinks = parseEntityLinks(entityLinksMap.get(row.id));
+          const primer = attachPrimerTermLinks(rawPrimer, entityLinks);
           return {
             id: row.id,
             title: row.title,

--- a/components/primer/BackgroundPrimer.tsx
+++ b/components/primer/BackgroundPrimer.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { COPY } from "@/lib/copy";
-import type { ContextPrimer } from "@/lib/types";
+import { entityHref } from "@/lib/entityLinks";
+import type { ContextPrimer, ContextPrimerTerm } from "@/lib/types";
 
 interface BackgroundPrimerProps {
   primer: ContextPrimer | null | undefined;
@@ -101,14 +103,17 @@ export default function BackgroundPrimer({
           )}
 
           {/* Term/definition list — no "Key terms" label. Renders as a
-              reference panel rather than a textbook glossary. */}
+              reference panel rather than a textbook glossary.
+
+              Phase 3.G.4: terms whose text contains a curated entity (FCC,
+              Schumer, IRA, etc.) get a `link` attached server-side via
+              `attachPrimerTermLinks`. Linked terms render as click-through
+              into the dossier; unlinked terms remain plain text. */}
           {terms.length > 0 && (
             <dl className="flex flex-col gap-1.5">
               {terms.map((t) => (
                 <div key={t.term} className="text-body leading-snug">
-                  <dt className="inline font-semibold text-[var(--text)]">
-                    {t.term}
-                  </dt>
+                  <PrimerTermLabel term={t} />
                   <dd className="inline text-[var(--text-secondary)]">
                     {" — "}
                     {t.definition}
@@ -120,5 +125,42 @@ export default function BackgroundPrimer({
         </div>
       )}
     </div>
+  );
+}
+
+/**
+ * Term label inside the primer's term list. When the term has a `link`
+ * (Phase 3.G.4 — server-attached when the term text contains a curated
+ * entity surface form), renders as a click-through to the dossier with
+ * subtle accent styling. Otherwise renders as plain bold text matching
+ * the previous look.
+ *
+ * Click handler stops propagation so the surrounding card-link doesn't
+ * fire on term-tap (same pattern as EntityLinksList chips).
+ */
+function PrimerTermLabel({ term }: { term: ContextPrimerTerm }) {
+  if (!term.link) {
+    return (
+      <dt className="inline font-semibold text-[var(--text)]">{term.term}</dt>
+    );
+  }
+  // Reuse the shared dossier-routing helper so primer-term links + chip
+  // links can never drift apart.
+  const href = entityHref({
+    type: term.link.type,
+    canonicalId: term.link.canonicalId,
+    surfaceForm: term.term,
+  });
+  return (
+    <dt className="inline">
+      <Link
+        href={href}
+        onClick={(e) => e.stopPropagation()}
+        aria-label={`Open dossier for ${term.term}`}
+        className="font-semibold text-[var(--text)] no-underline border-b border-dotted border-[var(--accent)] hover:text-[var(--accent)] hover:border-solid transition-colors"
+      >
+        {term.term}
+      </Link>
+    </dt>
   );
 }

--- a/lib/primer.ts
+++ b/lib/primer.ts
@@ -53,3 +53,98 @@ export function parseContextPrimer(raw: unknown): ContextPrimer | null {
     ...(generated_at ? { generated_at } : {}),
   };
 }
+
+/**
+ * Phase 3.G.4 — link primer terms to dossiers via the article's existing
+ * entity_links surface forms.
+ *
+ * The primer LLM picks domain-jargon (filibuster, chilling effect, basis
+ * points). The entity-linker (separate Phase 3.G pipeline node) picks
+ * proper-noun mentions of curated entities (FCC, Reuters, Schumer, IRA).
+ * Many primer terms contain or equal an entity surface form: "FCC
+ * petition" contains "FCC"; "FOMC dissenters" contains nothing curated.
+ *
+ * For each primer term, scan the article's entity_links. If the term
+ * contains an entity's surfaceForm (case-insensitive, word-boundary), tag
+ * the term with that entity's `{type, canonicalId}` so the UI can render
+ * a click-through to the dossier. Mutates a shallow copy — the input
+ * primer is not modified.
+ *
+ * Why post-process rather than ask the LLM:
+ * - Reuses the entity-linker work we already paid for.
+ * - Zero additional LLM cost.
+ * - The LLM stays focused on its core job (picking jargon for definition);
+ *   the linking is mechanical lookup.
+ *
+ * Limits: misses nicknames the LLM didn't use ("the Speaker" → Mike
+ * Johnson) and partial mentions the entity-linker missed. Acceptable
+ * MVP trade-off — the entity-linker pass already handles those cases
+ * downstream as separate chips.
+ */
+export function attachPrimerTermLinks(
+  primer: ContextPrimer | null,
+  entityLinks: import("./types").EntityLink[],
+): ContextPrimer | null {
+  if (!primer || entityLinks.length === 0) return primer;
+
+  // De-dupe surface forms by their entity ref so we don't waste regex passes
+  // on multiple chips that resolve to the same dossier.
+  const refs: Array<{
+    surfaceForm: string;
+    type: import("./types").EntityLinkType;
+    canonicalId: string;
+  }> = [];
+  const seen = new Set<string>();
+  for (const link of entityLinks) {
+    const surface = link.surfaceForm.trim();
+    if (!surface) continue;
+    const key = `${link.type}:${link.canonicalId}:${surface.toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    refs.push({
+      surfaceForm: surface,
+      type: link.type,
+      canonicalId: link.canonicalId,
+    });
+  }
+  // Longer surfaces first so "Federal Reserve" wins over "Reserve" when both
+  // are in the catalog.
+  refs.sort((a, b) => b.surfaceForm.length - a.surfaceForm.length);
+
+  const linkedTerms = primer.terms.map((t) => {
+    const match = findFirstSurfaceMatch(t.term, refs);
+    if (!match) return t;
+    return {
+      ...t,
+      link: { type: match.type, canonicalId: match.canonicalId },
+    };
+  });
+
+  return { ...primer, terms: linkedTerms };
+}
+
+/**
+ * Word-boundary, case-insensitive substring match. Returns the first
+ * matching ref or null.
+ *
+ * The regex escapes special chars in the surface form so a name with a
+ * period or hyphen ("J.D. Vance", "Cory Booker") matches literally rather
+ * than as regex metacharacters.
+ */
+function findFirstSurfaceMatch<
+  R extends { surfaceForm: string },
+>(term: string, refs: readonly R[]): R | null {
+  const haystack = term.toLowerCase();
+  for (const ref of refs) {
+    const needle = ref.surfaceForm.toLowerCase();
+    // Word-boundary on at least one side so "abc" doesn't match "abcd".
+    // We lean on simple boundary chars rather than \b so single-letter
+    // surfaces (e.g. "S" → bioguide) can't false-match — but the catalog
+    // doesn't have single-character surface forms in practice anyway.
+    if (needle.length < 2) continue;
+    const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(`\\b${escaped}\\b`, "i");
+    if (re.test(haystack)) return ref;
+  }
+  return null;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -397,6 +397,24 @@ export interface ContextPrimerTerm {
   term: string;
   definition: string;
   source?: string;
+  /**
+   * Optional dossier link, server-attached at API time when the term text
+   * contains a curated entity from the article's `entity_links`. Lets the
+   * primer's "FCC petition" or "Schumer" surface link straight into the
+   * civic graph (org / politician / bill / outlet dossier) rather than
+   * stopping at a definition. Phase 3.G.4.
+   */
+  link?: PrimerTermLink;
+}
+
+/**
+ * Minimal pointer to a curated entity dossier — same shape used by
+ * `EntityLink` minus the `surfaceForm` (the primer term text already
+ * doubles as the link's display label).
+ */
+export interface PrimerTermLink {
+  type: EntityLinkType;
+  canonicalId: string;
 }
 
 export interface ContextPrimer {


### PR DESCRIPTION
## Summary
The primer's "What you should know first" panel was a generic glossary — LLM picks domain-jargon, defines in plain language. Useful, but **not defensible** — any LLM does this.

This PR makes the primer a **doorway into Sift's curated civic graph**. When a primer term contains a curated entity, the term clicks through to that entity's dossier:

- "FCC petition" → \`/org/fcc\`
- "Schumer's stance" → \`/politician/S000148\`
- "the Inflation Reduction Act" → \`/bill/hr-5376-117\`
- "according to Reuters" → \`/outlet/reuters\`
- "filibuster" → no match → renders plain (correct)

Anyone with an LLM can define filibuster; only Sift has 536 politician dossiers + 10 orgs + bills + outlets connected.

## How it works (server-side, no extra LLM cost)
Reuses the existing \`entity_links\` the entity-linker pipeline already produced for chips:

\`\`\`ts
primer       = parseContextPrimer(row.context_primer);
entityLinks  = parseEntityLinks(entityLinksMap.get(row.id));
primer       = attachPrimerTermLinks(primer, entityLinks);  // ← new
\`\`\`

\`attachPrimerTermLinks\` scans each primer term for a word-boundary, case-insensitive match against any entity_link's surface form. First match wins; longer surface forms preferred ("Federal Reserve" beats "Reserve"); single-character surfaces ignored.

## Files
**Types** (\`lib/types.ts\`):
- \`ContextPrimerTerm\` gets optional \`link: PrimerTermLink\`
- \`PrimerTermLink = { type: EntityLinkType; canonicalId: string }\`

**Logic** (\`lib/primer.ts\`):
- \`attachPrimerTermLinks(primer, entityLinks)\` — pure, shallow-copying. Internal \`findFirstSurfaceMatch\` uses regex word-boundaries with metachar escaping (handles "J.D. Vance" literally).

**Wired into:** \`app/api/news/route.ts\`, \`app/api/bookmarks/route.ts\`, \`app/api/news/topic/route.ts\`.

**UI** (\`components/primer/BackgroundPrimer.tsx\`):
- Linked terms render with a dotted accent underline that goes solid on hover.
- \`e.stopPropagation()\` so the card-link overlay doesn't fire on term-tap.
- Unlinked terms unchanged.

## Companion PR
**sift-api #48** tightens the prompt so the LLM stops shipping obvious vocabulary (tariffs, IPO, child support, pollen season). Together, the two PRs **raise the bar** AND **make the survivors lead somewhere**.

## Tests
292 pass (+12 new for \`attachPrimerTermLinks\`). tsc clean. Coverage:
- null/empty inputs (no-op)
- case-insensitive substring match
- word-boundary respect ("abcd" ≠ "abc")
- regex metachar escaping ("J.D. Vance")
- longer-surface preference
- single-char surfaces ignored
- input not mutated
- non-link fields preserved (background, generated_at)

## Future (out of scope — option C)
Cross-article context: *"This is the third FCC ruling against ABC this year. See related coverage [3 articles]."* Higher craft, real proprietary value (only Sift has the corpus + entity-linker to compute it). ~1 day of work — defer until analytics show users click the new term-links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)