### PR TITLE
Project state mgmt (STATUS + CLAUDE) + iOS planning docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md — sift (Next.js frontend)
+
+Orientation for Claude Code sessions. Keep this short and current — if it grows past one screen, split the long bits into real docs in `docs/`.
+
+## Pre-session ritual
+
+Before doing real work in a session:
+
+1. Read [`STATUS.md`](./STATUS.md) — Active focus, Open question, Next 3, Blocked-on, Recent decisions.
+2. List open PRs (`mcp__github__list_pull_requests` or `gh pr list` locally) — anything mid-review.
+3. List open issues (`mcp__github__list_issues` or `gh issue list`) — especially ones on the Next 3.
+4. Skim [`docs/PROJECT_PLAN.md`](./docs/PROJECT_PLAN.md) if the work touches roadmap (tier label decisions).
+
+If `STATUS.md` is older than ~3 days during a high-velocity period (10+ PRs / week), flag the staleness to the user before starting.
+
+## End-of-PR doc-impact check
+
+Before opening the PR:
+
+- Did this change anything in `STATUS.md`'s Next 3, Blocked-on, or Open question? Update it.
+- Did this make or close a strategic decision? Add a `## Recent decisions` entry in `STATUS.md` and (if substantial) a row in [`docs/DECISIONS.md`](./docs/DECISIONS.md).
+- Did this change a public contract (API shape, page route, env var)? Update the relevant doc in `docs/` ([`TECHNICAL_SPEC.md`](./docs/TECHNICAL_SPEC.md), [`ARCHITECTURE.md`](./docs/ARCHITECTURE.md), `README.md`).
+- Did this change how the app boots / runs locally? Update the Quick Start in `README.md`.
+- Touched `docs/IOS_*.md` (plan / assessment / platform analysis)? Update the status banner at the top to reflect current state (Active / Under review / Archived).
+
+## Sibling repos
+
+| Repo | Role | Notes |
+|---|---|---|
+| [`kristenmartino/sift-api`](https://github.com/kristenmartino/sift-api) | Python FastAPI backend, owns the write path | Has its own `STATUS.md` + `CLAUDE.md`. Background pipeline + LangGraph compare. |
+| `kristenmartino/sift-mcp` | MCP server (v0.1 shipped) | Separate ship cadence. Demo target. |
+| `kristenmartino/portfolio-v2` | Case study deploy target | `src/content/work/sift.mdx`. Update on substantial product changes. |
+
+Commits do **not** cross repos — a "push the branch" request usually means just this one. Confirm before touching siblings.
+
+## See also
+
+- [`docs/PRD.md`](./docs/PRD.md) — original product vision
+- [`docs/PRODUCT_STORY.md`](./docs/PRODUCT_STORY.md) — current narrative (interview-prep relevant)
+- [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) — system design
+- [`docs/TECHNICAL_SPEC.md`](./docs/TECHNICAL_SPEC.md) — API + data contracts
+- [`docs/DECISIONS.md`](./docs/DECISIONS.md) — historical decision log (ADR-shaped)
+- [`docs/PROJECT_PLAN.md`](./docs/PROJECT_PLAN.md) — roadmap snapshot
+- [`docs/FEATURE_SPECS.md`](./docs/FEATURE_SPECS.md) — feature-level specs (large; reference, not read-through)
+- [`docs/IOS_APP_PLAN.md`](./docs/IOS_APP_PLAN.md) + [`docs/IOS_APP_ASSESSMENT.md`](./docs/IOS_APP_ASSESSMENT.md) + [`docs/IOS_VS_ANDROID.md`](./docs/IOS_VS_ANDROID.md) — native client plans (under review)

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,43 @@
+# Sift — STATUS
+
+**Updated:** 2026-05-20
+**Tier:** v1.5 (civic-literacy pivot, in flight)
+**Velocity:** High (10+ PRs / week)
+
+## Active focus
+
+Civic-literacy pivot rollout (web). Recently shipped: 170 new dossier entries seeded (via `sift-api`); entity linker fix gated A/B-able in production; `docs/PRODUCT_STORY.md` refreshed; portfolio-v2 case study deployed. Sift-mcp v0.1 shipped (separate repo) with Loom + DM to Harish.
+
+## Open strategic question
+
+**Native platform first: iOS vs Android?**
+
+Apple Developer Program enrollment is requested but may take weeks (24–72h personal, 4–8 weeks for new entities). Android: $25 one-time, ~instant approval, lenient Play Store review.
+
+**Working recommendation: start Android while iOS enrollment is pending.** Converts the enrollment-delay window from zero opportunity cost into a shipped Android v1; Android validates which native features actually matter before iOS gold-plates them; the backend infra (endpoints, push registration schema, share-extension handoff) is built once and reused. See [`docs/IOS_VS_ANDROID.md`](./docs/IOS_VS_ANDROID.md).
+
+Final call open.
+
+## Next 3
+
+1. **[committed]** [#56 — SSR / streaming for `/news` first-paint](https://github.com/kristenmartino/sift/issues/56) — architectural fix to break the 5.5s mobile LCP floor. LCP element after PR #55 is hydrated text inside `NewsAggregator`, not image — `priority`/`preload` is exhausted. Tier `v1.5` · `effort-week`.
+2. **[committed]** Civic-literacy pivot — final-mile checklist (umbrella issue, see Issues tab) — entity-linker promotion to default-on, dossier coverage parity per category, primer-expand instrumentation rollout. Tier `v1.5` · `effort-weeks`.
+3. **[sketch]** Resolve native platform direction — Android-first vs iOS-first vs PWA-only. Blocks iOS-plan revision and any mobile build. Decision-only; no issue. Tier `v2` · `effort-day`.
+
+## Blocked-on
+
+- Apple Developer Program enrollment (iOS work waits)
+- Harish demo response (sift-mcp v0.5 hardening waits, separate repo)
+- Resolution of the Open strategic question above (mobile work waits)
+
+## Recent decisions
+
+- **2026-05-20** — iOS plan v1 marked **under review**. Cross-functional assessment surfaced parity-shaped scope, premature canonical-API, and missing KPIs. See [`docs/IOS_APP_ASSESSMENT.md`](./docs/IOS_APP_ASSESSMENT.md). Plan retained as reference, not active direction.
+- **2026-05-20** — Canonical `/v1/*` API in sift-api **deferred**. For pre-PMF, reuse Next.js routes (+ Edge caching if needed); collapse later when web→mobile migration is scheduled.
+- **2026-05-20** — **Android-first leaning** (Path A) for native. Civic-literacy mission aligns with reach, not premium audience. Final decision open.
+- **2026-05-20** — DMCA audit: Sift's Railway footprint is **low-risk** under Railway's fair-use clause; real exposure is publisher-direct cease-and-desists, not host-mediated. Methodology page update queued in sift-api side.
+- *(sift-mcp side, separately committed in that repo: hybrid index+web architecture; 26-outlet pool with smart DB-exclusion selection; `load_dotenv(override=True)`; `compare_outlets` unified-claims-array return shape.)*
+
+---
+
+*See also: [`docs/PROJECT_PLAN.md`](./docs/PROJECT_PLAN.md), [`docs/DECISIONS.md`](./docs/DECISIONS.md), [`docs/PRODUCT_STORY.md`](./docs/PRODUCT_STORY.md), [`CLAUDE.md`](./CLAUDE.md). Sibling repos: `sift-api` (backend), `sift-mcp` (MCP server, separate cadence).*

--- a/docs/IOS_APP_ASSESSMENT.md
+++ b/docs/IOS_APP_ASSESSMENT.md
@@ -1,0 +1,96 @@
+# Sift — iOS Plan Assessment (cross-functional)
+
+**Date:** May 20, 2026
+**Status:** Active — informs the next revision of [`IOS_APP_PLAN.md`](./IOS_APP_PLAN.md)
+**Companion docs:** [`IOS_APP_PLAN.md`](./IOS_APP_PLAN.md), [`IOS_VS_ANDROID.md`](./IOS_VS_ANDROID.md)
+**Audience:** founder + future-me + future Claude sessions
+
+A senior-staff-level cross-functional review of the iPhone app plan as originally written. The plan is well-structured and the API recommendation is correct *for a later stage*, but for a pre-PMF solo build mid-pivot, the plan is shaped like work for a team of 8. The voices below capture what each stakeholder role would say if this were going through a real review.
+
+---
+
+## Round-the-table
+
+**CEO / founder.** The biggest issue isn't in the doc — it's what isn't. Sift is mid-pivot to civic-literacy ("the news, with footnotes"). The pivot is the thesis. This plan ships an iPhone app whose v1 explicitly defers the dossier index, compare, and native civic views to v1.1. That ships a worse mobile-web wrapper of a half-pivoted product. The question to answer before any of this is greenlit: **does an iOS app accelerate the civic-literacy pivot, or distract from it?** If the answer isn't an obvious yes, don't build it yet.
+
+**CPO.** Scope is "MVP" in name only. Four iOS-native features (push, widget, share extension, offline), plus a full reader, plus a new API surface, plus auth, plus bookmarks sync, plus universal links, in 8 weeks. That's a parity build with extra steps. A true MVP picks **one** native superpower and ships it: the share extension is the only one that materially changes the user's relationship with Sift ("what's the actual story behind this link" is the civic-literacy mission expressed in one gesture). Push and widget are table stakes for v1.5 once we know who actually uses the app.
+
+**CTO / VP Eng.** The "what a real company would do" rationale for a new `/v1/*` API is correct in steady state and wrong for *this* state. Real companies arrived at one canonical API by collapsing duplicate ones over time — they didn't start with one when they had a single client. Right now there's one client (web) and one API (Next.js routes). Building a second API in `sift-api` before the second client exists means running two read paths in parallel for months. The pragmatic sequence: **ship native against the existing Next.js routes** (add a CDN cache shim if cold starts hurt — Vercel Edge cache does this for free), and only collapse into `sift-api` when the web migration is already scheduled. Shaves 2–3 weeks off the plan.
+
+**Staff iOS engineer.** The 8-week timeline assumes a full-time iOS dev. The plan says "1 FT or 2 PT iOS + part-time backend." Where does that engineer come from? If it's the founder context-switching, double every estimate. Also: Apple Developer enrollment can be six weeks for new entities — push, share extension, and universal links **all require** the enrollment to be done before week 6 of dev. Start enrollment **today**, not week 1, or this plan slips silently. Lastly, SwiftData on iOS 17.0–17.2 has known issues; the plan acknowledges this but doesn't budget for the fallback to Core Data, which is a 1-week rewrite if it bites.
+
+**Staff backend engineer.** The new `share_artifacts` table and the push_dispatcher node are the only genuinely new backend work. Everything else in `/v1/*` is renaming existing Next.js handlers to Python — pure cost, zero new capability. Cut the rename. Reuse the Next.js routes for native reads. The new endpoints you actually need are three: `POST /v1/devices/register`, `POST /v1/share/sift-this`, `GET /v1/widget/today`. That's it.
+
+**Head of Design.** Civic-literacy on a phone is not "the web layout but smaller." The "What you should know first" primer is a paragraph + glossary tooltips — on iPhone that's a wall of text under a sticky header that no one will read. The native translation needs design work that isn't in this plan: progressive disclosure (collapsed by default, tap-to-expand the term you don't know), maybe an inline footnote pattern (number superscript → bottom sheet), maybe an entirely different IA. **No screens, no flows, no wireframes are referenced.** Add a 2-week design sprint before week 1 of engineering, or we'll rebuild this in v1.1.
+
+**Head of Growth.** Three issues. (1) **Why iPhone first, not Android?** Android is 70%+ of global share. Civic-literacy news appeals strongly outside the U.S. The plan doesn't justify the platform choice. See [`IOS_VS_ANDROID.md`](./IOS_VS_ANDROID.md). (2) Universal links are listed as "optional." They're the single highest-leverage growth feature — every shared Sift article URL, viewed by anyone with the app installed, should open in the app. Make it required v1. (3) **No ASO plan.** App name, keywords, screenshots, first-screen pitch — the plan gives App Store work two weeks at the end. Reality: the listing is the conversion funnel. Start it week 1 in parallel.
+
+**Head of Data / Analytics.** The plan's success metrics are crash-free rate and p95 latency. Those are health metrics, not success metrics. **Missing entirely:**
+
+- D1, D7, D30 retention targets
+- Push opt-in rate target (industry median: 50–60% for news)
+- Push CTR target (industry median: 3–5%)
+- Bookmark rate per session (proxy for "did the article matter")
+- Share extension usage per WAU (proxy for share-extension PMF)
+- "Read at source" tap rate (proxy for trust — too high means the summary failed)
+- Median session length & sessions/week
+- Web→app install rate (universal-link conversion)
+
+Without these, the team will ship features and have no way to know what worked. Adding the instrumentation later is 2× as expensive as adding it now.
+
+**Head of Editorial / Civic Mission.** The plan treats civic-literacy as a feature ("primer + glossary + entity chips") rather than the product. The push notification design — `importance_score > 0.9` + "breaking" heuristic — replicates exactly the notification pathology Sift was built to push back against. Sift's notifications should not be "X just happened, panic." They should be "you've been reading about X for two weeks; here's the new ruling and the three industries that lobbied against it." That's the differentiated push experience. The current spec ships generic breaking-news push, which is a race to the bottom we'll lose to AP and CNN.
+
+**CFO / Finance.** Where's the unit economics? Each "Sift this URL" call burns a Claude Haiku summarization + primer generation + entity-link pass. Estimate ~$0.005–$0.02 per call. Daily cap of 50 per user = up to $1/user/day worst case. With no monetization story in the plan, every active user is a net cost. Before any of this ships, the plan needs a paragraph on: **what does Sift charge for, and when?** If the answer is "later," the iOS build should be aggressively conservative on per-user inference cost (lower share-extension cap, cache aggressively, batch primer generation).
+
+**Legal / Privacy.** Two real risks understated. (1) **Apple §4.7 / §5.2.1 for news aggregators.** Sift summarizes copyrighted content. AP, Reuters, and Bloomberg have moved aggressively on AI summarization in 2025–26. The methodology page is good defense but not bulletproof. Get a content-rights review before submission, not after rejection. (2) **iOS push registration creates an `apns_token ↔ clerk_user_id` link** — that's a PII relationship that needs a DPA-compliant retention policy and deletion path (Clerk user deletion must cascade to `device_registrations`). Not in the plan.
+
+**Head of Support / Community.** Currently support burden is ~zero (web app, no support channel published). An iOS app with push notifications adds: "why did I get this notification," "the widget is blank," "I can't sign in on my phone," "the share extension didn't work for this URL." Plan needs a support channel before launch (a single `support@` email is fine) and the founder needs to budget ~3hrs/week for response in the first month.
+
+---
+
+## Synthesis — what should change
+
+1. **Decide the strategic question first.** Before any iOS work: is the iPhone app accelerating the civic-literacy pivot, or running in parallel to it? If parallel, kill or defer the iOS plan. If accelerating, the civic-literacy features (dossiers, primer, entity-linking) must be in v1, not v1.1. Either answer is fine; the current plan straddles both and gets neither.
+
+2. **Shrink v1 by 60%.** Pick **one** of {push, widget, share-extension} for v1. Vote: share extension, because it expresses the civic-literacy mission in a single gesture and is the only one that adds a behavior the web can't. Drop the others to v1.1. Offline cache stays — table stakes.
+
+3. **Skip the new `/v1/*` API for now.** Use the existing Next.js routes; add Edge caching if needed. Build only the three genuinely new endpoints in `sift-api`. Reclaim ~2 weeks.
+
+4. **Front-load design.** A 2-week native-IA design sprint before any Swift is written. Specifically: how the primer + glossary + entity chips translate to phone-sized progressive disclosure.
+
+5. **Instrument before you ship, not after.** PostHog + Sentry + a defined KPI dashboard (D1/D7/D30 retention, push opt-in, push CTR, share-extension WAU, "read at source" rate, web→app install rate) live before TestFlight, with explicit targets in the plan.
+
+6. **Add a revenue paragraph.** Even if it's "Sift is free through 2026 and explores subscription in 2027," put the actual decision in writing so eng knows the cost ceiling.
+
+7. **Justify iPhone-first explicitly, or do Android first.** See [`IOS_VS_ANDROID.md`](./IOS_VS_ANDROID.md). One sentence in the plan: "iPhone first because [editorial users / English-speaking U.S. market / TestFlight pipeline / iOS HIG fits civic-literacy patterns]." If you can't write that sentence with conviction, reconsider.
+
+8. **Apply for Apple Developer Program today.** Not week 1. Today. It's the single longest lead-time item.
+
+---
+
+## KPI scorecard the plan needs (and currently lacks)
+
+| KPI | Target for "iOS was worth building" | Why |
+|---|---|---|
+| D30 retention (iOS) | ≥ 25% | Below this and the app is uninstalled before push earns its keep |
+| Push opt-in rate | ≥ 50% | Industry-median news app; below means our permission ask is mistimed |
+| Push CTR | ≥ 4% | Sift's differentiated push thesis lives or dies here |
+| Share extension uses / WAU | ≥ 2 | Validates the "what's the actual story" use case |
+| Web → iOS install rate (via universal link banner) | ≥ 8% | Validates the funnel exists |
+| Sessions / WAU | ≥ 5 | News habit formation; under 3 and we're a one-time-read app |
+| % of sessions ending in ≥ 1 primer expand or chip tap | ≥ 40% | Civic-literacy actually being used, not just shipped |
+| iOS share of total WAU within 6 mo | ≥ 30% | Validates the platform-priority call |
+
+Set these targets in the plan. Without them, "the iOS app shipped" is a feature delivery, not a result.
+
+---
+
+## Where I'd land if asked to commit
+
+If I were the deciding voice: **defer the iOS app by one quarter.** Spend that quarter completing the civic-literacy pivot on web, getting to a credible web KPI floor (DAU > 1K, D30 > 20%), and *then* build native — with civic-literacy as the headline feature, not a footnote. The current plan is technically sound but strategically premature. Shipping it in May–July 2026 would consume the founder for 10 weeks at the exact moment the web product needs the most attention.
+
+If that's not the call and native ships now: cut to the **share-extension MVP** sketched above, ship it in 4 weeks not 10, and use the launch to learn what the next native feature should be.
+
+---
+
+*This document is the cross-functional review record for `IOS_APP_PLAN.md`. When the plan is revised, this assessment stays put as the historical record of what the panel said. Subsequent reviews go in new files (`IOS_APP_ASSESSMENT_v2.md`, etc.) or are appended below with date headers.*

--- a/docs/IOS_APP_PLAN.md
+++ b/docs/IOS_APP_PLAN.md
@@ -1,0 +1,449 @@
+# Sift — iPhone App Plan (sift-ios v1)
+
+**Date:** May 20, 2026
+**Status:** Plan — not yet started
+**Companion docs:** [`PRD.md`](./PRD.md), [`PROJECT_PLAN.md`](./PROJECT_PLAN.md), [`TECHNICAL_SPEC.md`](./TECHNICAL_SPEC.md), [`ARCHITECTURE.md`](./ARCHITECTURE.md)
+**Sibling repos today:** `kristenmartino/sift` (Next.js, Vercel), `kristenmartino/sift-api` (FastAPI, Railway)
+**New repo proposed:** `kristenmartino/sift-ios` (Swift, App Store Connect)
+
+---
+
+## TL;DR — decisions locked
+
+| Decision | Choice | Why |
+|---|---|---|
+| Stack | **Native Swift / SwiftUI** | Best feel, full access to WidgetKit / share extension / APNs / Live Activities; matches the editorial polish of the web app. |
+| v1 scope | **Focused reader MVP** | Feed across 10 categories + article detail with the civic-literacy footnotes + topic search + Clerk-synced bookmarks. Compare and civic dossier index ship in v1.1+. |
+| API home | **Single canonical API in `sift-api`** (`/v1/feed`, `/v1/topic`, `/v1/articles/:id`, etc.) | What mature publishers do (NYT, WSJ, Bloomberg): one content API, many clients. The Next.js read routes migrate behind it over time. Avoids building a "mix" we'd have to unwind. |
+| iOS-native features in v1 | **Push notifications, "Today on Sift" home-screen widget, "Sift this URL" share extension, offline cached feed** | These are the four that justify a native app vs a mobile-web bookmark. Everything else is deferred. |
+
+The rest of this doc is the how.
+
+---
+
+## Why an iPhone app
+
+Sift's reader surface is great on mobile web — but a phone is where news actually gets read, and three things on iPhone can't be done as a web page:
+
+1. **A glance is a moment, not a session.** A home-screen widget shows the top story per category before the user even opens an app. That's where Sift's "the day in 10 categories" framing earns its keep.
+2. **News breaks. Phones notify.** Followed topics → push notifications gives Sift a place in the "what just happened" loop that mobile web can't touch.
+3. **The internet flows through Share.** "I saw this link, what's the actual story?" is the moment Sift's civic-literacy layer is most valuable — and on iPhone that moment routes through the Share sheet, which only a native (or extension-bearing) app reaches.
+
+The bar for v1 is: a Sift user who installs the iOS app should never go back to mobile web for routine reading.
+
+---
+
+## v1 scope
+
+### In v1 (focused reader MVP)
+
+- **Feed across 10 categories** — Top, Technology, Business, Science, Energy, World, Health, Politics, Sports, Entertainment. Same source-of-truth as the web feed.
+- **Article detail view** — title, summary, "What you should know first" primer panel, inline glossary chips with tooltip previews, outlet badge with AllSides/MBFC ratings. Tap-through to read the original source in `SFSafariViewController`.
+- **Topic search** — vector-search powered, SSE-streamed results, same fallback semantics as web (`matchQuality: strong | weak`, `fallbackUsed: bool`).
+- **Bookmarks** — synced via Clerk (iOS SDK), backed by the existing `bookmarks` table in Neon.
+- **Auth** — Clerk iOS SDK for sign-in; bookmarks/notifications gated behind sign-in, anonymous browsing fully supported.
+- **Theming** — Newsprint (light) + Late Edition (dark), tracking the system appearance by default. Same warm editorial palette as web.
+
+### Four iOS-native features (also v1)
+
+1. Push notifications for breaking / followed topics
+2. "Today on Sift" home-screen widget
+3. "Sift this URL" share extension
+4. Offline reading / cached feed
+
+These are detailed in [§iOS-native features](#ios-native-features-in-v1).
+
+### Explicitly *not* in v1 — see [backlog](#backlog-for-v11)
+
+- Multi-source compare (LangGraph fan-out)
+- Full civic-dossier index browse (`/civic` equivalent — politicians/orgs/bills)
+- Live Activities for developing stories
+- Siri shortcuts / App Intents
+- iPad-optimized layout
+- watchOS companion
+- Daily-briefing audio
+- Outlet dossier full pages (the badge in v1 links out to the web page for the full dossier)
+
+---
+
+## iOS architecture
+
+### Tech choices
+
+| Concern | Choice |
+|---|---|
+| UI | SwiftUI (iOS 17+ target — gives us SwiftData, observable macros, `.contentTransition`, sensible inspector APIs) |
+| Persistence | **SwiftData** for bookmarks cache + offline article cache; UserDefaults for theme + small prefs |
+| Networking | `URLSession` with `async/await`; SSE via `URLSession.bytes(for:)` line iterator |
+| Concurrency | Structured concurrency (`async/await`, `TaskGroup`) — no Combine |
+| Auth | Clerk iOS SDK (`@clerk/clerk-ios`) — provides session tokens we forward to sift-api as `Authorization: Bearer <jwt>` |
+| Image loading | `AsyncImage` for v1; promote to `Nuke` or `Kingfisher` only if we hit the cache/perf wall |
+| Analytics | PostHog iOS SDK (matches what the web uses for search analytics today) |
+| Crash reporting | Sentry iOS — already on the team's free tier |
+| CI | GitHub Actions + Fastlane (`scan`, `gym`, `pilot`) — same Actions account as `sift` / `sift-api` |
+| Distribution | TestFlight → App Store Connect |
+| Min iOS | **iOS 17.0** (covers 92%+ of active iPhones at ship time; SwiftData and the new SwiftUI animations are worth the floor) |
+
+### Module layout
+
+```
+sift-ios/
+├── Sift.xcodeproj
+├── Sift/                           # Main app target
+│   ├── App/
+│   │   ├── SiftApp.swift           # @main, scene config, Clerk init
+│   │   ├── AppRouter.swift         # Tab + deep-link routing
+│   │   └── Theme.swift             # Newsprint / Late Edition tokens (mirror web)
+│   ├── Feed/
+│   │   ├── FeedView.swift          # Category tabs, feed list
+│   │   ├── FeedViewModel.swift     # @Observable; loads /v1/feed
+│   │   ├── ArticleCard.swift       # Mirrors components/ArticleCard.tsx
+│   │   ├── StoryCard.swift         # Mirrors components/StoryCard.tsx (v1.1)
+│   │   └── CategoryPicker.swift
+│   ├── ArticleDetail/
+│   │   ├── ArticleDetailView.swift
+│   │   ├── ContextPrimerView.swift # "What you should know first"
+│   │   ├── GlossaryChip.swift      # Inline civic-term tooltip
+│   │   ├── OutletBadge.swift       # AllSides + MBFC chip
+│   │   └── EntityLinksList.swift   # People / orgs / bills mentioned
+│   ├── Search/
+│   │   ├── TopicSearchView.swift
+│   │   └── SSEClient.swift         # Generic SSE consumer over URLSession.bytes
+│   ├── Bookmarks/
+│   │   ├── BookmarksView.swift
+│   │   └── BookmarkStore.swift     # SwiftData + Clerk sync
+│   ├── Auth/
+│   │   ├── ClerkClient.swift       # Wraps the Clerk SDK
+│   │   └── SignInView.swift
+│   ├── Networking/
+│   │   ├── SiftAPI.swift           # Typed client for sift-api
+│   │   ├── Endpoints.swift
+│   │   └── Models/                 # Decodable mirrors of lib/types.ts
+│   ├── Persistence/
+│   │   ├── SwiftDataSchema.swift
+│   │   └── OfflineCache.swift      # See §Offline reading
+│   ├── Push/
+│   │   ├── PushRegistrar.swift     # APNs token → POST /v1/devices/register
+│   │   └── NotificationHandler.swift
+│   └── Resources/
+│       ├── Assets.xcassets
+│       └── DiamondMark/            # SiftLogo mirrored as PDF + SF Symbol variants
+├── SiftWidget/                     # WidgetKit extension target
+│   ├── SiftWidget.swift
+│   ├── TodayOnSiftWidget.swift
+│   └── Provider.swift              # WidgetKit TimelineProvider → /v1/widget/today
+├── SiftShare/                      # Share extension target
+│   ├── ShareViewController.swift
+│   └── SiftThisHandoff.swift       # Posts URL to /v1/share/sift-this, opens main app
+├── SiftTests/                      # XCTest unit tests
+├── SiftUITests/                    # XCUITest smoke flows
+├── Fastfile
+├── .github/workflows/ios-ci.yml
+└── README.md
+```
+
+Three Xcode targets, one Swift Package (`SiftCore`) for code shared between the main app and the widget/share extensions (data models, networking client, theme tokens). The package is in-repo, not a separate repo.
+
+### Data model — Decodable Swift mirrors
+
+The iOS `Models/` directory is a **type-faithful mirror of `sift/lib/types.ts`**. The TypeScript file is the source of truth; the Swift mirrors are hand-written and kept in sync by:
+
+1. A unit test that decodes a recorded fixture JSON response from each `/v1/*` endpoint into the Swift model — fails loudly when the API ships a shape we don't expect.
+2. A `make sync-models` script that prints a side-by-side TS-vs-Swift field list; cheap heuristic, not codegen. Codegen (via `quicktype` or an OpenAPI spec) is an option we promote to if drift gets painful — explicitly deferred to v1.1.
+
+Field-by-field mapping for the v1 surface:
+
+| TS | Swift |
+|---|---|
+| `Article` (lib/types.ts) | `struct Article: Decodable, Identifiable` — `id`, `title`, `summary`, `sourceUrl`, `sourceName`, `publishedDate: Date?`, `imageUrl: URL?`, `category: CategoryId`, `readTime: Int`, `whyItMatters: String?`, `importanceScore: Double?`, `contextPrimer: ContextPrimer?`, `outlet: OutletProfile?`, `entityLinks: [EntityLink]` |
+| `CategoryId` | `enum CategoryId: String, Decodable, CaseIterable` — same 10 cases |
+| `ContextPrimer`, `ContextPrimerTerm`, `PrimerTermLink` | direct structs |
+| `OutletProfile`, `OutletAllSidesRating`, `OutletMbfcRating` | direct structs + enums |
+| `EntityLink`, `EntityLinkType`, `CivicContext` | direct structs + enum |
+| `TopicSearchResponse`, `SSEResultsEvent`, `SSEDoneEvent`, `SSEErrorEvent` | direct structs |
+
+Date decoding uses `JSONDecoder.DateDecodingStrategy.iso8601` everywhere. The web sends ISO-8601 already; sift-api will commit to the same on its mobile endpoints (see [§API contract](#api-contract)).
+
+### Theming
+
+The web has two themes — Newsprint (light) and Late Edition (dark) — defined as CSS custom properties in `sift/app/globals.css`. The iOS app mirrors them as a `Theme` struct exposing `Color` tokens; the values are copied (not computed) so design drift between web and iOS is intentional, not accidental. A future v1.1 task: extract the palette into a JSON token file in `sift/` that both web and iOS consume.
+
+### Auth
+
+- Clerk iOS SDK for the sign-in flow (presents Apple, Google, email — same providers the web allows).
+- After sign-in, the SDK gives us a session JWT. Every request to `/v1/*` (except `/v1/feed` and `/v1/topic`, which are public-readable) sends `Authorization: Bearer <jwt>`.
+- `sift-api` already trusts the Clerk JWT verification logic that the Next.js routes use today — we add the same verifier (FastAPI dependency) on the new mobile endpoints. The Clerk JWKS URL is environment-config; no per-client divergence.
+- Anonymous browsing is supported: feed and topic search work without a token. Bookmarks, push registration, and "Sift this URL" require sign-in.
+- **No Sign in with Apple-specific path** in v1 because Apple requires SIWA *only* when the app offers third-party social sign-in. Since Clerk includes Apple as one of its providers, Apple's review guideline §4.8 is satisfied — confirm with the reviewer notes at submission.
+
+---
+
+## API contract
+
+### Recommendation: single canonical API in `sift-api`
+
+**Where this lands:** all iOS endpoints live in `sift-api` under `/v1/*`. The Next.js routes (`/api/news`, `/api/news/topic`, etc.) stay where they are *for the web app only* in the short term, but the long-term plan is to migrate the web to read from `sift-api` too, collapsing duplication.
+
+**Why this, and not a split:**
+
+- A mature publisher (NYT, WSJ, Bloomberg, Reuters) runs one content API consumed by every client. Per-client adapters live inside each client, not in the backend.
+- `sift-api` already owns the write path *and* the data. Read endpoints there are colocated with the freshness signals (pipeline state, last-run timestamps) and avoid the Vercel function cold-start tax on user-visible reads.
+- The Next.js routes are tied to App Router conventions and SSR — they're a poor surface to expose to a second client.
+- "Mix" (iOS reads from Vercel, writes/compare to Railway) is a transient state during migration, never a target. Building it as a target means you'll unwind it later.
+
+The cost: net-new Python endpoints to write in `sift-api`, and the web migration to schedule (it can lag — iOS doesn't wait on it).
+
+### Endpoints required for v1
+
+All endpoints are JSON. SSE endpoints stream `text/event-stream`. All require `X-Sift-Client: ios/1.0` for analytics + per-client rate budgeting; protected endpoints additionally require `Authorization: Bearer <clerk-jwt>`.
+
+| Method | Path | Auth | Purpose | Mirrors today's web |
+|---|---|---|---|---|
+| `GET` | `/v1/feed?category=:id&limit=:n&after=:cursor` | none | Articles + stories for a category, cursor-paginated. Returns `NewsApiResponse` shape. | `sift/app/api/news/route.ts` |
+| `GET` | `/v1/articles/:id` | none | Single article with full `ContextPrimer`, `entityLinks`, `outlet`. iOS uses this for share-extension follow-up and push deep links. | (new — web has it via the in-memory list) |
+| `GET` | `/v1/topic?q=:query` (SSE) | none | Topic search streaming `results` / `done` / `error` events. Same payload shape as web. | `sift/app/api/news/topic/route.ts` |
+| `GET` | `/v1/widget/today` | none | Compact feed shape (10 categories × top 1 story each, `title`, `sourceName`, `imageUrl`, `id`). Cacheable at edge for 5 min. | (new — widget-specific shape) |
+| `POST` | `/v1/devices/register` | Clerk JWT | Register an APNs token + topic preferences. Body: `{ apnsToken, categories: CategoryId[], followedTopics: string[] }`. Idempotent on `apnsToken`. | (new) |
+| `DELETE` | `/v1/devices/:apnsToken` | Clerk JWT | Unregister on sign-out or notif-permission revoke. | (new) |
+| `GET` | `/v1/bookmarks` | Clerk JWT | List user bookmarks. | `sift/app/api/bookmarks/route.ts` |
+| `POST` | `/v1/bookmarks` | Clerk JWT | Add a bookmark `{ articleId }`. | `sift/app/api/bookmarks/route.ts` |
+| `DELETE` | `/v1/bookmarks/:id` | Clerk JWT | Remove a bookmark. | `sift/app/api/bookmarks/route.ts` |
+| `POST` | `/v1/share/sift-this` | Clerk JWT (or anon w/ rate limit) | Sift an arbitrary URL: fetch → summarize → primer → entity-link, return an `Article` shape (not persisted to feed; per-user keyed in a new `share_artifacts` table). | (new — see §share extension) |
+
+### Conventions
+
+- **All responses are camelCase JSON.** sift-api currently mixes camel and snake in its Pydantic models; the new `/v1/*` surface is camelCase to match the iOS Swift expectations and the existing web client. Internal snake_case stays in the DB layer.
+- **Dates are ISO-8601 strings**, not Unix timestamps. Matches what the web sends today.
+- **Errors use `{ "error": string, "details"?: string, "code"?: string }`** — same as the existing `NewsApiError` shape.
+- **Versioning:** anything in `/v1/*` is treated as a public contract. Breaking changes go to `/v2/*`. The iOS app pins to the major version at build time (`SiftAPI.basePath = "/v1"`).
+- **Cursor pagination** uses opaque base64 cursors (`after=:cursor`), not page numbers. The cursor encodes `(publishedDate, id)` so paging is stable as new articles ingest.
+
+### Backwards-compat for the web (no breakage in v1)
+
+The web keeps reading from its current Next.js routes. The new `/v1/*` endpoints in sift-api are net-additive — nothing the web depends on changes. A separate plan (`docs/WEB_API_MIGRATION.md`, future) lays out moving the web off Next.js routes onto `/v1/*`; that's not blocked by, and doesn't block, the iOS ship.
+
+---
+
+## iOS-native features in v1
+
+These are the four that earn the native app. Each gets a concrete v1 design.
+
+### 1. Push notifications
+
+**Trigger sources**
+
+- **Breaking news in a subscribed category** — the pipeline node that writes a new article can flag `is_breaking: bool` based on a heuristic (TODO: which signals? Likely `importance_score > 0.9` + `published_within_last_30min`). For now: simple threshold, refined post-launch.
+- **A followed topic has a new strongly-matching article** — user follows a topic (custom_topic in the existing schema); pipeline checks new articles against followed-topic embeddings; cosine ≥ 0.85 → push.
+
+**Pipeline addition (in `sift-api`)**
+
+- New table `device_registrations(apns_token text PRIMARY KEY, clerk_user_id text, categories text[], followed_topic_ids uuid[], created_at, last_seen_at)`.
+- New workflow node `push_dispatcher` runs after `store` in `pipeline_workflow.py`. For each new article, computes the target audience and enqueues APNs sends.
+- APNs sending via the `apns2` Python package, HTTP/2 with token auth. Apple Developer account: required ahead of time (4–8 weeks if not already enrolled).
+- Per-user dedupe: max one push per user per 15 minutes per category, max 5/day across everything. Hard-coded for v1; user-tunable in v1.1.
+
+**iOS app**
+
+- Request notification permission on first launch *only* after the user shows intent (taps "Notify me when news breaks" in onboarding, not a cold prompt). Apple's HIG strongly discourages the cold permission ask.
+- Notification payload includes `articleId` + category + a deep link (`sift://article/:id`).
+- Tapping the notification opens the app directly to `ArticleDetailView` for that article — `AppRouter` handles the deep link.
+
+**Out of scope for v1:** notification grouping/threading, rich notifications with images (defer until we see what the real engagement patterns look like — pretty notifications without earned trust will get muted).
+
+### 2. "Today on Sift" home-screen widget
+
+**Sizes:** small + medium for v1; large defers to v1.1.
+
+**Small widget:** one story — the top story from the "Top" category. Headline (3 lines max), source name, category color dot. Tapping opens the article.
+
+**Medium widget:** four stories arranged as a 2×2 — top stories from Top, Politics, Technology, Business (or user's first four "favorite" categories, set in app settings). Tap-target per cell.
+
+**Timeline**
+
+- WidgetKit `TimelineProvider` requests a snapshot at midnight local and every 4 hours after that.
+- Each refresh hits `GET /v1/widget/today` (cached at edge for 5 min — same data for every device, no per-user shape in v1).
+- Failure mode: timeline keeps the last successful snapshot for up to 24h; widget never goes blank, only goes stale.
+
+**Out of scope for v1:** Lock Screen widget, StandBy widget, watchOS complication. Deferred to v1.1.
+
+### 3. "Sift this URL" share extension
+
+The use case: user is reading a link in Safari / Messages / Twitter and wants Sift to do its civic-literacy thing — *"what's the actual story, and what should I know about it?"*
+
+**iOS side**
+
+- `SiftShare` extension target, declared for `public.url` and `public.plain-text` activity types.
+- The extension UI is a tiny SwiftUI sheet: "Sift this article?" + a spinner. Calls `POST /v1/share/sift-this` with the URL.
+- On success, hands off to the main app via `UIApplication.open(sift://share/:artifactId)`. Main app deep-links to a temporary `ArticleDetailView` rendering the response.
+- Failure modes (paywall, JS-rendered page, not-an-article): the extension shows a one-line reason and a "Try anyway" button that re-posts with `force: true`. Won't gold-plate this in v1 — the long-tail of weird pages is large.
+
+**Backend side**
+
+- New endpoint `POST /v1/share/sift-this { url }` in `sift-api`.
+- Reuses the existing pipeline pieces in `services/`: a one-off invocation of `summarizer.summarize` + `embedder.embed` + the primer generator + entity_linker. No DB write to `articles` (the feed is curated from RSS, not user submissions); writes a row to a new `share_artifacts` table keyed by `(clerk_user_id, url_hash)` so repeats are cached for 7 days.
+- Rate-limited: 10 / hour / signed-in user, 3 / hour / anon (anon goes through a soft IP-derived limit).
+- LLM cost guardrail: a `max_share_artifacts_per_day_per_user` config (default 50) so a runaway abuser can't burn the Claude bill.
+
+**Anti-abuse**
+
+- URL allowlist *(not)*: we don't restrict URLs — restricting kills the use case. We rely on rate limits + a daily cost ceiling instead.
+- Spam URLs (porn, malware) get caught by Claude's existing safety filters when summarization runs; we surface a generic "couldn't process this page" response rather than a content reason.
+
+### 4. Offline reading / cached feed
+
+The minimum that matters: a user on a subway shouldn't see a blank app.
+
+**What's cached**
+
+- The most recent successful `/v1/feed` response per category (10 categories × ~30 articles ≈ 300 article rows), persisted via SwiftData.
+- For each cached article, the body of the latest `ContextPrimer` + `entityLinks` (small JSON, fine to inline).
+- *Not cached:* original-source web content. Tapping "Read at source" while offline opens `SFSafariViewController` which handles offline gracefully (shows its own offline UI). We don't try to scrape and store source HTML.
+
+**Behavior**
+
+- On app launch: paint cached feed first, then revalidate against `/v1/feed` in the background. Web-style "stale-while-revalidate."
+- A small "Last updated 14m ago" line under the category header. Stale > 2h → muted color; stale > 24h → "Showing yesterday's news" banner.
+- Cache eviction: keep the most recent 7 days of articles, evict older. Cap total disk usage at 50 MB (images dominate — we ship a max image cache size to `AsyncImage`'s underlying cache).
+
+**Bookmarks offline**
+
+- Bookmark adds while offline queue locally in SwiftData and sync to `/v1/bookmarks` when network returns. Removes likewise. Conflict policy: client wins for v1 (a removed bookmark stays removed even if the server reinstated it from another device); we revisit if we see complaints.
+
+---
+
+## Cross-repo work
+
+| Repo | What changes | Why |
+|---|---|---|
+| **`kristenmartino/sift-ios`** *(new)* | Entire iOS codebase: app, widget, share extension, tests, Fastlane, CI. | Net-new client. |
+| **`kristenmartino/sift-api`** | Add `/v1/feed`, `/v1/articles/:id`, `/v1/topic`, `/v1/widget/today`, `/v1/devices/*`, `/v1/bookmarks/*`, `/v1/share/sift-this` endpoints. Add `device_registrations` + `share_artifacts` tables (init.sql + a migration). Add `push_dispatcher` workflow node + APNs sender. Move JSON shape to camelCase for `/v1/*` only. | Single-canonical-API decision lands here. |
+| **`kristenmartino/sift`** | No required changes for iOS to ship. *Optional:* App Store / Open Graph banner ("Get the app") on the marketing page; deep-link verification (`apple-app-site-association` served at `/.well-known/apple-app-site-association`) so `siftnews.kristenmartino.ai/article/:id` links open the iOS app when installed. | Marketing + universal-links polish, not blocking. |
+
+### Apple developer prerequisites (start now — these have lead time)
+
+1. **Apple Developer Program enrollment** — $99/yr; 24–72h for personal, can be 4–8 weeks for new business entities. **Start in week 1.**
+2. **App Store Connect app record** — needs a bundle ID, name ("Sift — News with Footnotes"?), category (News), age rating, privacy nutrition labels.
+3. **APNs key (.p8)** — generate once, store in Railway env as `APNS_AUTH_KEY` for `sift-api`.
+4. **Universal Links domain verification** — host `apple-app-site-association` JSON at `siftnews.kristenmartino.ai/.well-known/apple-app-site-association`.
+5. **Privacy nutrition labels** — Sift collects: account info (Clerk), device identifiers (APNs token), product interaction (PostHog), crash data (Sentry). Draft these against the [App Store Connect questionnaire](https://developer.apple.com/app-store/app-privacy-details/) early; reviewer will check.
+6. **App Review prep** — demo Clerk account credentials in reviewer notes, "Sign in not required to browse feed" explicitly called out, content moderation policy linked (the existing `/methodology` page is the right URL).
+
+---
+
+## Phasing & milestones
+
+Eight working weeks to TestFlight, ten to App Store. Assumes 1 full-time iOS dev or 2 part-time, plus part-time backend availability in `sift-api` weeks 1–3.
+
+### Week 1 — foundations
+
+- Create `kristenmartino/sift-ios` repo, Xcode project, Swift Package `SiftCore`.
+- Apple Developer enrollment kicked off.
+- `sift-api`: scaffold `/v1` router, port `/api/news` semantics into `/v1/feed`, deploy. Camel-case JSON model wrappers in place.
+- Smoke: iOS app loads `/v1/feed?category=top` and renders article titles in a `List`.
+
+### Week 2 — feed + theme
+
+- `FeedView` with category tabs (`TabView` + a horizontal scroller for the 10 categories).
+- `ArticleCard` matches the web's text-first design; outlet badge; category color dot.
+- Newsprint / Late Edition theme tokens; respect system appearance + a manual override in Settings.
+- Pull-to-refresh; loading skeletons; error state.
+
+### Week 3 — article detail + civic-literacy
+
+- `ArticleDetailView` rendering the full primer, glossary chips with tap-to-expand tooltips, entity-link chips that link to the web dossier in `SFSafariViewController` (full native dossier views deferred to v1.1).
+- Outlet badge tap → outlet dossier in `SFSafariViewController`.
+- "Read at source" → `SFSafariViewController` with reader mode hint.
+
+### Week 4 — search + bookmarks + auth
+
+- Clerk iOS SDK integration; sign-in / sign-up flow.
+- `TopicSearchView` with the SSE consumer (`SSEClient.swift`). Match-quality / fallback chips identical to web.
+- Bookmarks UI; local store with SwiftData; `/v1/bookmarks` sync on sign-in.
+- `sift-api`: `/v1/topic` SSE endpoint, `/v1/bookmarks` endpoints.
+
+### Week 5 — offline cache
+
+- SwiftData schema for cached articles.
+- Stale-while-revalidate behavior on app launch.
+- "Last updated" UI; offline banner.
+- Cache eviction + size cap; verify on a low-storage device.
+
+### Week 6 — push notifications
+
+- `sift-api`: `device_registrations` table; `/v1/devices/register` + `DELETE`; `push_dispatcher` workflow node; APNs sender via `apns2`.
+- iOS: `PushRegistrar` requests permission post-intent; foreground / background handling.
+- End-to-end test: insert a flagged article via psql, observe APNs delivery on a real device.
+
+### Week 7 — widget + share extension
+
+- `SiftWidget` target; `/v1/widget/today` endpoint; small + medium widget layouts.
+- `SiftShare` target; `/v1/share/sift-this` endpoint reusing existing summarizer + primer code; deep-link handoff.
+- Both manually tested across light / dark / both Newsprint and Late Edition themes.
+
+### Week 8 — polish + TestFlight
+
+- Crash + analytics wiring (Sentry, PostHog).
+- Privacy nutrition labels filled in App Store Connect.
+- Universal links live (`apple-app-site-association` deployed).
+- App icon (the diamond mark as a PDF, generated for all required sizes), launch screen.
+- Submit to TestFlight; internal testers (you + design + 5 friends) onboarded.
+
+### Weeks 9–10 — App Store submission
+
+- Bug-fix from TestFlight feedback.
+- Screenshots for App Store (6.7" + 6.1" + iPad Pro 12.9" minimum — the iPad shots can be "iPhone app, scaled" until v1.1).
+- Reviewer notes prepared; demo account; methodology link.
+- Submit for review; expect 1–3 day turnaround, plan for 1 round of resubmission.
+
+### Post-launch
+
+- Watch crash-free-session rate (target ≥ 99.5%), `/v1/feed` p95 latency (target ≤ 800ms cold), push delivery rate.
+- Read user reviews daily for the first 2 weeks; mine for v1.1 priorities.
+
+---
+
+## Risks & open questions
+
+| Risk / question | Mitigation / next step |
+|---|---|
+| **Apple Developer enrollment delays.** New entities can take 4–8 weeks. | Start week 1. No work blocks on it until TestFlight (week 8). |
+| **App Store review of news apps + AI summarization.** Reviewers occasionally flag aggregators for §4.7 (content origin) or §5.2.1 (proper rights). | Methodology page + per-article source attribution + clear "read at source" affordance. We don't republish, we summarize-with-citation. Plenty of precedent (Apple News, Artifact). |
+| **APNs cost & deliverability.** APNs is free; the cost is the LLM inference + DB queries that decide *who* to push to. | Per-user rate limits and a daily push budget. Monitor `push_dispatcher` p95 in week 6. |
+| **"Sift this URL" abuse / cost runaway.** Each share triggers a Claude summarization + primer generation. | Hard daily budget per user; soft IP-based limit for anon. Telemetry on `share_artifacts` insert rate. |
+| **Civic-literacy shape changes between now and ship.** The web civic pivot is mid-flight (`plans/sift-civic-literacy.md`). | iOS data models tolerate optional fields (`contextPrimer?`, `outlet?`, `entityLinks` defaulting to `[]`). API contract test catches shape drift in CI. We freeze the v1 iOS surface against the web shapes as of week 1 and treat civic-pivot field additions as additive. |
+| **The web Next.js routes vs new `/v1/*` — drift between them.** | Long-term we migrate web to `/v1/*`. Short-term we just don't let drift happen — the new endpoints in `sift-api` reuse the same `lib/db.ts` query patterns (translated to Python). A small contract test in `sift` confirms `/api/news` and `/v1/feed` return semantically equivalent payloads for the same category. |
+| **Open question: SwiftData under load.** SwiftData has rough edges in iOS 17.0–17.2 with large CloudKit-backed stores. | We're not using CloudKit (bookmarks sync goes through Clerk + sift-api, not iCloud). Local-only SwiftData has been stable. If it bites, fall back to Core Data. |
+| **Open question: do we ship a dossier index in v1?** | Currently scoped out. Dossier *chips inside an article* link to the web `/dossier/...` page via `SFSafariViewController` — good enough for v1. Full native dossier views are v1.1. |
+| **Open question: paywalled outlets in the feed.** | Same behavior as the web: Sift summary is shown; "Read at source" leads to a paywall the user sees. No change in v1. |
+
+---
+
+## Backlog for v1.1+
+
+Tracked here so the v1 scope discussion has a destination for cut features. None of these block v1.
+
+- **Multi-source compare** — port `/api/compare` SSE workflow; native UI for the framings comparison view.
+- **Native civic dossier views** — politicians, orgs, bills, outlets. Today they open in `SFSafariViewController`; native pages give us deep-link smoothness + offline.
+- **Civic dossier index browse** — equivalent of the web `/civic` page on iOS.
+- **Live Activities** for developing stories — Dynamic Island + lock screen updates as a story evolves (new outlets, new claims surfaced by compare).
+- **Lock Screen widgets + StandBy widget**.
+- **Siri shortcuts / App Intents** — "Hey Siri, sift today" → opens to the Top tab; "Sift this" share intent for voice.
+- **watchOS companion** — glance + complications; tap-through to phone for the article body.
+- **iPad-optimized layout** — three-pane layout (categories / feed / detail), keyboard shortcuts.
+- **Daily-briefing audio** — Claude-narrated summary of the top 5 stories with the civic footnotes inline. Pairs well with CarPlay.
+- **Bookmark collections / read-later** — moving from a flat list of bookmarks to user-defined folders.
+- **Reading-level toggle** — the `ReadingLevels` field on `Article` is already forward-declared in `lib/types.ts`. Render "Simpler / Default / Detailed" picker when the pipeline starts writing alternates.
+- **OpenAPI spec + codegen** — when the manual TS↔Swift mirroring gets painful (probably around 50+ model fields), generate from an OpenAPI spec emitted by sift-api.
+- **Migration of web to `/v1/*`** — own plan doc; not iOS-blocking.
+
+---
+
+## Appendix — file inventory at v1 ship (estimated)
+
+- `sift-ios` — ~120 Swift source files, ~12k LOC (app + widget + share extension + tests + SiftCore package).
+- `sift-api` — +12 net-new endpoints across 3 new routers (`mobile_feed.py`, `devices.py`, `share.py`), +2 tables, +1 workflow node, ~1,500 net-new LOC.
+- `sift` — no required changes; +1 marketing banner + 1 well-known file if we wire universal links in v1 (~50 LOC).
+
+---
+
+*This plan supersedes the iOS section (currently empty) of `PROJECT_PLAN.md`. Once approved, the v1.1+ backlog above gets promoted to its own tracking doc, and the iOS-specific changes to `sift-api` move into that repo's `CLAUDE.md` orientation.*

--- a/docs/IOS_APP_PLAN.md
+++ b/docs/IOS_APP_PLAN.md
@@ -1,10 +1,18 @@
 # Sift — iPhone App Plan (sift-ios v1)
 
 **Date:** May 20, 2026
-**Status:** Plan — not yet started
-**Companion docs:** [`PRD.md`](./PRD.md), [`PROJECT_PLAN.md`](./PROJECT_PLAN.md), [`TECHNICAL_SPEC.md`](./TECHNICAL_SPEC.md), [`ARCHITECTURE.md`](./ARCHITECTURE.md)
+**Status:** ⚠️ **Under review — do not act on this plan as written.** See companion docs below.
+**Companion docs:** [`IOS_APP_ASSESSMENT.md`](./IOS_APP_ASSESSMENT.md), [`IOS_VS_ANDROID.md`](./IOS_VS_ANDROID.md), [`PRD.md`](./PRD.md), [`PROJECT_PLAN.md`](./PROJECT_PLAN.md), [`TECHNICAL_SPEC.md`](./TECHNICAL_SPEC.md), [`ARCHITECTURE.md`](./ARCHITECTURE.md)
 **Sibling repos today:** `kristenmartino/sift` (Next.js, Vercel), `kristenmartino/sift-api` (FastAPI, Railway)
 **New repo proposed:** `kristenmartino/sift-ios` (Swift, App Store Connect)
+
+> ### Review summary (May 20, 2026)
+>
+> A cross-functional assessment of this plan (see [`IOS_APP_ASSESSMENT.md`](./IOS_APP_ASSESSMENT.md)) identified material issues — most importantly that the v1 scope is parity-shaped not MVP-shaped, the new `/v1/*` API in `sift-api` is premature for a pre-PMF product, and KPIs / monetization are missing. A separate platform analysis ([`IOS_VS_ANDROID.md`](./IOS_VS_ANDROID.md)) argues Android-first is the stronger call for Sift's civic-literacy mission, with PWA-improved web as the cheapest interim step.
+>
+> **Current direction (open):** revise toward a much smaller scope (likely "share extension only" on whichever platform ships first), or defer native entirely and improve PWA on web. Decision pending.
+>
+> Plan body retained below as the reference artifact for the original proposal. Do not start implementation against it.
 
 ---
 

--- a/docs/IOS_VS_ANDROID.md
+++ b/docs/IOS_VS_ANDROID.md
@@ -1,0 +1,83 @@
+# Sift — iOS vs Android (platform-first analysis)
+
+**Date:** May 20, 2026
+**Status:** Active — open decision
+**Companion docs:** [`IOS_APP_PLAN.md`](./IOS_APP_PLAN.md), [`IOS_APP_ASSESSMENT.md`](./IOS_APP_ASSESSMENT.md)
+
+The original iPhone plan assumed iOS-first by default. This document scrutinizes that assumption and recommends Path A (Android-first, with a PWA bridge on web first).
+
+---
+
+## The honest read
+
+**Android-first is defensible for most news products. iOS-first is defensible for Sift specifically.** The reason has nothing to do with iOS being "better" — it's that Sift's content surface in v1 is U.S.-only (FARA, OpenSecrets, GovTrack, ProPublica, Congress.gov), and the U.S. news-engaged, educated, high-income audience — the people who'd actually use a civic-literacy reader — is ~65–70% iPhone. Globally Android dominates 70/30, but globally Sift's content doesn't apply.
+
+That argument has a shelf life of about one quarter. The moment Sift broadens beyond U.S. civic content (UK Companies House data, EU Transparency Register, Canadian lobbying registry — all in scope for the same thesis), the platform math flips immediately. **iOS-first only works if Sift commits to a U.S. v1 and ships Android within ~6 months of the iOS launch.**
+
+---
+
+## What the tie-breaker actually depends on
+
+| Optimize for | Picks |
+|---|---|
+| Engagement quality + monetization later | iOS first |
+| Reach + mission scale (civic literacy for everyone) | Android first |
+| Dev velocity & cost (no $99/yr, no enrollment delay, lenient store review) | Android first |
+| News-app brand signal & TestFlight beta loop | iOS first |
+| Lowest App Review rejection risk for AI summarization | Android first |
+| Native widget / share-extension quality | iOS first (Android equivalents exist but OEM fragmentation degrades them) |
+
+Three of those favor Android in ways the original plan didn't acknowledge. The one to weight heaviest right now: **dev velocity.** A solo builder mid-pivot can ship a Kotlin/Compose app to Play Store in roughly 60% of the time it takes to ship the same SwiftUI app to App Store, and the Play Store review is forgiving in ways App Review is not. For a not-yet-PMF product, that's enormous.
+
+---
+
+## The question to ask before iOS vs Android
+
+If both platforms ship eventually — and for a civic-literacy product with global ambition, both should — the platform-first question is the wrong question. The right one is: **native-per-platform or cross-platform?** The original plan steered to native Swift because the question was "iOS-best." If the answer is now "we're shipping both," the math changes:
+
+- **Two native codebases (SwiftUI + Compose):** ~1.8× the work, best feel, full access to widget / share / Live Activity / Glance.
+- **Flutter or KMP shared core + native UI:** ~1.2–1.3× the work for both platforms vs one, near-native feel, slight degradation on the platform-specific native features.
+- **PWA-first (delay native entirely):** ~0.1× the work — Sift's web app mostly already does this. Add `manifest.ts` (already there), service worker for offline, push via Web Push API (works on Android, partial on iOS 16.4+). Ship that in 1–2 weeks and use it to learn what natives users would actually pay for.
+
+---
+
+## Two paths forward
+
+### Path A — Mission-first (Android leading)
+
+1. Ship PWA-improved web first (~2 weeks): service worker for offline, install prompt, Web Push API.
+2. Use it to learn what users actually do on phones — which features drive sessions, what content they bookmark, where they bounce.
+3. Then Android-first native (~8 weeks, Kotlin/Compose), with content broadened beyond U.S.-only civic data to justify the global reach.
+4. iOS follows ~Q4 2026.
+
+### Path B — Audience-first (iOS leading, but smaller)
+
+1. Ship PWA-improved web first (~2 weeks). Same as Path A.
+2. Then the **share-extension MVP iOS app** sketched in [`IOS_APP_ASSESSMENT.md`](./IOS_APP_ASSESSMENT.md) (~4 weeks, not 10).
+3. Android starts the moment the iOS share-extension validates the "Sift this URL" use case.
+4. Full iOS reader follows once the share extension has signal.
+
+---
+
+## Recommendation
+
+**Path A.** The civic-literacy mission is more aligned with Android's reach than iOS's premium audience, and the dev-velocity advantage of Android-first for a solo builder is decisive. The "but iPhone users pay more" argument only matters once there's something to charge for, which is the wrong problem to be solving in 2026.
+
+The strongest counter to this recommendation: **if Sift stays U.S.-only through 2026**, Path B is closer to right (the U.S. civic-literacy audience really is iOS-skewed). The decision hinges on the geography of Sift's v1 content, which is itself an open product question.
+
+---
+
+## Decision queue (open)
+
+The platform-first question can't be resolved alone — it depends on:
+
+1. **Geographic scope of civic content** in v1. U.S.-only → tilts iOS. Global from the start → tilts Android.
+2. **Native vs cross-platform vs PWA.** If PWA gets us 80% of the value at 10% of the cost, native ordering matters less.
+3. **Monetization timeline.** Subscription in 2027? → iOS first matters. Free indefinitely? → Android first matters.
+4. **Solo-builder reality.** 8–10 weeks of dev is 8–10 weeks not spent on the civic-literacy pivot. May argue for PWA-only through 2026.
+
+These four decisions should land before the platform-first call is made.
+
+---
+
+*This document accompanies the iOS plan assessment and predates a final platform decision. Once a platform-first direction is chosen, this doc moves to `archived/` and the chosen path becomes the active plan.*


### PR DESCRIPTION
## Summary

Two things bundled (same branch, kept as a single PR since they're connected):

1. **Project state management scaffolding** — `STATUS.md` + `CLAUDE.md` at repo root, following the quickstart pattern already applied to `sift-mcp` (PR #5 there).
2. **iOS planning artifacts** — the original iPhone plan, a cross-functional assessment that flagged it as parity-shaped + premature, and an iOS-vs-Android platform analysis. All under `docs/`, marked **under review** until the open strategic question is resolved.

## Files

| File | Status | Purpose |
|---|---|---|
| `STATUS.md` | new | Active focus / Open question / Next 3 / Blocked-on / Recent decisions |
| `CLAUDE.md` | new | Pre-session ritual + end-of-PR doc-impact check (root, not under `docs/`) |
| `docs/IOS_APP_PLAN.md` | new | Original iPhone-app plan — **status banner: under review** |
| `docs/IOS_APP_ASSESSMENT.md` | new | 12-stakeholder cross-functional critique + KPI scorecard |
| `docs/IOS_VS_ANDROID.md` | new | Platform-first analysis; recommends Android-first (Path A) |

## State created (snapshot — see `STATUS.md` for the live version)

**Active focus:** civic-literacy pivot rollout on web; recent ship: 170 dossier entries, entity linker fix, PRODUCT_STORY refresh, portfolio-v2 case study, sift-mcp v0.1 + Harish DM.

**Open strategic question:** native platform first — iOS vs Android? Working recommendation: **start Android while iOS enrollment is pending** (turns 4–8wk wait into a shipped Android v1).

**Next 3:**
1. `[committed]` #56 — SSR / streaming for `/news` first-paint · `tier-v1.5` `effort-week`
2. `[committed]` #98 — Civic-literacy pivot final-mile checklist · `tier-v1.5` `effort-weeks`
3. `[sketch]` Resolve native platform direction · `tier-v2` `effort-day` (decision-only)

**Blocked-on:** Apple Developer enrollment; Harish demo response; native-platform decision.

**Recent decisions:** iOS plan under review; canonical `/v1/*` API deferred; Android-first leaning; DMCA-low-risk on Railway. Plus sift-mcp side: hybrid index+web, 26-outlet pool, `compare_outlets` unified-claims-array, `load_dotenv(override=True)`.

## Manual follow-up (no MCP tool for these in the current harness)

### Labels to create on this repo

```bash
gh label create effort-day      --color cccccc --description "<1 day of focused work"
gh label create effort-week     --color bbbbbb --description "1–7 days of focused work"
gh label create effort-weeks    --color 999999 --description "2+ weeks of focused work"
gh label create tier-v1         --color 0e8a16 --description "Shipped surface — maintenance only"
gh label create tier-v1.5       --color 1d76db --description "Civic-literacy pivot in flight"
gh label create tier-v2         --color 5319e7 --description "Native client family"
gh label create tier-v3         --color e99695 --description "Speculative future"
gh label create tier-v4         --color f9d0c4 --description "Speculative future"
```

### Apply labels to new + relevant existing issues

```bash
gh issue edit 98 --add-label "tier-v1.5,effort-weeks"   # Civic-literacy final-mile (new)
gh issue edit 56 --add-label "tier-v1.5,effort-week"    # SSR perf
gh issue edit 59 --add-label "tier-v1.5,effort-week"    # Design system extract
gh issue edit 60 --add-label "tier-v1.5,effort-week"    # Craft polish
gh issue edit 62 --add-label "tier-v1.5,effort-day"     # ESLint migration
```

### Add to user-level Project ("Kristen Portfolio" — `users/kristenmartino/projects/3`)

- `kristenmartino/sift#98` — Civic-literacy pivot — final-mile checklist
- `kristenmartino/sift#56` — SSR perf
- *(sift-api issues are added on its own PR below)*

UI: https://github.com/users/kristenmartino/projects/3 → `+ Add item` → paste each issue URL.

## Test plan

- [ ] `STATUS.md` renders correctly on GitHub
- [ ] `CLAUDE.md` renders correctly on GitHub
- [ ] All `docs/IOS_*.md` cross-links resolve
- [ ] Labels created (manual, post-merge)
- [ ] Issues added to Project (manual, post-merge)

## Related

- Sibling PR on `sift-api`: project-state-mgmt + DMCA / dossier issues (forthcoming in same push)
- Companion repo: `kristenmartino/sift-mcp` PR #5 set this same pattern up there (greenfield, 30 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fiartht66EhNgcPGJsBmo7)_