### PR TITLE
fix(mobile): stack external-link rows + bump chip tap target

### DIFF
--- a/components/bill/BillDossier.tsx
+++ b/components/bill/BillDossier.tsx
@@ -207,9 +207,14 @@ export default function BillDossier({ bill, sponsor }: BillDossierProps) {
             </p>
             <ul className="space-y-2.5">
               {externalLinkEntries.map(({ key, url, label }) => (
+                // Stacked label-above-link on mobile; side-by-side on md+.
+                // The 200px fixed label column makes long URLs unreadable
+                // at 375px (only ~100px left for the URL after padding +
+                // gap), so on mobile we let the URL get the full width
+                // and put the small-caps label on its own line above.
                 <li
                   key={key}
-                  className="grid grid-cols-[200px_1fr] gap-x-6 items-baseline border-b border-[var(--border-subtle)] pb-2.5"
+                  className="flex flex-col gap-y-1 md:grid md:grid-cols-[200px_1fr] md:gap-y-0 md:gap-x-6 md:items-baseline border-b border-[var(--border-subtle)] pb-2.5"
                 >
                   <span className="font-body text-outlet uppercase tracking-wider text-[var(--text-muted)]">
                     {label}

--- a/components/glossary/EntityLinksList.tsx
+++ b/components/glossary/EntityLinksList.tsx
@@ -61,7 +61,13 @@ export default function EntityLinksList({ links }: EntityLinksListProps) {
                 href={entityHref(link)}
                 onClick={(e) => e.stopPropagation()}
                 aria-label={`${entityTypeLabel(link.type)}: ${link.surfaceForm}. Open dossier.`}
-                className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[12px] no-underline transition-colors duration-200 relative z-[2] border border-[var(--border)] text-[var(--text-secondary)] bg-[var(--card-bg)] hover:border-[var(--accent)] hover:text-[var(--accent)]"
+                // Touch-target note: py-1.5 + 12px line-height + border = ~32px
+                // visible height on mobile, which is still under the 44px
+                // Apple HIG recommendation but materially better than the
+                // 22-24px the chip had originally. Side padding bumped from
+                // px-2 to px-2.5 for the same reason. Visual weight stays
+                // small enough to read as a "chip" not a "button."
+                className="inline-flex items-center gap-1.5 px-2.5 py-1.5 sm:py-0.5 rounded-full text-[12px] leading-none no-underline transition-colors duration-200 relative z-[2] border border-[var(--border)] text-[var(--text-secondary)] bg-[var(--card-bg)] hover:border-[var(--accent)] hover:text-[var(--accent)]"
               >
                 {glyph && (
                   <span

--- a/components/org/OrgDossier.tsx
+++ b/components/org/OrgDossier.tsx
@@ -170,9 +170,11 @@ export default function OrgDossier({ org }: OrgDossierProps) {
             </p>
             <ul className="space-y-2.5">
               {externalLinkEntries.map(({ key, url, label }) => (
+                // See BillDossier for the same pattern + rationale —
+                // stack on mobile so long URLs aren't crammed into ~100px.
                 <li
                   key={key}
-                  className="grid grid-cols-[200px_1fr] gap-x-6 items-baseline border-b border-[var(--border-subtle)] pb-2.5"
+                  className="flex flex-col gap-y-1 md:grid md:grid-cols-[200px_1fr] md:gap-y-0 md:gap-x-6 md:items-baseline border-b border-[var(--border-subtle)] pb-2.5"
                 >
                   <span className="font-body text-outlet uppercase tracking-wider text-[var(--text-muted)]">
                     {label}

--- a/components/outlet/OutletDossier.tsx
+++ b/components/outlet/OutletDossier.tsx
@@ -208,9 +208,11 @@ export default function OutletDossier({
             </p>
             <ul className="space-y-2.5">
               {externalLinkEntries.map(({ key, url, label }) => (
+                // Stack on mobile so long URLs aren't crammed into the
+                // narrow value column at 375px. Side-by-side on md+.
                 <li
                   key={key}
-                  className="grid grid-cols-[180px_1fr] gap-x-6 items-baseline border-b border-[var(--border-subtle)] pb-2.5"
+                  className="flex flex-col gap-y-1 md:grid md:grid-cols-[180px_1fr] md:gap-y-0 md:gap-x-6 md:items-baseline border-b border-[var(--border-subtle)] pb-2.5"
                 >
                   <span className="font-body text-outlet uppercase tracking-wider text-[var(--text-muted)]">
                     {label}

--- a/components/politician/PoliticianDossier.tsx
+++ b/components/politician/PoliticianDossier.tsx
@@ -182,9 +182,12 @@ export default function PoliticianDossier({
             </p>
             <ul className="space-y-2.5">
               {externalLinkEntries.map(({ key, url, label }) => (
+                // See BillDossier for the same pattern + rationale —
+                // stack on mobile so long URLs aren't crammed into the
+                // narrow value column at 375px.
                 <li
                   key={key}
-                  className="grid grid-cols-[160px_1fr] gap-x-6 items-baseline border-b border-[var(--border-subtle)] pb-2.5"
+                  className="flex flex-col gap-y-1 md:grid md:grid-cols-[160px_1fr] md:gap-y-0 md:gap-x-6 md:items-baseline border-b border-[var(--border-subtle)] pb-2.5"
                 >
                   <span className="font-body text-outlet uppercase tracking-wider text-[var(--text-muted)]">
                     {label}


### PR DESCRIPTION
## Summary
Code-and-spec audit of every dossier route at 375px viewport (iPhone 13 mini) turned up two real usability issues:

### 1. Dossier external-link grids cram URLs into ~100-150px
All four dossier types render "Where to read more" as a fixed grid:

| Dossier | Grid |
|---|---|
| Bill | \`grid-cols-[200px_1fr]\` |
| Org | \`grid-cols-[200px_1fr]\` |
| Outlet | \`grid-cols-[180px_1fr]\` |
| Politician | \`grid-cols-[160px_1fr]\` |

At 375px with page padding + grid gap, that leaves ~100-150px for the URL. Long URLs got truncated to stubs:

\`\`\`
PROPUBLICA      https://projects.propubli…
\`\`\`

Fix: same pattern \`ComparisonDemo.tsx\` already uses — stack on mobile, grid on \`md:\`:

\`\`\`
flex flex-col gap-y-1
md:grid md:grid-cols-[XXXpx_1fr] md:gap-y-0 md:gap-x-6 md:items-baseline
\`\`\`

Mobile: label on its own row above the URL, URL at full width.
Desktop: unchanged.

### 2. Entity chips had ~24px tap target
\`EntityLinksList\` chips used \`px-2 py-0.5 text-[12px]\` which renders as a 22-24px visible chip — below Apple HIG (44px) and Google's M3 (48dp).

Bump to \`px-2.5 py-1.5 sm:py-0.5 leading-none\`. ~32px tap target on mobile (still under 44 but materially better), original tight register at \`sm:\` and up so the desktop chip rail doesn't bloat.

\`sm:\` breakpoint matches the article-grid breakpoint (where it goes from single to multi-column), so chip register tracks surface density at every viewport.

## Out of scope (acknowledged, deferred)
The \`EntityChipTooltip\` hover-reveal still only works on desktop. Mobile users get the full dossier on tap, which is strictly more info than the inline tooltip — that was the deliberate trade-off when shipping #89. Touch-specific tap-to-toggle would need client state and conflict with the "tap = navigate" expectation.

## Verification
- \`npx tsc --noEmit\` clean
- 315 jest tests pass
- **Vercel preview at 375x812** — the Preview MCP iframe was sandboxed and couldn't navigate to localhost; this PR relies on the Vercel preview URL for visual verification once CI lands.

## Files
- \`components/bill/BillDossier.tsx\`
- \`components/org/OrgDossier.tsx\`
- \`components/outlet/OutletDossier.tsx\`
- \`components/politician/PoliticianDossier.tsx\`
- \`components/glossary/EntityLinksList.tsx\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)