### PR TITLE
feat(org): add 'agency' to OrgType for federal-agency dossiers

### DIFF
--- a/lib/civic.ts
+++ b/lib/civic.ts
@@ -79,6 +79,7 @@ export const ORG_TYPE_LABELS: Record<OrgType, string> = {
   "super-pac": "Super PACs",
   "foundation": "Foundations",
   "industry-group": "Industry groups",
+  "agency": "Federal agencies",
   "other": "Other",
 };
 

--- a/lib/org.ts
+++ b/lib/org.ts
@@ -21,6 +21,7 @@ const ORG_TYPES: ReadonlySet<string> = new Set([
   "super-pac",
   "foundation",
   "industry-group",
+  "agency",
   "other",
 ]);
 
@@ -44,6 +45,7 @@ const ORG_TYPE_LABELS: Record<OrgType, string> = {
   "super-pac": "Super PAC",
   foundation: "Foundation",
   "industry-group": "Industry group",
+  agency: "Federal agency",
   other: "Organization",
 };
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -116,6 +116,7 @@ export type OrgType =
   | "super-pac"
   | "foundation"
   | "industry-group"
+  | "agency"
   | "other";
 
 /**


### PR DESCRIPTION
## Summary
Companion to **sift-api PR #49**, which adds 15 federal agencies (FCC, DOJ, FBI, EPA, FDA, SEC, IRS, Pentagon, Federal Reserve, etc.) to \`org_profiles\` so the entity-linker can recognize them and primer terms can click through to dossiers.

This PR teaches the frontend the new type so the dossier pages and \`/civic\` index render cleanly.

## Why both PRs together
Without this enum bump:
- Agency dossier pages would show **no type label** in the lede (just "Founded 1934 · Annual budget ~\$390M")
- \`/civic\` would group all 15 agencies under whatever the fallback bucket is

## Diff
\`\`\`diff
// lib/types.ts: OrgType union
+ | "agency"

// lib/org.ts: ORG_TYPES Set + ORG_TYPE_LABELS Record
+ "agency",
+ agency: "Federal agency",   // dossier-lede label

// lib/civic.ts: section-heading labels on /civic index
+ "agency": "Federal agencies",
\`\`\`

## After deploy
- \`/org/fcc\` lede reads "Federal agency · Founded 1934 · Annual budget ~\$390M"
- \`/civic\` shows a new "Federal agencies" section with all 15 agencies grouped together
- Primer terms like "FCC petition" / "FBI agents" / "EPA rule" resolve to dossier links

## Tests
292 pass. tsc clean. No new tests — this is a single enum member; the existing fallback tests already cover the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)