### PR TITLE
fix(og): rebuild stale unfurl card + per-route metadata overrides

### DIFF
--- a/app/bill/[id]/page.tsx
+++ b/app/bill/[id]/page.tsx
@@ -19,11 +19,26 @@ export async function generateMetadata({
   const bill = await getBillById(id);
   if (!bill) return { title: "Bill not found" };
   const display = formatBillIdDisplay(bill.billId);
+
+  // Per-route metadata override so shared bill links carry the bill's
+  // name in the unfurl card. og:image inherits the site default.
+  const fullTitle = `${display} (${bill.shortTitle ?? "Bill"}) — Sift`;
+  const description = `Sponsor, cosponsors, status, and lobbying spend for ${
+    bill.shortTitle ?? display
+  } on Sift.`;
   return {
     title: `${display} — Bill dossier`,
-    description: `Sponsor, cosponsors, status, and lobbying spend for ${
-      bill.shortTitle ?? display
-    } on Sift.`,
+    description,
+    openGraph: {
+      title: fullTitle,
+      description,
+      type: "article",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: fullTitle,
+      description,
+    },
   };
 }
 

--- a/app/civic/page.tsx
+++ b/app/civic/page.tsx
@@ -13,10 +13,25 @@ import type { PoliticianChamber } from "@/lib/types";
 // page snappy without staleness mattering at this cadence.
 export const revalidate = 600;
 
+// Per-route metadata override so shared /civic links carry the index's
+// own title/description in unfurl cards (not the homepage default).
+const CIVIC_TITLE = "Civic dossiers — Sift";
+const CIVIC_DESC =
+  "Browse Sift's curated politician, organization, and bill dossiers. 536 sitting members of Congress, federal agencies, the major think-tanks shaping policy, and landmark bills.";
+
 export const metadata: Metadata = {
-  title: "Civic dossiers — Sift",
-  description:
-    "Browse Sift's curated politician, organization, and bill dossiers. 536 sitting members of Congress, the major think-tanks shaping policy, and landmark bills.",
+  title: CIVIC_TITLE,
+  description: CIVIC_DESC,
+  openGraph: {
+    title: CIVIC_TITLE,
+    description: CIVIC_DESC,
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: CIVIC_TITLE,
+    description: CIVIC_DESC,
+  },
 };
 
 interface CivicPageProps {

--- a/app/colophon/page.tsx
+++ b/app/colophon/page.tsx
@@ -24,7 +24,7 @@ const ARCHITECTURE = [
   "Articles load in under 50ms — AI processing happens in the background, not when you read.",
   "Works without an account — sign in only if you want bookmarks synced across devices.",
   "Graceful degradation: every feature works independently, so one slow service never blocks the page.",
-  "100+ sources are ingested, deduplicated, and ranked every 10 minutes before you open the app.",
+  "~50 vetted sources are ingested, deduplicated, and ranked every 30 minutes before you open the app.",
 ];
 
 export default function ColophonPage() {

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,6 +1,12 @@
 import { ImageResponse } from "next/og";
 
-export const alt = "Sift — AI-Curated News";
+// Updated 2026-05: the original card baked in three stale claims —
+// "100+ sources" (true count is ~58), "Updated every 10 min" (pipeline
+// runs every 30 min after the cost-cut bump), and an "AI-Curated News"
+// positioning that doesn't communicate the actual differentiator (civic
+// context / cross-spectrum framing / money trail). The current version
+// uses the live product tagline and avoids numeric claims that go stale.
+export const alt = "Sift — The news, with footnotes";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
@@ -43,30 +49,43 @@ export default function OGImage() {
           Sift
         </span>
 
-        {/* Tagline */}
+        {/* Tagline — matches COPY.header.tagline */}
         <span
           style={{
-            fontSize: 28,
-            color: "rgba(255,255,255,0.6)",
-            marginTop: 20,
-            fontFamily: "sans-serif",
+            fontSize: 32,
+            color: "rgba(255,255,255,0.75)",
+            marginTop: 24,
+            fontFamily: "Georgia, serif",
+            fontStyle: "italic",
             fontWeight: 400,
           }}
         >
-          AI-Curated News, Already Read for You
+          The news, with footnotes.
         </span>
 
-        {/* Stats line */}
+        {/* Hairline rule */}
+        <div
+          style={{
+            width: 96,
+            height: 1,
+            background: "rgba(255,255,255,0.2)",
+            marginTop: 40,
+            marginBottom: 28,
+          }}
+        />
+
+        {/* Differentiator line — three durable claims, no numbers */}
         <span
           style={{
-            fontSize: 16,
-            color: "rgba(255,255,255,0.3)",
-            marginTop: 40,
+            display: "flex",
+            fontSize: 18,
+            color: "rgba(255,255,255,0.55)",
             fontFamily: "sans-serif",
-            letterSpacing: "0.05em",
+            letterSpacing: "0.04em",
+            textAlign: "center",
           }}
         >
-          100+ sources &middot; 10 categories &middot; Updated every 10 min
+          Civic context &middot; Cross-spectrum framing &middot; The money behind each story
         </span>
       </div>
     ),

--- a/app/org/[slug]/page.tsx
+++ b/app/org/[slug]/page.tsx
@@ -19,9 +19,25 @@ export async function generateMetadata({
   const { slug } = await params;
   const org = await getOrgBySlug(slug);
   if (!org) return { title: "Organization not found" };
+
+  // Per-route metadata override so shared org-dossier links carry the
+  // org's name in the unfurl card. og:image inherits the site default
+  // for now; per-route images are a Phase 2 polish.
+  const fullTitle = `${org.name} — Org dossier | Sift`;
+  const description = `Type, funding, political lean, and FARA disclosure for ${org.name} on Sift.`;
   return {
     title: `${org.name} — Org dossier`,
-    description: `Type, funding, political lean, and FARA disclosure for ${org.name} on Sift.`,
+    description,
+    openGraph: {
+      title: fullTitle,
+      description,
+      type: "profile",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: fullTitle,
+      description,
+    },
   };
 }
 

--- a/app/outlet/[slug]/page.tsx
+++ b/app/outlet/[slug]/page.tsx
@@ -21,9 +21,24 @@ export async function generateMetadata({
   const { slug } = await params;
   const outlet = await getOutletBySlug(slug);
   if (!outlet) return { title: "Outlet not found" };
+
+  // Per-route metadata override so shared outlet links carry the
+  // outlet's name in the unfurl card.
+  const fullTitle = `${outlet.name} — Outlet dossier | Sift`;
+  const description = `Ownership, funding, bias, and factual-reporting context for ${outlet.name} on Sift.`;
   return {
     title: `${outlet.name} — Outlet dossier`,
-    description: `Ownership, funding, bias, and factual-reporting context for ${outlet.name} on Sift.`,
+    description,
+    openGraph: {
+      title: fullTitle,
+      description,
+      type: "profile",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: fullTitle,
+      description,
+    },
   };
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
     absolute: "Sift — The news, with footnotes.",
   },
   description:
-    "Sift reads hundreds of sources and adds the footnotes the news assumes you don't need — civic context, cross-spectrum framing, and the money behind every story. Linked to public records. Refreshed every 10 minutes.",
+    "Sift reads from ~50 vetted outlets across the political spectrum and adds the civic context, cross-spectrum framing, and money trail the news assumes you already know. Every claim links to a public record.",
 };
 
 // ISR: re-render at most once every 10 minutes — same heartbeat as the

--- a/app/politician/[bioguide]/page.tsx
+++ b/app/politician/[bioguide]/page.tsx
@@ -20,9 +20,29 @@ export async function generateMetadata({
   const { bioguide } = await params;
   const politician = await getPoliticianByBioguide(bioguide);
   if (!politician) return { title: "Politician not found" };
+
+  // Per-route metadata override so shared dossier links carry the
+  // politician's name, not the homepage's generic title. og:image still
+  // inherits the homepage OG — route-specific images are a Phase 2 polish.
+  const partyState =
+    politician.party && politician.state
+      ? ` (${politician.party}-${politician.state})`
+      : "";
+  const fullTitle = `${politician.name}${partyState} — Politician dossier | Sift`;
+  const description = `Committees, top industries by PAC contributions, and voting context for ${politician.name} on Sift.`;
   return {
     title: `${politician.name} — Politician dossier`,
-    description: `Committees, top industries by PAC contributions, and voting context for ${politician.name} on Sift.`,
+    description,
+    openGraph: {
+      title: fullTitle,
+      description,
+      type: "profile",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: fullTitle,
+      description,
+    },
   };
 }
 

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -350,7 +350,7 @@ export const COPY = {
     compareCta: "Compare any topic",
     // Source colophon.
     colophonHeading: "Read from",
-    colophonSummary: "~50 vetted outlets \u00b7 across the political spectrum \u00b7 refreshed every 10 minutes",
+    colophonSummary: "~50 vetted outlets \u00b7 across the political spectrum \u00b7 refreshed every 30 minutes",
     // Footer colophon link.
     colophonLink: "Colophon",
   },


### PR DESCRIPTION
## Summary
Three convergent problems on what \`siftnews.kristenmartino.ai\` looks like when shared.

### 1. The OG image is launch-day stale
| Element | Was | Should be |
|---|---|---|
| Tagline | "AI-Curated News, Already Read for You" | "The news, with footnotes." *(matches \`COPY.header.tagline\`)* |
| Stats | "100+ sources · Updated every 10 min" | ~58 feeds; pipeline runs every 30 min (was bumped to cut spend 66%) |
| Positioning | "AI-Curated News" | The civic-literacy differentiator |

Rebuilt: same dark background + indigo diamond, but the wordmark is now followed by the live tagline and a **differentiator subhead** ("Civic context · Cross-spectrum framing · The money behind each story") that doesn't go stale because there are no numbers in it.

### 2. Every sub-page inherits the homepage OG card
\`/politician/S000148\` had Schumer in \`<title>\` and \`<meta name="description">\` but **\`og:title\` / \`og:image\` came from the homepage default in \`app/layout.tsx\`**. Twitter/Slack/iMessage all use \`og:*\`, so the unfurl card said "Sift — The news, with footnotes" with the generic image even when linked to Schumer.

Fixed: per-route \`generateMetadata\` now sets \`openGraph\` and \`twitter\` blocks for:
- \`/politician/[bioguide]\` → "Chuck Schumer (D-NY) — Politician dossier | Sift"
- \`/org/[slug]\` → "Federal Communications Commission — Org dossier | Sift"
- \`/bill/[id]\` → "H.R. 5376 (Inflation Reduction Act of 2022) — Sift"
- \`/outlet/[slug]\` → "Reuters — Outlet dossier | Sift"
- \`/civic\` → "Civic dossiers — Sift"

Image still inherits the global Sift card. Per-route dynamic OG images are a deliberate Phase 2 polish.

### 3. The same stale facts hide in three more places
Caught while looking — same "10 minutes" and "100+ sources" claims plus an awkward "you don't need" parse problem:
- \`app/page.tsx\` — homepage meta description
- \`app/colophon/page.tsx\` — "100+ sources … every 10 minutes"
- \`lib/copy.ts\` — \`colophonSummary\` rendered in home-page footer

All three updated to ~50 outlets / 30 minutes / unified framing.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] 315 jest tests pass
- [ ] CI \`Type Check & Test\` green
- [ ] After deploy: spot-check unfurl at opengraph.xyz or by sharing the link in a private Slack — should show "Chuck Schumer..." on a dossier link, not the generic Sift card

🤖 Generated with [Claude Code](https://claude.com/claude-code)