### PR TITLE
chore: realign Sift copy and docs around civic-literacy framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,25 @@ Browser --> Vercel (Next.js) --reads--> Neon Postgres (pgvector)
 - **sift-api**: Python FastAPI + LangGraph on Railway — background pipeline + comparison workflow
 - **Database**: Neon Postgres (pgvector) — shared source of truth
 
-## Features (current)
+## Civic-literacy layer (what makes Sift Sift)
 
-- **10 categories**: Top, Technology, Business, Science, Energy, World, Health, Politics, Sports, Entertainment
-- **AI summaries**: Every article summarized by Claude Haiku 4.5
-- **Topic search**: Vector similarity (Voyage AI embeddings + pgvector), SSE streaming, Claude web search fallback
-- **Multi-source comparison**: LangGraph workflow — fan-out web search across outlets, extract claims, compare
-- **Bookmarks**: localStorage + Clerk server sync
-- **Dark/light themes**: "Late Edition" (dark) and "Newsprint" (light) with warm editorial tones
-- **SiftLogo**: Diamond mark brand identity across all touchpoints
-- **Auth**: Clerk (free to 10K MAU)
+- **Civic dossiers**: every politician, organization, bill, and outlet in an article links to a structured dossier — committee assignments, top industries by PAC contributions, ownership, funding, FARA registration, voting records, AllSides + MBFC ratings. Sourced from OpenSecrets, GovTrack, ProPublica Nonprofit Explorer, FARA, Vote Smart, and FEC. Citations on every page.
+- **Inline glossary**: civic terms surface contextually inside the article — defined where the reader needs them, in the language they need.
+- **Adaptive primers**: *"What you should know first"* + key terms, AI-generated at ingest. Expands when a story sits on top of complex policy.
+- **Cross-spectrum framing**: how outlets across left / center / right framed the same story. Sift surfaces AllSides + MBFC ratings verbatim — never computes its own.
+- **Methodology**: source curation policy and symmetric-application rules public at `/methodology`.
+- **Civic dossier index**: searchable, filterable view of curated politicians, organizations, and bills at `/civic`.
 
-## Features (civic-literacy MVP, in progress — see plan)
+## Foundation (the reader surface)
 
-- **Background primer**: *"What you should know first"* + 3–5 term definitions, AI-generated at ingest
-- **Cross-spectrum comparison**: how outlets across left / center / right framed the same story, with AllSides + MBFC ratings shown for each outlet
-- **Reading-level adjuster**: Simpler / Standard / Detailed slider, Claude-rewritten and cached
-- **Inline glossary with financial AND political context**: hover any entity (outlet, politician, think tank, pundit, bill) for an externally-sourced dossier — ownership, donors, voting records, foreign funding (FARA), interest-group ratings. All linked to AllSides, MBFC, OpenSecrets, GovTrack, ProPublica Nonprofit Explorer, FARA, Vote Smart, and FEC
-- **Methodology**: source curation policy and symmetric-application rules public at `/methodology`
+- **10 categories**: Top, Technology, Business, Science, Energy, World, Health, Politics, Sports, Entertainment.
+- **AI summaries**: every article summarized by Claude Haiku 4.5 in the background pipeline — user requests never touch Claude.
+- **Topic search**: vector similarity (Voyage AI embeddings + pgvector), SSE streaming, Claude web-search fallback for niche queries.
+- **Multi-source comparison**: LangGraph workflow — fan-out search across outlets, extract claims, compare. Described, not labeled.
+- **Bookmarks**: localStorage + Clerk server sync.
+- **Dark/light themes**: "Late Edition" (dark) and "Newsprint" (light) with warm editorial tones.
+- **SiftLogo**: diamond mark brand identity across all touchpoints.
+- **Auth**: Clerk (free to 10K MAU).
 
 ## Quick start
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,40 +1,40 @@
 # Sift — Product Requirements Document
 
-**Version:** 2.1
-**Date:** March 31, 2026
+**Version:** 3.0 (civic-literacy)
+**Date:** May 18, 2026
 **Author:** Martino
 **Domain:** siftnews.kristenmartino.ai
-**Status:** Production live
+**Status:** Production live; civic-literacy MVP shipped, in iteration
 
 ---
 
 ## Vision
 
-Sift is a news reader where AI does the reading for you. Open it, see the top stories across 10 categories, each with a concise summary written for comprehension — not a headline written for clicks. Search any topic, compare coverage across outlets. Close it. 60 seconds. That's the experience.
+**Read the news with civic footnotes.** Sift is a news reader where every politician, organization, bill, and political term in an article links to a plain-English explainer — sourced from public records, threaded into the reading flow. Open it, read a story, click any entity, get the dossier that wasn't in the article. For people who want to follow what's happening without already knowing the players.
 
 ## Value proposition
 
-**For users:** "Open Sift. In 60 seconds, know what's happening across 10 categories — tech, business, science, energy, world, health, politics, sports, entertainment, and curated top stories. Search any topic. Compare how different outlets cover the same story. Every summary is AI-written."
+**For readers:** Open Sift. Read a story about a Senate vote. Click any name — senator, lobbying group, bill — and get who they are, what they've done, and what they want. Sourced from public records. *Read the headline; learn the civics as you go.*
 
-**For hiring managers:** "I built a hybrid AI system from 0 to 1: Next.js frontend on Vercel, Python/LangGraph backend on Railway, Neon Postgres with pgvector, background content pipeline with 100+ RSS feeds, multi-source comparison via fan-out web search, topic search via vector similarity with SSE streaming — all for ~$9/month."
+**For hiring managers:** I built a civic-literacy news product end-to-end — Next.js + Postgres frontend on Vercel, Python FastAPI + LangGraph backend on Railway, civic dossier graph over Postgres entity tables, scheduled AI pipeline that does the analytical work off the user's critical path. Live latency stays under 100ms because the AI moved to a background pipeline that writes to Postgres; the frontend is a database read.
 
 ---
 
 ## What makes Sift different
 
-1. **AI summaries from RSS feeds** — not raw publisher descriptions, not chatbot Q&A. A curated reading experience.
-2. **Custom topics via vector search** — type anything, get instant results from a pre-built article index. Falls back to Claude web_search for niche queries.
-3. **Multi-source comparison** — see how Reuters, BBC, and AP covered the same story, with agreements and disputes identified.
-4. **Background pipeline** — content is always fresh. User requests are pure database reads. No loading spinners.
-5. **Domain-specific coverage** — Energy category with grid, renewables, utilities, NextEra, FPL coverage that no mainstream aggregator provides.
+1. **Civic dossiers, not just summaries.** Every politician, organization, bill, and news outlet has a structured page sourced from public records (OpenSecrets, GovTrack, ProPublica Nonprofit Explorer, FARA, FEC, Vote Smart). News stories link out to them inline.
+2. **Inline glossary that respects the reader.** Civic terms surface contextually inside the article — not in a separate panel. Defined where the reader needs them, in the language they need.
+3. **Adaptive primers for complex policy.** When a story sits on top of complex policy (the Inflation Reduction Act, debt-ceiling mechanics, FTC consent decrees), the primer expands to fit what the reader needs.
+4. **Cross-spectrum framing, observed not labeled.** When multiple outlets cover the same story, Sift shows what each chose to emphasize. AllSides political-lean and MBFC factual-reporting ratings shown verbatim — Sift never computes its own. The reader does the interpretation; the product does the legwork.
+5. **AI off the critical path.** Earlier versions did live click-time generation and ran 15+ seconds per category load. Sift moved the AI to a background pipeline that writes enriched content to Postgres. User requests are pure database reads — ~50ms.
 
 ---
 
 ## Target users
 
-1. **Primary:** Professionals who want a morning news scan across multiple domains in 60 seconds
-2. **Secondary:** People interested in niche topics (energy/utilities, AI policy) underserved by mainstream aggregators
-3. **Tertiary:** Hiring managers evaluating AI engineering skills
+1. **Primary:** Engaged citizens who follow politics but don't already know who every senator, lobbying body, or think tank is — and want to. The "I read the news and feel like I'm missing context" reader.
+2. **Secondary:** Civic-literacy educators, journalists, and policy folks who need quick context on the players and history behind a story.
+3. **Tertiary:** Hiring managers evaluating product, design, and engineering judgment.
 
 ---
 
@@ -42,111 +42,74 @@ Sift is a news reader where AI does the reading for you. Open it, see the top st
 
 Two services, one database:
 
-- **Next.js on Vercel** — frontend, API routes (Postgres reads), Clerk auth, SSE streaming
-- **Python FastAPI + LangGraph on Railway** — background pipeline (RSS → Claude → Voyage → Postgres), multi-source comparison, asyncio scheduler
-- **Neon Postgres + pgvector** — single source of truth for articles, embeddings, custom topics, bookmarks
+- **Next.js on Vercel** — frontend, API routes (Postgres reads), Clerk auth, civic dossier pages, methodology page, SSE streaming for topic search.
+- **Python FastAPI + LangGraph on Railway** — background pipeline: primer generation, entity extraction, entity linking to dossiers, summarization, story synthesis, story clustering, civic context generation, batched API client, cross-source comparison workflow, usage tracking.
+- **Neon Postgres + pgvector** — single source of truth for articles, embeddings, entity dossiers, bookmarks.
 
-Content pipeline runs every 10 minutes via Railway's background scheduler. User requests never touch Claude — they read from Postgres in <50ms.
+Pipeline runs every 10 minutes via asyncio scheduler on Railway. User requests never touch Claude — they read from Postgres in <50ms.
 
-Total cost: ~$9/month.
-
-Full technical details: SIFT_ARCHITECTURE_v2.md and SIFT_TECHNICAL_SPEC.md.
+Full technical details: `ARCHITECTURE.md` and `TECHNICAL_SPEC.md`.
 
 ---
 
 ## Feature specification
 
-### Tier 0 — Ship blockers (Week 1-2)
+### Foundation (the reader surface — shipped)
 
-| ID | Feature | Effort |
+| ID | Feature |
+|---|---|
+| F1 | 10-category news feed (Top, Tech, Business, Science, Energy, World, Health, Politics, Sports, Entertainment) |
+| F2 | AI article summaries in the background pipeline (Claude Haiku 4.5) |
+| F3 | Topic search via vector similarity (Voyage AI + pgvector) with SSE streaming + Claude web-search fallback |
+| F4 | Multi-source comparison (LangGraph fan-out → claim extraction → side-by-side framing) |
+| F5 | Bookmarks (localStorage + Clerk server sync) |
+| F6 | Dark/light themes ("Late Edition" / "Newsprint") |
+| F7 | Auth (Clerk, free to 10K MAU) |
+| F8 | Landing page + methodology page |
+| F9 | SiftLogo brand mark across touchpoints |
+
+### Civic-literacy layer (shipped + in iteration)
+
+| ID | Feature | Status |
 |---|---|---|
-| S0 | Postgres schema + migrations | 2 hr |
-| S1 | Python FastAPI service scaffold on Railway | 3 hr |
-| S2 | LangGraph pipeline workflow (RSS → Claude → Voyage → store) | 6 hr |
-| S3 | RSS feed integration (100+ feeds, 10 categories) | 4 hr |
-| S4 | Next.js API routes rewrite (Postgres reads) | 3 hr |
-| S5 | Card redesign — text-first + RSS images | 3 hr |
-| S6 | Vercel Cron configuration | 30 min |
-| S7 | Clerk auth integration | 1 hr |
+| C1 | Background primer — *"What you should know first"* + key terms, AI-generated at ingest | Shipped |
+| C2 | Inline glossary — civic terms surface contextually inside articles, with chip tooltips and dossier click-through | Shipped (Phase 3.G + 3.H) |
+| C3 | Politician dossiers — committee assignments, top industries by PAC contributions, interest-group ratings, external links to GovTrack / OpenSecrets / Vote Smart / Ballotpedia / Wikipedia | Shipped (Phase 3.C) |
+| C4 | Organization dossiers — political lean, finances, major funders, FARA registration, external links to ProPublica Nonprofit Explorer / IRS 990 / FARA / official site | Shipped (Phase 3.D) |
+| C5 | Bill dossiers — status, sponsor, cosponsors, lobbying spend, external links to GovTrack / Congress.gov / OpenSecrets | Shipped (Phase 3.E) |
+| C6 | Outlet dossiers — ownership, funding, AllSides political-lean rating, MBFC factual-reporting rating, recent stories | Shipped (Phase 2.B + 2.C) |
+| C7 | Cross-spectrum compare — three-bucket (L / C / R) framing comparison, AllSides-rated | Shipped (Phase 2.C.2) |
+| C8 | Civic dossier index — searchable, filterable, all entity types | Shipped (Phase 3.I) |
+| C9 | Reading-level adjuster — Simpler / Standard / Detailed slider, Claude-rewritten and cached | In design |
+| C10 | Primer expansion instrumentation — measure what users actually expand | In progress |
+| C11 | Per-paragraph primer triggering — surface primers in the reading flow, not above the fold | Next |
 
-### Tier 1 — Core product (Week 2-3)
+### Non-goals
 
-| ID | Feature | Effort |
-|---|---|---|
-| T1 | Custom topics — vector search + fallback | 6 hr |
-| T2 | SSE streaming for article delivery | 4 hr |
-| T3 | LangGraph comparison workflow | 6 hr |
-| T4 | Bookmarks synced to Postgres (via Clerk user ID) | 2 hr |
-| T5 | Landing page at siftnews.kristenmartino.ai | 4 hr |
-
-### Tier 2 — Differentiation (Week 3-4)
-
-| ID | Feature | Effort |
-|---|---|---|
-| T6 | Morning briefing — single paragraph top 3 stories | 3 hr |
-| T7 | "Why this matters" context line per article | 3 hr |
-| T8 | Share article (copy link + native share) | 1 hr |
-| T9 | Trend detection — "this topic appeared 4 of 5 days" | 4 hr |
-| T10 | Favicon + OG image + visual identity | 3 hr |
-
-### Tier 3 — Portfolio showcase (Post-launch)
-
-| ID | Feature | Effort |
-|---|---|---|
-| T11 | Summary customization (ELI5 / Technical / Executive) | 3 hr |
-| T12 | Semantic search across past articles | 4 hr |
-| T13 | Daily digest email | 6 hr |
-| T14 | Reading analytics dashboard | 4 hr |
-| T15 | Multi-language support | 4 hr |
-
----
-
-## Card design
-
-**Mixed layout — RSS images when available, text-first when not.**
-
-Cards with images: image at top, content below. Standard news card pattern.
-
-Cards without images: thin category color accent bar at top (3px, category color), no image area at all. Badge, headline in Playfair Display, AI summary, source metadata. Clean editorial layout.
-
-Both card types coexist in the grid. No gradient fallbacks, no placeholder icons, no OG scraping.
-
----
-
-## Non-goals
-
-- Not a real-time ticker (refreshes every 10-15 min, not live)
-- Not a social platform (no comments, no voting)
-- Not a full-text reader (links to original sources)
-- Not a chatbot (browse, don't interrogate)
+- Not a chatbot interface. Browse, don't interrogate.
+- Not a trust-judgment layer. Sift surfaces AllSides + MBFC ratings verbatim; it does not compute its own.
+- Not a propaganda decoder. (Different product, different corpus, different audience.)
+- Not a real-time ticker. Refreshes every 10–15 minutes.
+- Not a full-text reader. Links to original sources.
+- Not a social platform. No comments, no voting.
 
 ---
 
 ## Competitive landscape
 
-| Product | Sift's advantage |
-|---|---|
-| Google News | Sift provides AI summaries, not just headlines |
-| Apple News | Sift doesn't need publisher deals |
-| Feedly | Sift handles source discovery automatically |
-| Perplexity Daily | Sift is purpose-built for browsing, not search |
-| Hacker News | Sift covers 7 domains + custom topics, with summaries |
+| Product | What it does | Where Sift differs |
+|---|---|---|
+| Apple News / Google News | Aggregates headlines + summaries from publishers | Sift adds civic dossiers + inline glossary + adaptive primers — context the news assumes the reader already has |
+| Perplexity Discover | AI-curated news with web-search-style summaries | Sift is structured around an entity-dossier graph, not a retrieval/chat loop |
+| NewsGuard / AllSides / Ad Fontes | Site-level trust/bias ratings | Sift surfaces those ratings inline (verbatim) and adds entity-level context around them |
+| OpenSecrets / GovTrack / ProPublica | Public-records databases by entity type | Sift threads them together at point-of-reading, so the reader doesn't have to leave the article |
+| Civic-education content (Civics 101, Ground News context blocks) | Standalone civic content | Sift integrates civic context directly into the news reading flow |
 
 ---
 
-## Build sequence
+## Open questions
 
-```
-Week 1:  Python service + Postgres + LangGraph pipeline + RSS
-Week 2:  Next.js rewrite (DB reads) + card redesign + Clerk + SSE
-Week 3:  Comparison workflow + custom topics + landing page
-Week 4:  QA + monitoring + deploy to production + share with 10 people
-```
-
----
-
-## Open questions (for Stark)
-
-1. **Custom topics — what's the UI?** Freeform text field? Suggested topics? Both?
-2. **Comparison — where does it live?** Button on each article? Separate tab? Triggered by detecting the same story across categories?
-3. **Monetization — ever?** Custom topics and comparison could be premium features behind Clerk auth. But this is portfolio-first.
+1. **Glossary scope.** Currently civic-only. Could extend to financial, scientific, or technical terms. Where to draw the line?
+2. **Primer triggering granularity.** Article-level (current) vs. per-paragraph vs. user-paced. Empirical question, needs the instrumentation now landing.
+3. **Dossier coverage.** ~600 sitting members of Congress + curated orgs + landmark bills. Where's the next expansion — historical politicians, state-level, lobbying firms, federal agencies?
+4. **Monetization.** Portfolio-first for now. The structural feature most likely to support paid: research-grade exports (PDF dossier packets, custom briefings) for institutional users.

--- a/docs/PRODUCT_STORY.md
+++ b/docs/PRODUCT_STORY.md
@@ -1,75 +1,66 @@
 # Sift: 0→1 Product Story
 
-## Building an AI-Curated News Aggregator from Concept to Production
+## Civic Literacy in a News Reader — How Sift Found Its Shape
 
 ---
 
-### Situation
+### The bet
 
-The news aggregation market is saturated with products that solve the same problem the same way: pull headlines from RSS feeds or wire services, rank by recency or clicks, and dump them into a reverse-chronological feed. The result is a commodity experience — every app shows the same Reuters and AP stories in roughly the same order. Meanwhile, generative AI had unlocked a fundamentally different approach to content curation — one where an AI model could search the web in real time, evaluate source quality, and synthesize original summaries — but no consumer product had shipped this as the primary content pipeline.
+The news-aggregation market is saturated. Apple News, Google News, Perplexity Discover, every wire-feed reader — they converged on the same shape: pull headlines, summarize, list by recency. I started Sift believing the gap was upstream of the reader: that AI-curated summaries from live web search could deliver three things wire feeds couldn't — broader source diversity, summaries written for comprehension rather than clicks, and topic coverage shaped by structured subtopics rather than editorial choice.
 
-I saw a gap: a lightweight, fast news reader where every article summary is AI-generated from live web search, not regurgitated from syndication feeds. The core thesis was that AI-curated news could deliver three things traditional aggregators couldn't: broader source diversity (the model searches beyond the usual wire services), contextual summaries written for comprehension rather than clicks, and topic coverage shaped by structured subtopics rather than editorial bias.
-
-The constraints were real. I was building solo, funding my own API costs, and targeting a portfolio-ready product that demonstrated both product thinking and hands-on AI engineering. The product needed to work end-to-end — not as a demo, but as something a real user could open daily and get value from.
+That was the hypothesis I wrote into the first PRD. It assumed the bottleneck for serious readers was volume and selection — *more, better, fresher.* I built v1 around it: AI summaries from Claude's web-search tool, 7 categories, 100+ feeds, all generated live at click time.
 
 ---
 
-### Task
+### The test
 
-Design, build, and ship a production-grade news aggregator that uses Claude's web search capability as the primary content engine. Specifically:
+The prototype shipped. The architecture got harder than I expected. Claude's web-search tool refused to format results as rigid JSON, so I reframed the prompt from data extraction to summarization — the model could "summarize the top five stories you found" but not "return a JSON array of search snippets." I built a three-strategy JSON parser to handle the unpredictable response shapes. I migrated from a single-file React artifact to Next.js with server-side API keys, deterministic article IDs, and 30+ tests. Phase 2 hardened the error pipeline; Phase 3 split the system into a Python/LangGraph backend on Railway and a Next.js frontend on Vercel reading from Neon Postgres. Every story summary, every topic search, every cross-source comparison ran through the pipeline.
 
-**Product goals:**
-
-Deliver a daily-driver news reader across 7 categories (Top Stories, Technology, Business, Science, Energy, World, Health) where every summary is AI-generated from real-time web search results. Articles must link to original sources so the product adds value without replacing journalism. The interface needed to feel fast and polished despite the inherent latency of AI-powered content generation.
-
-**Technical goals:**
-
-Build a full-stack application with a React frontend, server-side API proxy (keeping API keys off the client), persistent user state (bookmarks, theme preferences), and a robust error handling system that gracefully manages the unpredictable nature of LLM responses — including model refusals, malformed JSON, timeouts, and empty results.
-
-**Portfolio goals:**
-
-Demonstrate the complete product development lifecycle: requirements analysis, architectural decisions with documented rationale, iterative debugging with root cause analysis, test coverage, and a production deployment plan. Show that I can take a product from zero to one, not just build features on an existing codebase.
+I used the product daily. So did the friends I asked to try it. That's when two things broke the original hypothesis.
 
 ---
 
-### Action
+### The surprise
 
-**Discovery and API spike.** I started by exploring the Anthropic Messages API's web_search tool — the core technical bet for the product. This turned out to be the most consequential phase of the project. I discovered that the model would refuse to format web search results as structured JSON when prompted with rigid extraction commands like "Return ONLY a JSON array." The model interpreted this as a request to fabricate structured data from unstructured search snippets, which conflicted with its instruction-following behavior. This was a critical insight: the entire content pipeline depended on reliable structured output from an API that wasn't designed for structured output.
+**Latency.** Live web-search-driven generation cost 15+ seconds per category load. I patched this by moving the AI off the user's critical path: a background pipeline writes to Postgres on a schedule, the frontend serves enriched content from cache. Live latency went from 15s to ~50ms. Architecturally clean. But the patch surfaced a deeper question: if the AI work doesn't have to happen at click time, what's it actually *for* — and what is the user supposed to see that's distinctive?
 
-**Prompt engineering breakthrough.** I solved the model refusal problem by reframing the prompt from data extraction to summarization. Instead of commanding "format these search results as JSON," I positioned the task as "search for news about this topic, then summarize the top 5 stories you found." The key phrase was "it's fine to summarize in your own words and make reasonable guesses for any missing fields." This aligned with the model's strengths — summarization and synthesis — rather than fighting against its guardrails. The JSON format was presented as a helpful structure for the summary, not as a rigid extraction template.
+**The substantive disagreement wasn't where I thought.** Multi-source comparison was supposed to be the headline feature. In production, when the corpus is curated mainstream sources (Reuters, AP, BBC, NYT, WSJ, Bloomberg, etc.), the "different framings" are usually surface variations of the same coverage. The compare view kept producing outputs that were technically interesting and substantively dull. Asking AI to compare three wire descriptions of the same Senate vote tells the reader they all said roughly the same thing — which a reader could see by skimming the three headlines.
 
-**Iterative architecture.** I built the product in three distinct phases, each informed by what broke in the previous one:
-
-*Phase 1 — Working prototype (single-file React artifact):* Built the complete UI and API integration in a single 831-line React component to validate the core experience. This phase proved the product thesis — AI-curated summaries were substantively different from wire service headlines — but revealed significant technical debt. Silent error handling (`catch { return [] }`) masked failures, non-unique article IDs broke bookmarks, and the API key was exposed client-side.
-
-*Phase 2 — Hardened error handling:* After the prototype surfaced 6+ debugging iterations caused by compounding silent failures, I rebuilt the error pipeline. Every API failure mode got a specific handler: HTTP errors, empty response blocks, malformed JSON, model refusals, and timeouts. I built a 3-strategy JSON parser that handles clean arrays, prose-wrapped JSON, and individual scattered objects — because the model's response format varied unpredictably across calls. I added diagnostic error messages, AbortController-based timeouts, and a slow-loading indicator.
-
-*Phase 3 — Production migration (Next.js):* Decomposed the monolith into a proper Next.js 15 application with TypeScript, Tailwind CSS, and a server-side API route. This addressed every production blocker from the prototype: API key moved to server-side environment variables, bookmarks persist via localStorage, article IDs use deterministic URL hashing, and the codebase is testable. I wrote 30+ unit tests covering utilities, API response parsing, and component rendering — with particular depth on the JSON parser that had caused the most debugging time.
-
-**Structured subtopic coverage.** To ensure broad coverage within each category, I designed a subtopic system where each category defines a primary topic and 2-4 subtopics. The prompt explicitly instructs the model to "search across these subtopics for broad coverage" and "include at least one story from each subtopic if possible." For the Energy category, this means separate searches across grid/utilities, renewables, energy prices, and specific companies — the functional equivalent of boolean OR operators in a traditional search API, translated into natural language instructions for the AI.
-
-**Architecture for future complexity.** I designed a hybrid architecture that keeps simple operations simple (single API call for basic news fetch stays in Next.js) while planning a separate Python/FastAPI service with LangGraph for features that genuinely need multi-step orchestration: multi-source comparison (parallel searches across outlets → claim extraction → synthesis), topic clustering, and AI summary customization. This distinction — knowing when orchestration frameworks add value versus when they add unnecessary complexity — was a deliberate architectural decision documented in the project's decision log.
+The bottleneck wasn't volume, source diversity, or cross-source disagreement. The bottleneck was that **most readers don't know who the players are.** They can read five outlets on the same vote and still not know who the senator is, what the bill does, what the relevant lobbying body wants, or how the framing has shifted from the last time the question came up. The thing they actually need is not more articles — it's the political, organizational, and legislative scaffolding embedded around each story.
 
 ---
 
-### Result
+### The revision
 
-**Shipped product:**
+That insight reshaped the product. The hypothesis I started with — *an AI-curated alternative to wire-feed aggregators* — turned out not to point at the right differentiator. The differentiator was never the AI. It was **civic decoding.** Sift isn't "news synthesized by AI." It's *news that teaches you the politics behind it as you read.*
 
-Sift is a production AI-curated news aggregator live at siftnews.kristenmartino.ai, serving 10 categories with 100+ RSS sources, AI summaries from Claude Haiku 4.5, vector-powered topic search, and multi-source comparison. The interface features text-first article cards with RSS images, named dark/light themes ("Late Edition" / "Newsprint"), persistent bookmarks with Clerk sync, SSE streaming for topic search, and a diamond brand mark. Articles link to original sources.
+The AI is still load-bearing. The pipeline grew from a single summarization step to ten services on Railway: primer generation, entity extraction, entity linking to dossiers, summarization, story synthesis, story clustering, civic-context generation, batched API client, cross-source comparison workflow, usage tracking. But the AI is infrastructure now, not the product. The product is the reader being able to follow a story without first having to research who everyone is.
 
-**Architecture (v2):**
+Concretely, that meant building four surfaces:
 
-The v2 architecture split the system into three services: Next.js frontend on Vercel (reads from Postgres, serves UI), Python FastAPI + LangGraph on Railway (background pipeline + comparison workflow), and Neon Postgres with pgvector (shared source of truth). Content pipeline runs every 10 minutes via asyncio scheduler. User requests are pure database reads (<50ms). Multi-source comparison uses a LangGraph workflow with fan-out web search across outlets. Topic search uses Voyage AI embeddings with pgvector cosine similarity and Claude web search fallback. Total cost: ~$9/month.
+- **Civic dossiers** for politicians (committee assignments, top industries by PAC contributions, interest-group ratings, links to GovTrack / OpenSecrets / Vote Smart), organizations (political lean, finances, major funders, FARA registration, links to ProPublica Nonprofit Explorer / IRS 990 / FARA), bills (status, sponsor, cosponsors, lobbying spend, links to GovTrack / Congress.gov / OpenSecrets), and news outlets (ownership, funding, AllSides political-lean, MBFC factual-reporting). All sourced from public records.
+- **Inline glossary** for civic terms inside the article itself — chip pills with tooltip previews and click-through to the full dossier.
+- **Adaptive primers** that expand when a story sits on top of complex policy.
+- **Cross-spectrum framing** that describes what each outlet emphasized rather than labeling them. AllSides and MBFC ratings shown verbatim — Sift never computes its own.
 
-**Technical outcomes:**
+I also built things I didn't ship. An early version had TrustSignal, PropagandaTag, and ExtremistFlag — judgment-layer features for rating source quality. Applied to a mainstream-source corpus, they produced nothing meaningful: every outlet looked roughly trustworthy because they roughly are. Worse, applying them would have meant making claims I couldn't defend at the corpus level. I left them out of the shipped surface. (The genuinely useful version of that layer applies to *propaganda* outlets, not mainstream ones — a different product on a different corpus with a different audience.)
 
-Two repositories totaling ~5,000+ lines across 50+ source files. The Next.js frontend includes 7 custom hooks, SSE streaming, Clerk auth, and CI via GitHub Actions. The Python backend includes two LangGraph workflows (pipeline + comparison), 100+ RSS feeds, and CI with ruff + pytest. Neon Postgres stores articles with 1024-dim Voyage AI embeddings and an IVFFlat index for fast similarity search. 21 architectural decisions documented with rationale.
+---
 
-**Measurable improvements over v1 prototype:**
+### What I learned
 
-Architecture: AI moved from request path to background pipeline (<50ms reads vs 10-20s Claude calls). Scale: 7 categories → 10 categories, ~56 RSS feeds → 100+ feeds. Features: added topic search (vector + fallback), multi-source comparison (LangGraph fan-out), landing page, brand identity. Cost: reduced from projected ~$30/mo to actual ~$9/mo by using Vercel Hobby + Neon free tier + Railway asyncio scheduler. Deployment: full CI/CD with auto-deploy on both repos.
+Three things, in order of how much they changed my thinking:
 
-**Key lessons documented:**
+1. **Product-shape questions reveal themselves only in contact with reality.** The "compare three wire descriptions of the same Senate vote" UX failure didn't show up in design review. It showed up in usage. The right move was to take the framing instinct ("readers want to compare outlets") seriously enough to ship it — then take the failure seriously enough to redirect the product when it landed flat.
 
-The single most impactful lesson was that API behavior discovery should happen before integration, not during debugging. A 2-hour spike on the Anthropic web_search tool's response format and refusal patterns would have prevented 6+ hours of debugging caused by compounding failures from an untested prompt change. The second lesson was that prompt engineering is product design — the shift from "format as JSON" to "summarize in your own words" wasn't a technical fix, it was a reframing of what we were asking the AI to do. The third lesson was about deployment: Railway auto-injects PORT environment variables that override user settings, and model IDs like `claude-haiku-4-5-20251001` require the full date suffix — both discovered through production debugging.
+2. **Engineering decisions can quietly undo product hypotheses.** When the original architecture hit 15s latency on every click, the engineering fix (move AI off the critical path) was correct. But it also rendered the original "AI-curated alternative" framing thinner than I realized — the AI was no longer visible to users as a product feature. The fix solved the symptom; the framing needed to follow.
+
+3. **The civic-literacy layer was always the unfakeable part.** Anyone with an API key can build "AI summaries of the news." Building the dossier graph, the inline glossary, the public-records pipeline, the methodology — none of that is something to spin up over a weekend. It's the part of Sift that has cost the most and matters the most. It's also the part a hiring manager can verify by reading a dossier and clicking the citation.
+
+---
+
+### What's next
+
+The next version is about making the civic layer denser without making the article surface heavier — per-paragraph primer triggering, observation-mode cross-spectrum compare, deeper dossier coverage on the entities that show up most often, methodology that scales as the corpus grows. Same direction; tighter execution.
+
+The product is for the reader who wants to follow what's happening without already knowing the players. *Read the headline; learn the civics as you go.*

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -336,7 +336,7 @@ export const COPY = {
   landing: {
     // Single editorial paragraph below the lead story. The "what is this".
     explainer:
-      "Sift reads from ~50 vetted outlets every morning, summarizes the stories worth knowing, and links back to the originals \u2014 so you can stop checking ten tabs and get on with your day.",
+      "Sift reads the day's news and adds the civic footnotes. Politicians, organizations, bills, and political terms link to plain-English explainers \u2014 sourced from public records. Follow what's happening without already knowing the players.",
     leadEyebrow: "Today\u2019s lead",
     leadFallbackTitle: "Today\u2019s stories are still being filed",
     leadFallbackBody:
@@ -346,7 +346,7 @@ export const COPY = {
     // Section heading for the multi-source comparison demo.
     compareEyebrow: "How outlets framed it",
     compareTitle: "The Federal Reserve\u2019s May rate decision",
-    compareSubtitle: "One story, three angles. This is what Sift\u2019s compare view does on every topic.",
+    compareSubtitle: "One story, three angles. Sift shows what each outlet chose to emphasize \u2014 described, not labeled \u201cbiased\u201d or \u201cobjective.\u201d You read; the product does the legwork.",
     compareCta: "Compare any topic",
     // Source colophon.
     colophonHeading: "Read from",


### PR DESCRIPTION
## Summary
Realign Sift's in-product copy and documentation around civic-literacy framing — matching what's actually deployed (dossiers + glossary + primers + cross-spectrum framing), not the abandoned AI-curation thesis.

- `lib/copy.ts` — `landing.explainer` + `landing.compareSubtitle` now lead with civic decoding.
- `README.md` — reorder features (civic-literacy layer first, foundation second); update wording.
- `docs/PRD.md` — full rewrite (v3.0 civic-literacy): vision, value prop, features, competitive landscape, open questions.
- `docs/PRODUCT_STORY.md` — full rewrite using bet → test → surprise → revision arc.

## Test plan
- [x] `tsc --noEmit` passes locally
- [x] Landing page renders new `explainer` + `compareSubtitle` copy (verified via dev server + curl)
- [x] No old framing strings (`"stop checking ten tabs"`, `"stories worth knowing"`, `"This is what Sift"`) remain in the rendered HTML
- [ ] CI passes
- [ ] Vercel preview / prod deploy reflects new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)