### PR TITLE
docs: add HOW_IT_WORKS.md + KPIS.md (interview-prep + success rubric)

### DIFF
--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -1,0 +1,158 @@
+# Sift — How It Works
+
+**Updated:** 2026-05-20
+**Audience:** future-me; agents picking up this codebase; you, sketching it on a whiteboard during an interview
+
+The 5-minute version of Sift end-to-end. Read this once; then you can talk about the system without opening the codebase. For depth on any layer, follow the links to the canonical docs.
+
+---
+
+## The product in two sentences
+
+Sift is "the news, with footnotes" — an AI-curated news reader with a civic-literacy layer that adds the context news assumes you already have: an adaptive "what you should know first" primer, inline glossary tooltips, structured dossiers on every politician / organization / bill / outlet, and cross-spectrum framing — all sourced from public records (OpenSecrets, GovTrack, ProPublica, FARA, AllSides, MBFC). Live at [siftnews.kristenmartino.ai](https://siftnews.kristenmartino.ai).
+
+## The architecture in three boxes
+
+```mermaid
+flowchart LR
+  Browser((Browser / iPhone))
+
+  subgraph Vercel[Vercel - Next.js 15]
+    Next[Next.js App + Server Components]
+  end
+
+  subgraph Railway[Railway - FastAPI + LangGraph]
+    Sched["asyncio scheduler<br/>every 10 min"]
+    PipeWF[Pipeline workflow]
+    CmpWF[Compare workflow]
+  end
+
+  subgraph Neon[Neon Postgres + pgvector]
+    Articles[(articles + embeddings)]
+    Stories[(stories)]
+    Dossiers[(politicians, orgs, bills, outlets)]
+    Bookmarks[(bookmarks)]
+  end
+
+  Claude(["Claude Haiku 4.5"])
+  Voyage(["Voyage AI embeddings"])
+  RSS(["100+ RSS feeds"])
+  Clerk(["Clerk auth"])
+
+  Browser <--> Next
+  Next -- reads --> Neon
+  Next -- proxy compare --> CmpWF
+  Sched --> PipeWF
+  PipeWF -- fetch --> RSS
+  PipeWF -- summarize --> Claude
+  PipeWF -- embed --> Voyage
+  PipeWF -- writes --> Neon
+  CmpWF -- fan-out search --> Claude
+  Next -. auth .-> Clerk
+```
+
+Three deployment surfaces, one source of truth:
+
+| Surface | Owns | Repo |
+|---|---|---|
+| **Vercel** — Next.js 15, App Router, TypeScript | The user-facing reads + UI | `kristenmartino/sift` |
+| **Railway** — Python 3.12, FastAPI, LangGraph | The background pipeline + on-demand compare workflow + write path | `kristenmartino/sift-api` |
+| **Neon Postgres** with pgvector | All persistent state — articles + embeddings, stories, dossiers, bookmarks | shared |
+
+Plus: Clerk for auth, Sentry for error tracking, Anthropic API for Claude, Voyage AI for embeddings.
+
+## The three user paths through the system
+
+### 1. Browse path — what 99% of traffic does
+
+- Open `siftnews.kristenmartino.ai/news?category=politics`
+- Next.js Server Component reads from Postgres (`sift/lib/db.ts` query, partial indexes from `migrations/004_feed_indexes.sql` in sift-api)
+- Returns in ~50ms server-side
+- Article cards + civic primer panels render
+
+The whole category-browse experience is a database read. **No AI in the request path.**
+
+### 2. Topic search — vector + Claude fallback
+
+- User types a custom topic (e.g. "AI policy in EU healthcare")
+- Voyage AI embeds the query (≤ 50ms)
+- pgvector cosine similarity against indexed articles
+- If ≥ 3 strong matches → stream results via SSE
+- If weak matches → fall back to Claude `web_search` for the niche query (~10–15s), stream results as they arrive
+
+### 3. Multi-source compare — the showpiece
+
+- User picks 2–5 outlets + a topic
+- Vercel proxies the request to Railway `POST /v1/analyze/compare`
+- LangGraph fan-out: parallel Claude `web_search` per outlet (~5–12s each, 20s per-outlet timeout)
+- Claim extraction → agreement classification (`unanimous` / `majority` / `disputed` / `unique`)
+- Unified claims array returned with source tags
+
+## Why this architecture (the trade-offs to articulate)
+
+| Decision | Trade-off | Why this side |
+|---|---|---|
+| **AI split by SLA** — pipeline-time for browse, request-time for compare | More complex than "everything live" | Browse is the daily habit (must be 50ms). Compare is the moment-of-need (10–15s is fine). One SLA model can't serve both. |
+| **RSS hybrid + Claude summaries** (not Claude search) | RSS feeds can lag breaking news by minutes | RSS gives reliable images, dates, attribution. Claude does only the part it's uniquely good at (summarizing). |
+| **Neon Postgres + pgvector** (not Pinecone / Weaviate) | Single-purpose vector DBs are faster at scale | At Sift's scale, pgvector + partial indexes serve all 30 query shapes under 200ms in production. One database to operate, one pool, vector + structured queries in the same `WHERE`. |
+| **Two repos, separate deploys** | Two CI pipelines | The frontend ships on its cadence (UI changes daily); the pipeline ships on its (changes weekly). Vercel cold-starts don't touch the slow path; Railway's persistent process is right for LangGraph. |
+| **LangGraph** (not bare async, not LangChain monolith) | Adds a workflow framework | Buys: typed state, structured error handling, retry, graph visualization. The pipeline is 5 nodes; compare is 4. Both are easier to reason about as graphs than as nested async functions. |
+| **Clerk for auth** (not roll-our-own) | Vendor dependency | Free to 10K MAU. Solves Apple/Google/email sign-in + session + JWT. ~30 min integration vs ~30 hours rolling our own. |
+| **Civic data sourced from public records, not Sift's judgment** | Slower content curation, no proprietary scoring | Methodology page is defensible — every claim cites OpenSecrets / FARA / GovTrack / AllSides / MBFC. Sift doesn't compute political lean; it surfaces what published raters say verbatim. |
+| **iOS-17+ floor** (forward-looking; in IOS plan, not shipped) | Excludes ~8% of iPhones | Civic-literacy reader user is educated, urban, on newer devices — empirically 96%+. SwiftData + iOS 17 SwiftUI animations are worth the floor. |
+
+## The civic-literacy layer (the differentiator)
+
+What separates Sift from "RSS reader + Claude summary":
+
+- **"What you should know first" primer.** An adaptive panel above each article with the key terms + context the article assumes you already have. AI-generated at ingest time — no live LLM call. Expandable. Persisted as `articles.context_primer` JSONB.
+- **Inline glossary chips.** Civic terms surface contextually inside the article body. Tooltip preview on hover, click-through to the full dossier.
+- **Civic dossiers.** Politicians, organizations, bills, and outlets each have a structured page:
+  - *Politicians* — committee assignments, top PAC industries by contribution, Vote Smart interest-group ratings
+  - *Orgs* — type, political lean, funding model, major funders, FARA registration
+  - *Bills* — status, sponsor, cosponsors, lobbying-for/against amounts
+  - *Outlets* — parent company, AllSides + MBFC ratings, funding model, founding year
+- **Cross-spectrum framing.** When multiple outlets covered the same event, Sift shows how each framed it, bucketed by AllSides political lean (left / center / right).
+- **Entity linking.** The pipeline's `entity_linker_llm.py` node (LLM-gated, A/B-able) resolves mentions in article text to the curated dossiers. Mid-rollout — see [STATUS.md](../STATUS.md).
+
+## Current state
+
+| Tier | Status | Notes |
+|---|---|---|
+| **v1** — general-audience aggregator | Shipped March 2026 | Git tag `v1-general-audience`. ~$9/mo to run. |
+| **v1.5** — civic-literacy pivot | In flight | 170 new dossier entries seeded May 2026; entity linker fix gated A/B; `/civic` index page operational. See [`docs/plans/`](./plans/). |
+| **v2** — native clients | Planned | iOS plan exists but **under review** — see [`docs/IOS_APP_PLAN.md`](./IOS_APP_PLAN.md), [`docs/IOS_APP_ASSESSMENT.md`](./IOS_APP_ASSESSMENT.md). Platform-first call (iOS vs Android vs PWA-only) is open — see [`docs/IOS_VS_ANDROID.md`](./IOS_VS_ANDROID.md). |
+
+## What I'd change if asked at interview
+
+Honest retrospective for whiteboard discussion:
+
+- **Started with `Claude web_search` for both discovery and summarization.** Took two months to learn that's the wrong split — Claude is great at summarization, mediocre at search. Switched to RSS-hybrid in v1.5 dev. Cost: $200+ in burned Claude API spend during the wrong-path period.
+- **No instrumentation from day 1.** PostHog wired in retroactively. Means we don't have D30 retention curves for v1. v1.5 is where instrumentation actually lands. Lesson: ship analytics before features, not after.
+- **One canonical API would have been right from the start, but only at v2 scale.** The iOS plan flirted with a "canonical `/v1/*`" API in sift-api. The cross-functional assessment correctly pushed back: that's the right move at maturity, not pre-PMF. Initial pre-PMF call: collapse what's already there, not proliferate.
+- **Civic-literacy first, not aggregator first.** v1 was a generic aggregator; v1.5 pivots to civic-literacy. In retrospect, the civic angle was always the differentiator. If I were starting over, the primer + dossier surface would be in v1.
+
+## Where to read more
+
+| Question | Doc |
+|---|---|
+| What's the product vision? | [PRD.md](./PRD.md) |
+| What's the founder narrative for it? | [PRODUCT_STORY.md](./PRODUCT_STORY.md) |
+| Why did we make X technical choice? | [DECISIONS.md](./DECISIONS.md) (D1–D30 settled) |
+| What's currently active? | [`../STATUS.md`](../STATUS.md) |
+| What does success look like / current vs target? | [KPIS.md](./KPIS.md) |
+| What's planned next? | [PROJECT_PLAN.md](./PROJECT_PLAN.md), [plans/](./plans/) |
+| How do the data contracts shape? | [TECHNICAL_SPEC.md](./TECHNICAL_SPEC.md), `lib/types.ts` |
+| Where are the feed-query indexes? | `sift-api/migrations/004_feed_indexes.sql` + [sift-api CLAUDE.md](https://github.com/kristenmartino/sift-api/blob/main/CLAUDE.md) |
+| Where are the slow queries that serve the feed? | `sift/lib/db.ts` lines 36, 85, 121, 150 |
+| iOS plan + critique + platform analysis | [IOS_APP_PLAN.md](./IOS_APP_PLAN.md), [IOS_APP_ASSESSMENT.md](./IOS_APP_ASSESSMENT.md), [IOS_VS_ANDROID.md](./IOS_VS_ANDROID.md) |
+
+## Sister repos
+
+- [`kristenmartino/sift-api`](https://github.com/kristenmartino/sift-api) — Python pipeline + LangGraph compare workflow. Has its own `STATUS.md` + `CLAUDE.md`.
+- `kristenmartino/sift-mcp` — MCP server (v0.1 shipped) exposing the compare workflow + hybrid index/web search as MCP tools. Demo target. Separate ship cadence.
+- `kristenmartino/portfolio-v2` — case study deploy target at `src/content/work/sift.mdx`.
+
+---
+
+*This doc is the answer to "tell me about a project you built." 30-second version: first three sections. Deep cut: follow the links.*

--- a/docs/KPIS.md
+++ b/docs/KPIS.md
@@ -1,0 +1,75 @@
+# Sift — KPIs
+
+**Updated:** 2026-05-20
+**Status:** Instrumentation in flight; many targets are aspirational for v1.5 / v2
+
+Single page of "what success looks like." Used as the rubric when triaging Next 3 + when pitching the product. Keep tight — if it grows past one screen, prune to the few KPIs the team is actually moving.
+
+---
+
+## North-star metrics
+
+| Metric | Definition | Target | Where measured | Status |
+|---|---|---|---|---|
+| **DAU** | Distinct authenticated + anonymous browser sessions per day | 1K by end of v1.5 | PostHog | Not yet measured |
+| **D30 retention** | % of new users active on day 30 | ≥ 20% | PostHog | Not yet measured |
+| **% sessions with civic engagement** | % of sessions with ≥ 1 primer expand or entity chip tap | ≥ 40% | PostHog events `primer_term_expand`, `entity_chip_tap` | Instrumentation rolling out — see [sift#98](https://github.com/kristenmartino/sift/issues/98) |
+
+## Engagement (per-session)
+
+| Metric | Target | Status |
+|---|---|---|
+| Median session length | ≥ 3 min | Not measured |
+| Articles read per session | ≥ 5 | Not measured |
+| Bookmark rate (% of read articles bookmarked) | ≥ 8% | Measurable now (Clerk + `bookmarks` table) — not dashboarded |
+| "Read at source" tap rate | 10–25% *(target band)* | Not measured |
+| Topic search uses per WAU | ≥ 0.5 | Not measured |
+
+The "Read at source" band has a top end on purpose — too many click-throughs means the Sift summary isn't doing its job.
+
+## Civic-literacy specific
+
+| Metric | Target | Status |
+|---|---|---|
+| Dossier coverage per category | ≥ 80% of articles have ≥ 1 resolved `EntityLink` | Measurable now via `scripts/coverage_audit.py` (sift-api). In flight — [sift-api#53](https://github.com/kristenmartino/sift-api/issues/53) |
+| Primer-expand rate per article view | ≥ 15% | Instrumentation in flight — sift#98 |
+| Cross-spectrum compare uses per WAU | ≥ 0.2 | Not measured |
+| % of articles with ≥ 3 cross-spectrum framings | ≥ 25% | Measurable now (story threading writes framings array) |
+
+## Operational
+
+| Metric | Current | Target | Status |
+|---|---|---|---|
+| `/api/news` p95 latency (server) | ~150ms per `feed-perf` CI | ≤ 200ms | Healthy |
+| `/news` mobile LCP (end-to-end) | 5.5s after PR #55 wins | ≤ 2.5s | Blocked on [sift#56](https://github.com/kristenmartino/sift/issues/56) (SSR + streaming) |
+| Pipeline run duration (10-min cron) | ~90s avg | ≤ 5 min | Healthy; ample margin |
+| Pipeline failure rate (Sentry) | < 1% | < 1% | Healthy |
+| Monthly cost | ~$9 (current) | < $100 through v1.5 | On track. Projected $30–50/mo at growth. |
+
+## Native client (v2 — not yet measurable)
+
+Targets staked in [`docs/IOS_APP_ASSESSMENT.md`](./IOS_APP_ASSESSMENT.md) — restated here so this page is the single source. Without targets, "iOS shipped" is a feature delivery, not a result.
+
+| Metric | Target |
+|---|---|
+| D30 retention (native) | ≥ 25% |
+| Push opt-in rate | ≥ 50% |
+| Push CTR | ≥ 4% |
+| Share-extension uses per WAU | ≥ 2 |
+| Web → native install rate (universal link banner) | ≥ 8% |
+| Native share of total WAU within 6 mo of launch | ≥ 30% |
+| % sessions with civic engagement (native) | ≥ 40% (parity with web) |
+
+## Where to look (live data)
+
+Once instrumentation lands, the canonical dashboards live at:
+
+- **PostHog** — engagement, retention, civic events
+- **Sentry** — error rate, failure types (`siftnews` project)
+- **Vercel Analytics** — page-level perf, geographic distribution
+- **Railway dashboards** — pipeline duration, scheduler runs, FastAPI request rates
+- **CI `feed-perf` job** — query-level p95s on every relevant PR (`sift-api/.github/workflows/ci.yml`)
+
+---
+
+*KPIs without targets and instrumentation are just opinions. Each row on this page should be set in PostHog with an alert by end of v1.5.*


### PR DESCRIPTION
## Summary

Two durable interview-prep / product-knowledge docs to make the system talkable from memory:

1. **`docs/HOW_IT_WORKS.md`** — End-to-end system walkthrough in ~200 lines. Mermaid architecture diagram, 3 user paths, trade-offs table, civic-literacy layer, current state, honest retrospective.
2. **`docs/KPIS.md`** — Single-page success rubric. North-star metrics + engagement + civic-specific + operational + native-client (v2) targets, with current-vs-target columns and PostHog/Sentry/Vercel dashboard pointers.

Designed to be read once and recalled from memory in an interview or PM standup — not reference docs you keep open.

## Where they fit

```
sift/docs/
├── PRD.md                   # vision
├── PRODUCT_STORY.md         # founder narrative
├── HOW_IT_WORKS.md          # NEW — system walkthrough (interview-prep)
├── ARCHITECTURE.md          # deep technical
├── TECHNICAL_SPEC.md        # data contracts
├── DECISIONS.md             # ADR log (D1–D30 settled)
├── PROJECT_PLAN.md          # roadmap snapshot
├── KPIS.md                  # NEW — success rubric
├── FEATURE_SPECS.md         # feature-level specs (large; reference)
├── IOS_APP_PLAN.md          # native v2 plan (under review)
├── IOS_APP_ASSESSMENT.md    # cross-functional critique
└── IOS_VS_ANDROID.md        # platform-first analysis
```

The two new files plug specific gaps:
- `HOW_IT_WORKS.md` — there was no single doc that explained the whole system end-to-end. PRD covers vision, ARCHITECTURE covers internals, but neither answers "tell me about a project you built" in 5 min.
- `KPIS.md` — targets and current-state were scattered (`PROJECT_PLAN.md` had operational, the iOS docs had native, civic-literacy had its own targets). Now one page.

## Not in this PR

- `DECISIONS.md` update for the May 2026 batch (iOS plan under review, canonical API deferred, Android-first leaning, github-projects MCP installed) — captured in `STATUS.md` currently; will append to `DECISIONS.md` in a follow-up to keep this PR scoped.
- `docs/interview-prep/30s-pitch.md` / `2min-overview.md` / `20min-walkthrough.md` — drafts deferred until the v1.5 civic-literacy story stabilizes (the elevator pitch shouldn't lock in until the pivot is settled).

## Test plan

- [ ] `HOW_IT_WORKS.md` renders correctly on GitHub (Mermaid diagram included)
- [ ] `KPIS.md` cross-links resolve (sift#56, sift#98, sift-api#53, IOS_APP_ASSESSMENT.md)
- [ ] No broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fiartht66EhNgcPGJsBmo7)_