### PR TITLE
chore: reposition Sift as aggregator + civic-literacy layer (two-layer framing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sift
 
-**The news, with footnotes.** A civic-literacy news app for the American public. Sift reads from ~50 vetted outlets across the political spectrum, adds the footnotes the news assumes you don't need — civic context, cross-spectrum framing, and the financial and political ties behind every entity — all linked to public records.
+**The news, with footnotes.** An AI-powered news aggregator with a civic-literacy layer on top. Sift reads from ~50 vetted outlets across the political spectrum, AI-summarizes the day's stories across 10 categories, lets you search any topic or compare coverage across sources — *and* adds the civic footnotes the news assumes you already have: an adaptive *"what you should know first"* primer, inline glossary tooltips, structured dossiers on every politician / organization / bill / outlet, cross-spectrum framing — all sourced from public records.
 
 **Live:** [siftnews.kristenmartino.ai](https://siftnews.kristenmartino.ai)
 
@@ -19,25 +19,30 @@ Browser --> Vercel (Next.js) --reads--> Neon Postgres (pgvector)
 - **sift-api**: Python FastAPI + LangGraph on Railway — background pipeline + comparison workflow
 - **Database**: Neon Postgres (pgvector) — shared source of truth
 
-## Civic-literacy layer (what makes Sift Sift)
-
-- **Civic dossiers**: every politician, organization, bill, and outlet in an article links to a structured dossier — committee assignments, top industries by PAC contributions, ownership, funding, FARA registration, voting records, AllSides + MBFC ratings. Sourced from OpenSecrets, GovTrack, ProPublica Nonprofit Explorer, FARA, Vote Smart, and FEC. Citations on every page.
-- **Inline glossary**: civic terms surface contextually inside the article — defined where the reader needs them, in the language they need.
-- **Adaptive primers**: *"What you should know first"* + key terms, AI-generated at ingest. Expands when a story sits on top of complex policy.
-- **Cross-spectrum framing**: how outlets across left / center / right framed the same story. Sift surfaces AllSides + MBFC ratings verbatim — never computes its own.
-- **Methodology**: source curation policy and symmetric-application rules public at `/methodology`.
-- **Civic dossier index**: searchable, filterable view of curated politicians, organizations, and bills at `/civic`.
-
 ## Foundation (the reader surface)
 
 - **10 categories**: Top, Technology, Business, Science, Energy, World, Health, Politics, Sports, Entertainment.
 - **AI summaries**: every article summarized by Claude Haiku 4.5 in the background pipeline — user requests never touch Claude.
 - **Topic search**: vector similarity (Voyage AI embeddings + pgvector), SSE streaming, Claude web-search fallback for niche queries.
-- **Multi-source comparison**: LangGraph workflow — fan-out search across outlets, extract claims, compare. Described, not labeled.
+- **Multi-source comparison**: LangGraph workflow — fan-out search across outlets, extract claims, compare framings. Described, not labeled.
 - **Bookmarks**: localStorage + Clerk server sync.
 - **Dark/light themes**: "Late Edition" (dark) and "Newsprint" (light) with warm editorial tones.
 - **SiftLogo**: diamond mark brand identity across all touchpoints.
 - **Auth**: Clerk (free to 10K MAU).
+
+## Civic-literacy layer (what makes Sift Sift)
+
+- **"What you should know first"**: an adaptive primer above each story — key terms and context the article assumes you already have. AI-generated at ingest, expandable for complex policy.
+- **Inline glossary**: civic terms surface contextually inside the article — defined where the reader needs them. Chip tooltips with previews; click-through to the full dossier.
+- **Civic dossiers**: every politician, organization, bill, and outlet links to a structured dossier — committee assignments, top industries by PAC contributions, ownership, funding, FARA registration, voting records, AllSides + MBFC ratings. Sourced from OpenSecrets, GovTrack, ProPublica Nonprofit Explorer, FARA, Vote Smart, and FEC. Citations on every page.
+- **Cross-spectrum framing**: how outlets across left / center / right framed the same story. Sift surfaces AllSides + MBFC ratings verbatim — never computes its own.
+- **Methodology**: source curation policy and symmetric-application rules public at `/methodology`.
+- **Civic dossier index**: searchable, filterable view of curated politicians, organizations, and bills at `/civic`.
+
+## Architecture move — AI split by SLA
+
+- **Browse path**: pre-computed in a background pipeline; frontend reads from Postgres in ~50ms. The whole category-browsing experience is a database read.
+- **Live AI path**: multi-source compare and topic search run AI live (fan-out, claim extraction, web search) and accept ~10–15s, streaming as they go. Different work, different SLA.
 
 ## Quick start
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -10,23 +10,39 @@
 
 ## Vision
 
-**Read the news with civic footnotes.** Sift is a news reader where every politician, organization, bill, and political term in an article links to a plain-English explainer — sourced from public records, threaded into the reading flow. Open it, read a story, click any entity, get the dossier that wasn't in the article. For people who want to follow what's happening without already knowing the players.
+**A news aggregator with civic footnotes.** Sift is an AI-powered news aggregator across 10 categories — with a civic-literacy layer on top. Open it, read today's stories across categories. Search any topic. Compare how outlets covered the same story. And on every story, click any name — senator, lobbying group, bill — to get who they are, what they've done, and what they want. Sourced from public records.
 
 ## Value proposition
 
-**For readers:** Open Sift. Read a story about a Senate vote. Click any name — senator, lobbying group, bill — and get who they are, what they've done, and what they want. Sourced from public records. *Read the headline; learn the civics as you go.*
+**For readers:** Open Sift. Today's stories across 10 categories — Top, Tech, Business, Science, Energy, World, Health, Politics, Sports, Entertainment, each AI-summarized. Search any topic. Compare coverage across outlets. And on every story: *"What you should know first,"* an inline glossary for civic terms, and structured dossiers on the politicians, organizations, and bills involved. *Read the headline; learn the civics as you go.*
 
-**For hiring managers:** I built a civic-literacy news product end-to-end — Next.js + Postgres frontend on Vercel, Python FastAPI + LangGraph backend on Railway, civic dossier graph over Postgres entity tables, scheduled AI pipeline that does the analytical work off the user's critical path. Live latency stays under 100ms because the AI moved to a background pipeline that writes to Postgres; the frontend is a database read.
+**For hiring managers:** I built an AI-powered news aggregator + civic-literacy layer end-to-end — Next.js + Postgres frontend on Vercel, Python FastAPI + LangGraph backend on Railway. The architectural move that matters is splitting AI by SLA: the browse path (categories, summaries, dossiers, primers) is pre-computed in a background pipeline and served from Postgres in ~50ms; the live AI path (multi-source compare, topic search) runs on request and streams, accepting ~10–15s because the user is asking for analysis, not browsing.
 
 ---
 
 ## What makes Sift different
 
-1. **Civic dossiers, not just summaries.** Every politician, organization, bill, and news outlet has a structured page sourced from public records (OpenSecrets, GovTrack, ProPublica Nonprofit Explorer, FARA, FEC, Vote Smart). News stories link out to them inline.
-2. **Inline glossary that respects the reader.** Civic terms surface contextually inside the article — not in a separate panel. Defined where the reader needs them, in the language they need.
-3. **Adaptive primers for complex policy.** When a story sits on top of complex policy (the Inflation Reduction Act, debt-ceiling mechanics, FTC consent decrees), the primer expands to fit what the reader needs.
-4. **Cross-spectrum framing, observed not labeled.** When multiple outlets cover the same story, Sift shows what each chose to emphasize. AllSides political-lean and MBFC factual-reporting ratings shown verbatim — Sift never computes its own. The reader does the interpretation; the product does the legwork.
-5. **AI off the critical path.** Earlier versions did live click-time generation and ran 15+ seconds per category load. Sift moved the AI to a background pipeline that writes enriched content to Postgres. User requests are pure database reads — ~50ms.
+The product is two layers stacked, plus an architectural move that makes both work:
+
+### Foundation — AI-powered news aggregator
+
+1. **10 categories** from ~50 vetted outlets across the political spectrum.
+2. **AI summaries** on every article, pre-computed in the background pipeline.
+3. **Topic search** via vector similarity (Voyage AI + pgvector), SSE streaming, with Claude web-search fallback for niche queries.
+4. **Multi-source comparison** via LangGraph fan-out: pulls coverage across outlets, extracts claims, shows side-by-side framing.
+5. **Bookmarks** (Clerk-synced), dark/light themes, auth.
+
+### Differentiator — civic-literacy layer
+
+6. **"What you should know first"** — adaptive primer above each story; key terms and context the article assumes you already have.
+7. **Inline glossary** — civic terms surface contextually inside the article, with chip tooltips and click-through to the full dossier.
+8. **Civic dossiers** — every politician, organization, bill, and news outlet has a structured page sourced from public records (OpenSecrets, GovTrack, ProPublica Nonprofit Explorer, FARA, FEC, Vote Smart). News stories link out to them inline.
+9. **Cross-spectrum framing** — when multiple outlets cover the same story, what each Left / Center / Right outlet chose to emphasize. AllSides + MBFC ratings shown verbatim — Sift never computes its own.
+
+### Architecture move — AI split by SLA
+
+10. **Browse path:** pre-computed in a background pipeline; frontend reads from Postgres in ~50ms. The whole category-browsing experience is a database read.
+11. **Live AI path:** multi-source compare and topic search run live, accept ~10–15s, and stream as they go. Different work, different SLA.
 
 ---
 

--- a/docs/PRODUCT_STORY.md
+++ b/docs/PRODUCT_STORY.md
@@ -1,14 +1,14 @@
 # Sift: 0→1 Product Story
 
-## Civic Literacy in a News Reader — How Sift Found Its Shape
+## A News Aggregator with Civic Footnotes — How Sift Found Its Shape
 
 ---
 
 ### The bet
 
-The news-aggregation market is saturated. Apple News, Google News, Perplexity Discover, every wire-feed reader — they converged on the same shape: pull headlines, summarize, list by recency. I started Sift believing the gap was upstream of the reader: that AI-curated summaries from live web search could deliver three things wire feeds couldn't — broader source diversity, summaries written for comprehension rather than clicks, and topic coverage shaped by structured subtopics rather than editorial choice.
+The news-aggregation market is saturated. Apple News, Google News, Perplexity Discover, every wire-feed reader — they converged on the same shape: pull headlines, summarize, list by recency. I started Sift believing the gap was upstream of the reader: that AI-curated summaries from live web search, AI-powered topic search across categories, and multi-source comparison could deliver three things wire feeds couldn't — broader source diversity, summaries written for comprehension rather than clicks, and topic coverage shaped by structured subtopics rather than editorial choice.
 
-That was the hypothesis I wrote into the first PRD. It assumed the bottleneck for serious readers was volume and selection — *more, better, fresher.* I built v1 around it: AI summaries from Claude's web-search tool, 7 categories, 100+ feeds, all generated live at click time.
+That was the hypothesis I wrote into the first PRD. It assumed the bottleneck for serious readers was volume and selection — *more, better, fresher.* I built v1 around it: AI summaries from Claude's web-search tool, 7 categories (later 10), 100+ feeds, all generated live at click time.
 
 ---
 
@@ -22,26 +22,30 @@ I used the product daily. So did the friends I asked to try it. That's when two 
 
 ### The surprise
 
-**Latency.** Live web-search-driven generation cost 15+ seconds per category load. I patched this by moving the AI off the user's critical path: a background pipeline writes to Postgres on a schedule, the frontend serves enriched content from cache. Live latency went from 15s to ~50ms. Architecturally clean. But the patch surfaced a deeper question: if the AI work doesn't have to happen at click time, what's it actually *for* — and what is the user supposed to see that's distinctive?
+**Latency.** Live web-search-driven generation cost 15+ seconds per category load. I patched this by moving the AI off the user's critical path: a background pipeline writes to Postgres on a schedule, the frontend serves enriched content from cache. Live browse latency went from 15s to ~50ms. (Multi-source compare and topic search still take ~10–15s — they run AI live and accept the latency because the user is asking for analysis, not browsing. Two paths by SLA.)
 
-**The substantive disagreement wasn't where I thought.** Multi-source comparison was supposed to be the headline feature. In production, when the corpus is curated mainstream sources (Reuters, AP, BBC, NYT, WSJ, Bloomberg, etc.), the "different framings" are usually surface variations of the same coverage. The compare view kept producing outputs that were technically interesting and substantively dull. Asking AI to compare three wire descriptions of the same Senate vote tells the reader they all said roughly the same thing — which a reader could see by skimming the three headlines.
+**The AI-summary layer alone wasn't the differentiator.** Multi-source comparison was supposed to be the headline feature. In production, when the corpus is curated mainstream sources, the "different framings" are usually surface variations of the same coverage. The compare view kept producing outputs that were technically interesting and substantively dull. Asking AI to compare three wire descriptions of the same Senate vote tells the reader they all said roughly the same thing — which a reader could see by skimming the three headlines.
 
-The bottleneck wasn't volume, source diversity, or cross-source disagreement. The bottleneck was that **most readers don't know who the players are.** They can read five outlets on the same vote and still not know who the senator is, what the bill does, what the relevant lobbying body wants, or how the framing has shifted from the last time the question came up. The thing they actually need is not more articles — it's the political, organizational, and legislative scaffolding embedded around each story.
+The bottleneck wasn't volume, source diversity, or cross-source disagreement. The bottleneck was that **most readers don't know who the players are.** They can read five outlets on the same vote and still not know who the senator is, what the bill does, what the relevant lobbying body wants, or how the framing has shifted from the last time the question came up. The thing they actually need is not better summaries — it's the political, organizational, and legislative scaffolding around each story.
 
 ---
 
 ### The revision
 
-That insight reshaped the product. The hypothesis I started with — *an AI-curated alternative to wire-feed aggregators* — turned out not to point at the right differentiator. The differentiator was never the AI. It was **civic decoding.** Sift isn't "news synthesized by AI." It's *news that teaches you the politics behind it as you read.*
+So I kept the aggregator and added a civic-literacy layer on top.
 
-The AI is still load-bearing. The pipeline grew from a single summarization step to ten services on Railway: primer generation, entity extraction, entity linking to dossiers, summarization, story synthesis, story clustering, civic-context generation, batched API client, cross-source comparison workflow, usage tracking. But the AI is infrastructure now, not the product. The product is the reader being able to follow a story without first having to research who everyone is.
+The aggregator continues to do what an aggregator does — 10 categories, ~50 outlets, AI summaries pre-computed in the background pipeline, topic search via vector similarity with SSE streaming, multi-source comparison via LangGraph fan-out. That's the daily-driver experience that builds the habit. The AI work is still there, just split by SLA: the browse path is pre-computed and serves from Postgres in ~50ms; multi-source compare and topic search run live and accept ~10–15s.
 
-Concretely, that meant building four surfaces:
+What got added is the civic-literacy layer:
 
+- **"What you should know first"** — an adaptive primer above each story. Key terms and context the article assumes the reader already has, AI-generated at ingest, expandable when the story sits on top of complex policy.
+- **Inline glossary** — civic terms surface contextually inside the article. Chip pills with tooltip previews; click-through to the full dossier.
 - **Civic dossiers** for politicians (committee assignments, top industries by PAC contributions, interest-group ratings, links to GovTrack / OpenSecrets / Vote Smart), organizations (political lean, finances, major funders, FARA registration, links to ProPublica Nonprofit Explorer / IRS 990 / FARA), bills (status, sponsor, cosponsors, lobbying spend, links to GovTrack / Congress.gov / OpenSecrets), and news outlets (ownership, funding, AllSides political-lean, MBFC factual-reporting). All sourced from public records.
-- **Inline glossary** for civic terms inside the article itself — chip pills with tooltip previews and click-through to the full dossier.
-- **Adaptive primers** that expand when a story sits on top of complex policy.
-- **Cross-spectrum framing** that describes what each outlet emphasized rather than labeling them. AllSides and MBFC ratings shown verbatim — Sift never computes its own.
+- **Cross-spectrum framing** — when multiple outlets cover the same story, what each chose to emphasize. AllSides and MBFC ratings shown verbatim — Sift never computes its own.
+
+The combination is what changed. An aggregator without civic context is a commodity — every news app shows the same Reuters and AP stories. A civic-context tool without the daily news flow is a research database — useful when you need it, not a daily-driver. *Aggregator + civic footnotes* is what makes Sift Sift.
+
+The pipeline grew from a single summarization step to ten services on Railway: primer generation, entity extraction, entity linking to dossiers, summarization, story synthesis, story clustering, civic-context generation, batched API client, cross-source comparison workflow, usage tracking. The AI is still load-bearing — but it's infrastructure in service of both layers, not the product itself.
 
 I also built things I didn't ship. An early version had TrustSignal, PropagandaTag, and ExtremistFlag — judgment-layer features for rating source quality. Applied to a mainstream-source corpus, they produced nothing meaningful: every outlet looked roughly trustworthy because they roughly are. Worse, applying them would have meant making claims I couldn't defend at the corpus level. I left them out of the shipped surface. (The genuinely useful version of that layer applies to *propaganda* outlets, not mainstream ones — a different product on a different corpus with a different audience.)
 
@@ -51,16 +55,16 @@ I also built things I didn't ship. An early version had TrustSignal, PropagandaT
 
 Three things, in order of how much they changed my thinking:
 
-1. **Product-shape questions reveal themselves only in contact with reality.** The "compare three wire descriptions of the same Senate vote" UX failure didn't show up in design review. It showed up in usage. The right move was to take the framing instinct ("readers want to compare outlets") seriously enough to ship it — then take the failure seriously enough to redirect the product when it landed flat.
+1. **Product-shape questions reveal themselves only in contact with reality.** The "compare three wire descriptions of the same Senate vote" UX failure didn't show up in design review. It showed up in usage. The right move was to take the framing instinct ("readers want to compare outlets") seriously enough to ship it — then take the failure seriously enough to add a layer when it landed flat.
 
-2. **Engineering decisions can quietly undo product hypotheses.** When the original architecture hit 15s latency on every click, the engineering fix (move AI off the critical path) was correct. But it also rendered the original "AI-curated alternative" framing thinner than I realized — the AI was no longer visible to users as a product feature. The fix solved the symptom; the framing needed to follow.
+2. **Engineering decisions can quietly shape product hypotheses.** When the original architecture hit 15s latency on every click, the engineering fix (move AI off the critical path) was correct. But the patch also meant the AI was no longer visible to users as a product feature, which forced a sharper question: if the AI runs in the background, what is the product the user actually sees? The answer became civic literacy.
 
-3. **The civic-literacy layer was always the unfakeable part.** Anyone with an API key can build "AI summaries of the news." Building the dossier graph, the inline glossary, the public-records pipeline, the methodology — none of that is something to spin up over a weekend. It's the part of Sift that has cost the most and matters the most. It's also the part a hiring manager can verify by reading a dossier and clicking the citation.
+3. **The aggregator was the foundation; the civic-literacy layer is the moat.** Building a working AI-powered news aggregator with 10 categories, vector-search topic discovery, and multi-source compare is real engineering — but it's an engineering problem with a known shape. Building the dossier graph, the inline glossary, the public-records pipeline, the methodology is the part that hasn't been done at this resolution. Both layers matter; one is the daily-driver, the other is what makes the daily-driver worth opening.
 
 ---
 
 ### What's next
 
-The next version is about making the civic layer denser without making the article surface heavier — per-paragraph primer triggering, observation-mode cross-spectrum compare, deeper dossier coverage on the entities that show up most often, methodology that scales as the corpus grows. Same direction; tighter execution.
+The civic layer is dense; making the article surface heavier would undo it. The next moves are about precision, not addition — per-paragraph primer triggering (instrumentation in flight), observation-mode cross-spectrum compare, deeper dossier coverage on the entities that show up most often, methodology that scales as the corpus grows. Same direction; tighter execution.
 
-The product is for the reader who wants to follow what's happening without already knowing the players. *Read the headline; learn the civics as you go.*
+The product is the aggregator that adds the civic context the news assumes you already have. *Read the headline; learn the civics as you go.*

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -336,7 +336,7 @@ export const COPY = {
   landing: {
     // Single editorial paragraph below the lead story. The "what is this".
     explainer:
-      "Sift reads the day's news and adds the civic footnotes. Politicians, organizations, bills, and political terms link to plain-English explainers \u2014 sourced from public records. Follow what's happening without already knowing the players.",
+      "Sift surfaces today's news across categories from ~50 outlets \u2014 and adds civic footnotes to every story. What you should know first, terms you may not know, the political viewpoint of the outlet, dossiers on the senators and organizations involved, and side-by-side coverage across sources.",
     leadEyebrow: "Today\u2019s lead",
     leadFallbackTitle: "Today\u2019s stories are still being filed",
     leadFallbackBody:


### PR DESCRIPTION
## Summary
Realign Sift's positioning across in-product copy and documentation as **a news aggregator with civic footnotes** — both layers, not just the civic-literacy differentiator.

- `lib/copy.ts` — `landing.explainer` uses the human-readable feature framing: *what you should know first, terms you may not know, political viewpoint of the outlet, dossiers on senators and orgs, side-by-side coverage.*
- `README.md` — intro repositions as "AI-powered news aggregator with a civic-literacy layer on top." Features reordered (Foundation first, Civic-literacy second). Added an Architecture-move section calling out AI split by SLA.
- `docs/PRD.md` — Vision / Value Prop / What-makes-different rewritten with two-layer framing (foundation + differentiator + architecture move).
- `docs/PRODUCT_STORY.md` — full rewrite. Revision section is now "kept the aggregator and added civic literacy on top" (addition, not pivot). Lesson 3 acknowledges aggregator as real engineering work; civic layer as the moat.

## Test plan
- [x] `tsc --noEmit` passes locally
- [x] Landing page renders new `explainer` copy ("What you should know first," "terms you may not know," "political viewpoint of the outlet," "side-by-side coverage across sources") — verified via dev server
- [x] Old explainer strings absent from rendered HTML
- [ ] CI passes
- [ ] Vercel preview / prod deploy reflects new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)