### PR TITLE
feat(primer): instrument panel-expand clicks (Phase 1)

### DIFF
--- a/app/api/primer/expand/route.ts
+++ b/app/api/primer/expand/route.ts
@@ -1,0 +1,92 @@
+/**
+ * POST /api/primer/expand — record a panel-expand click.
+ *
+ * Phase 1 primer-funnel instrumentation. The "What you should know
+ * first" panel has had three rounds of content iteration with zero
+ * signal on whether anyone opens it. This route is the dark-vision
+ * gear: every expand fires once; aggregations let us see the rate.
+ *
+ * Request shape (JSON):
+ *   { articleId?: string, surface?: 'feed' | 'bookmarks' }
+ *
+ * Response: 204 on success; 4xx on bad input; never blocks user
+ * experience (client fires-and-forgets).
+ *
+ * Privacy posture mirrors /api/news/topic (search analytics):
+ *   - IPs HMAC-hashed via shared SEARCH_IP_SECRET, never raw
+ *   - session_id read from x-sift-session-id header (localStorage)
+ *   - UA classified to mobile|desktop|bot|unknown
+ *   - Rate-limited per IP + globally to prevent abuse
+ */
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  classifyUserAgent,
+  extractClientIp,
+  hashIp,
+  isLoggingEnabled,
+} from "@/lib/searchAnalytics";
+import { logPrimerExpand } from "@/lib/primerAnalyticsLog";
+import { rateLimit } from "@/lib/rate-limit";
+
+const VALID_SURFACES = new Set(["feed", "bookmarks"]);
+
+export async function POST(request: NextRequest) {
+  // Kill switch: if analytics are disabled (env var), 204 silently.
+  // Don't tell the client; the UI doesn't care either way.
+  if (!isLoggingEnabled()) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  // Rate limit: ~one expand per second per IP is more than humanly
+  // reasonable. Global cap prevents a single client from exhausting
+  // the global rate budget. Same posture as /api/news/topic.
+  const rawIp = extractClientIp(request.headers);
+  const ip = rawIp ?? "unknown";
+  const perIp = rateLimit(`primer-expand:${ip}`, {
+    maxRequests: 60,
+    windowMs: 60_000,
+  });
+  const global = rateLimit("primer-expand:global", {
+    maxRequests: 600,
+    windowMs: 60_000,
+  });
+  if (!perIp.allowed || !global.allowed) {
+    const retryMs = Math.max(perIp.retryAfterMs, global.retryAfterMs);
+    return NextResponse.json(
+      { error: "Too many requests" },
+      { status: 429, headers: { "Retry-After": String(Math.ceil(retryMs / 1000)) } },
+    );
+  }
+
+  let body: { articleId?: unknown; surface?: unknown } = {};
+  try {
+    body = await request.json();
+  } catch {
+    // Empty body is fine — we still log the event with null fields.
+  }
+
+  const articleId =
+    typeof body.articleId === "string" && body.articleId.length <= 64
+      ? body.articleId
+      : null;
+  const surface =
+    typeof body.surface === "string" && VALID_SURFACES.has(body.surface)
+      ? body.surface
+      : null;
+  const sessionId = request.headers.get("x-sift-session-id");
+  const userAgent = request.headers.get("user-agent");
+
+  // Fire-and-forget INSERT. `await` so we surface server-side failures
+  // (vs background-promise leaks), but the function itself never
+  // throws — failures are caught + logged inside.
+  await logPrimerExpand({
+    articleId,
+    surface,
+    sessionId,
+    ipHash: hashIp(rawIp),
+    userAgentClass: classifyUserAgent(userAgent),
+  });
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -64,6 +64,17 @@ export default function PrivacyPage() {
           </section>
 
           <section>
+            <h2 className="font-heading text-lg font-bold text-[var(--text)] mb-2">Primer-panel analytics</h2>
+            <p>
+              When you open the &quot;What you should know first&quot; panel on an article card,
+              we log a single anonymous event with the article id, a coarse user-agent class,
+              an anonymous session id, and an HMAC-hashed IP (never raw). We do this to
+              understand whether the panel is being read so we know whether to keep investing
+              in it. Same <strong>90-day retention</strong> as search analytics.
+            </p>
+          </section>
+
+          <section>
             <h2 className="font-heading text-lg font-bold text-[var(--text)] mb-2">Your rights</h2>
             <p>
               You can delete your account and all associated data by contacting us. Local storage

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -207,6 +207,8 @@ export default function ArticleCard({
           <BackgroundPrimer
             primer={article.contextPrimer}
             defaultExpanded={!!featured}
+            articleId={article.id}
+            surface="feed"
           />
         )}
 

--- a/components/primer/BackgroundPrimer.tsx
+++ b/components/primer/BackgroundPrimer.tsx
@@ -15,6 +15,16 @@ interface BackgroundPrimerProps {
    * in this first cut — Phase 1C just renders the affordance.
    */
   defaultExpanded?: boolean;
+  /**
+   * Optional article id + surface for Phase 1 primer-expand instrumentation.
+   * When both are present, the first user-initiated expand fires a single
+   * fire-and-forget POST to /api/primer/expand so we can measure how often
+   * anyone actually opens the panel. Default-expanded cards (e.g. featured
+   * hero) do NOT count as user expands — we only fire on the click that
+   * flips state from collapsed → expanded.
+   */
+  articleId?: string;
+  surface?: "feed" | "bookmarks";
 }
 
 /**
@@ -40,6 +50,8 @@ interface BackgroundPrimerProps {
 export default function BackgroundPrimer({
   primer,
   defaultExpanded = false,
+  articleId,
+  surface,
 }: BackgroundPrimerProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
 
@@ -48,15 +60,33 @@ export default function BackgroundPrimer({
   const { background, terms } = primer;
   if (!background && terms.length === 0) return null;
 
+  // Fire-and-forget analytics POST when the user-initiated click flips
+  // state collapsed → expanded. Skipped on the auto-expanded path (e.g.
+  // featured hero card) since that's not a user action. Failure is
+  // swallowed; the UI flips state either way.
+  const handleExpand = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setExpanded(true);
+    if (articleId) {
+      // Body is null-safe — surface omitted is fine (server logs null).
+      fetch("/api/primer/expand", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ articleId, ...(surface ? { surface } : {}) }),
+        // Keep the request lightweight; no need to wait, no need to retry.
+        keepalive: true,
+      }).catch(() => {
+        /* analytics is best-effort; ignore */
+      });
+    }
+  };
+
   return (
     <div className="my-1 relative z-[2]">
       {!expanded && (
         <button
           type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            setExpanded(true);
-          }}
+          onClick={handleExpand}
           aria-expanded={false}
           className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-bold tracking-[0.04em] uppercase border border-[var(--border)] bg-transparent text-[var(--text-secondary)] hover:text-[var(--text)] hover:border-[var(--text-muted)] transition-colors duration-200 cursor-pointer"
         >

--- a/lib/primerAnalyticsLog.ts
+++ b/lib/primerAnalyticsLog.ts
@@ -1,0 +1,64 @@
+/**
+ * DB-touching half of primer-expand instrumentation. Kept separate from
+ * the route + client wiring so server-only Node APIs (crypto/HMAC, pg)
+ * never leak into the client bundle.
+ *
+ * `logPrimerExpand` is fire-and-forget — failure is logged here and
+ * never propagates. The user's expand experience always completes.
+ *
+ * See lib/searchAnalytics.ts for the matching helpers (hashIp,
+ * classifyUserAgent, isLoggingEnabled). We reuse them as-is so the
+ * privacy posture stays consistent across both analytics tables.
+ */
+import pool from "./db";
+import { isLoggingEnabled } from "./searchAnalytics";
+
+export interface PrimerExpandRow {
+  articleId: string | null;
+  surface: string | null;          // 'feed' | 'bookmarks' | future
+  sessionId: string | null;
+  ipHash: string | null;
+  userAgentClass: string | null;
+}
+
+/**
+ * Insert one row into `primer_expand_events`. Returns the row's id on
+ * success; null on disabled-by-flag, missing-table, or any other failure.
+ *
+ * Tolerates "table does not exist" gracefully — sift can deploy before
+ * the sift-api migration lands without breaking primer behavior.
+ */
+export async function logPrimerExpand(
+  row: PrimerExpandRow,
+): Promise<string | null> {
+  if (!isLoggingEnabled()) return null;
+  try {
+    const result = await pool.query<{ id: string }>(
+      `INSERT INTO primer_expand_events
+        (article_id, surface, session_id, ip_hash, user_agent_class)
+       VALUES ($1,$2,$3,$4,$5)
+       RETURNING id`,
+      [
+        row.articleId,
+        row.surface,
+        row.sessionId,
+        row.ipHash,
+        row.userAgentClass,
+      ],
+    );
+    return result.rows[0]?.id ?? null;
+  } catch (err) {
+    const msg = String(err);
+    if (
+      msg.includes("primer_expand_events") &&
+      msg.includes("does not exist")
+    ) {
+      console.warn(
+        "primer_expand_events table not yet provisioned; skipping insert",
+      );
+      return null;
+    }
+    console.warn("logPrimerExpand failed:", err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
Companion to **sift-api #52** (the parallel \`primer_expand_events\` table). This PR wires the actual INSERT plus a privacy-page section.

After three rounds of primer-content work (#48 prompt tighten, #90 term-link, #91/#46 agency dossiers + linker upgrades) we still have **no signal on whether anyone opens the panel**. The next decision — keep iterating on primer content vs stop and move on — depends on one number: expand rate per primer impression. Without this PR that decision is a guess.

## Architecture (reuses the search-analytics posture)
| Piece | Location | Notes |
|---|---|---|
| Pure helpers | \`lib/searchAnalytics.ts\` (existing) | hashIp, classifyUserAgent, isLoggingEnabled, extractClientIp — reused |
| DB INSERT | \`lib/primerAnalyticsLog.ts\` (NEW) | Mirrors \`searchAnalyticsLog.ts\`; tolerates missing table |
| Endpoint | \`app/api/primer/expand/route.ts\` (NEW) | POST, rate-limited, JSON body \`{ articleId?, surface? }\`, 204 on success |
| UI fire | \`components/primer/BackgroundPrimer.tsx\` | \`keepalive: true\` fire-and-forget on the collapsed→expanded click; default-expanded cards do NOT fire (not a user action) |
| Threading | \`components/ArticleCard.tsx\` | Passes \`article.id\` + \`surface=\"feed\"\` down |

## Privacy posture
Identical to search analytics (#92):
- IP hashed via shared \`SEARCH_IP_SECRET\` HMAC-SHA256 — never raw
- 90-day retention via \`scripts/cleanup_old_primer_events.py\` in sift-api
- \`session_id\` is localStorage UUID, not a cookie
- Kill switch: \`SEARCH_LOGGING_ENABLED=false\`
- New \`/privacy\` section spells this out

## Rate limits
- 60/min/IP, 600/min/global. A single user clicking "Show context" 60+ times in a minute is either testing or a bot.
- 429 with \`Retry-After\` on overflow.

## Endpoint validation
- \`surface\` against an allow-list of [\`feed\`, \`bookmarks\`]
- \`articleId\` length ≤ 64 chars
- Anything else → field stored as null, event still logged so we don't lose volume signal

## Deploy order
**sift-api #52 must merge FIRST** (table must exist). This PR can ship any time after; if it runs against a DB without the table, \`logPrimerExpand\` hits the "does not exist" branch and skips silently.

## What we'll learn in 7-14 days
- **Expand rate** — does anyone open the panel at all?
- **By UA class** — does mobile expand more or less than desktop?
- **Per-article rollups** — do politics articles get opened more than entertainment?
- **Decision tree:**
  | If expand rate is… | Then… |
  |---|---|
  | <5% | Stop iterating on primer content; possibly remove the panel |
  | 5-20% | Keep current quality, don't over-invest |
  | >20% | Real signal; investments justify themselves; consider primer-term-click tracking next |

## Tests
315 pass. No new tests this round — pure helpers are already covered by \`__tests__/searchAnalytics.test.ts\`; logPrimerExpand mirrors logSearchQuery exactly. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)