### PR TITLE
Set up project state management

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,19 @@
+# sift — backlog
+
+Items not committed to a current milestone. Promote to GitHub issues when work is committed; until then, capture here in prose.
+
+> **What goes here:** half-formed ideas, deferred features that don't fit a current `tier-*` milestone, quirks worth tracking but not urgent. See [CLAUDE.md](CLAUDE.md#where-to-file-new-work-decision-tree) for the decision tree.
+
+## Stretch / nice-to-have
+
+- *(Add items here as they surface.)*
+
+## Bugs / quirks to revisit
+
+- *(Add items as you hit them. Tie back to a commit or issue if you can.)*
+
+## Considered and rejected
+
+Architectural alternatives discussed and chosen against. Captured so we don't re-litigate.
+
+- *(Empty for now. Populate as design decisions are made and alternatives are weighed.)*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md — orientation for Claude Code (and future-me)
+
+Context to load before editing anything in `sift`. Keep this file **short**; if a section grows past one screen, split into a real doc.
+
+## Pre-session ritual
+
+Run these first, in order. Skip none.
+
+```bash
+cat STATUS.md            # active focus, open questions, next 3, recent decisions
+gh pr list               # what's open, what's mid-flight
+gh issue list            # what's committed but not started
+cat BACKLOG.md           # deferred work + bugs/quirks to revisit
+```
+
+The 30 seconds this takes saves hours of "wait, I thought we already decided…" later.
+
+## The two-repo split
+
+This is the frontend half of a two-repo product:
+
+| Repo | Role |
+|---|---|
+| `sift/` (this repo — Next.js 16, TypeScript, Vercel) | User-facing frontend **and read path** |
+| `sift-api/` (FastAPI, Python 3.12, Railway) | Background pipeline, compare workflow, **write path** |
+
+Both talk to the **same Neon Postgres**. They are independent git repos — don't `git add` across them. A "push the branch" request is usually `sift/` only; confirm before touching `sift-api/`.
+
+## Where the slow path actually is
+
+**Client → Next.js API route → `lib/db.ts` → Postgres.** The queries users wait on for the `/api/news` feed live in `lib/db.ts`. The indexes that serve them are defined in `sift-api/migrations/004_feed_indexes.sql` (applied at sift-api startup).
+
+- Client abort budget: `API_TIMEOUT_MS = 10_000` in `lib/constants.ts`. Exceeding it surfaces "We hit a snag pulling today's stories" via `lib/hooks.ts`. No retry; one timeout = one error UI.
+- Pool: `lib/db.ts` has `max: 5`. Don't raise casually — Neon free/hobby tiers cap connections.
+
+When optimizing feed reads, read `lib/db.ts` first, then `sift-api/migrations/` + `sift-api/app/db.py:_apply_migrations` for the index layer. See [sift-api/CLAUDE.md](https://github.com/kristenmartino/sift-api/blob/main/CLAUDE.md) for the dual-file schema pattern and the `feed-perf` CI job that guards regressions.
+
+## Where to file new work (decision tree)
+
+| What you found | Where it goes |
+|---|---|
+| **Bug blocking current work** | Fix in active branch. Don't file. |
+| **Concrete feature committing to in next ~2 weeks** | GitHub issue with `tier-v1.5` / `tier-v2` + `effort-*` labels. Add to STATUS.md "Next 3" if it bumps something. |
+| **Concrete feature wanted eventually, no commitment** | BACKLOG.md "Stretch / nice-to-have." |
+| **Quirk or minor bug, not urgent** | BACKLOG.md "Bugs / quirks to revisit." |
+| **Critical bug found but not fixed** | GitHub issue with `bug` label *and* note in BACKLOG.md. STATUS.md "Blocked-on" if it blocks Next 3. |
+| **Strategic question / open architectural decision** | STATUS.md "Open strategic questions" — never a GitHub issue. |
+| **Architectural decision now made** | STATUS.md "Recent decisions." |
+| **Out-of-scope idea surfaced during work** | BACKLOG.md "Stretch / nice-to-have." |
+
+**Rule:** dated + scoped → file an issue. Half-formed → BACKLOG.md. Issues you'll never close are noise.
+
+## Things I've tripped on
+
+- **`sift/docs/FEATURE_SPECS.md` is 2400+ lines.** Useful for product intent (what / why); not for code-location questions. Reading the actual code is faster.
+- **Mobile LCP floor of 5.5s** isn't going to budge without server-component conversion ([#56](https://github.com/kristenmartino/sift/issues/56)). Don't chase it with bundle optimization first.
+- **The `NewsAggregator.tsx` monolith** is the main app surface — splitting it into primitives is tracked in [#59](https://github.com/kristenmartino/sift/issues/59). Be careful adding to it; the refactor is queued.
+
+## Before closing a PR
+
+- **If the change shifted active focus / Next 3 / open questions** → update `STATUS.md` in the PR.
+- **If it added a deferred item, surfaced a quirk worth tracking, or recorded an architectural decision** → update `BACKLOG.md` (or STATUS.md "Recent decisions") in the PR.
+- **If it changed setup / env / how-to-run** → update `README.md` if present.
+- **If it changed a feed query** → coordinate with sift-api; rerun `sift-api/scripts/explain_feed_queries.py` against prod.
+
+Don't open PRs that change behavior without touching the doc that explains the behavior.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,69 @@
+# sift — status
+
+> **Pre-session ritual:** `cat STATUS.md && gh pr list && gh issue list && cat BACKLOG.md`. See [CLAUDE.md](CLAUDE.md).
+
+## Active focus
+
+**Civic-literacy pivot — final-mile.** Recently repositioned Sift's framing around the aggregator + civic-literacy layer (#96, #97). Primer instrumentation Phase 1 just landed (#95). Topic-search funnel instrumented (#92). Org type expanded for federal agencies (#91). Primer terms now link to dossiers via entity_links (#90). In flight: the broader final-mile checklist in [#98](https://github.com/kristenmartino/sift/issues/98), the mobile/perf push, and PR [#100](https://github.com/kristenmartino/sift/pull/100) (github-projects MCP server — applicable to project state mgmt across repos).
+
+## Open strategic questions
+
+Three live unknowns. None block current work; all shape decisions in the next 1–3 months.
+
+### 1. When is the civic-literacy pivot "shipped" — and what's the v2 trigger?
+
+The pivot has been in flight across many PRs (primer, glossary, dossiers, framing). [#98 final-mile checklist](https://github.com/kristenmartino/sift/issues/98) is the current closure plan. Open question: what's the explicit "done" criterion? Candidates:
+- All four entity types (politician / org / bill / outlet) have full dossier coverage for any article in the index
+- Per-paragraph primer triggers ship (currently above-the-fold only)
+- Cross-spectrum framing surface reflects "observation, not judgment" (still in flight per case study reflections)
+
+`tier-v2` is reserved for native client family (mobile + desktop). v1.5 → v2 trigger probably = "civic-literacy pivot is durable enough that mobile is worth the investment."
+
+### 2. Per-paragraph primer triggers — when and how?
+
+Primers currently attach above the fold by topic match. The reflection on the [case study](https://kristenmartino.ai/work/sift) flagged a *reader-pacing model that surfaces primers in the reading flow* as the next move. Instrumentation just landed (#95) so we'll soon have data on whether readers expand the above-fold primer at all — that signal informs whether per-paragraph is the right next step or whether the above-fold version needs more work first.
+
+### 3. Cross-spectrum framing — observation vs labeling?
+
+Current `CompareView` shows side-by-side framing across outlets. The version worth shipping next *describes what each outlet chose to emphasize, without claiming any of them are wrong* (per case study reflection). The trust-scoring / propaganda-tagging / extremism-flag features that were built but pulled produce nothing meaningful on a mainstream corpus.
+
+What would resolve: prototype the "observation" version of CompareView and ship behind a flag; A/B against the current label-style framing.
+
+## Next 3
+
+Issues live in GitHub; this is the human-readable summary.
+
+1. **[#98 Civic-literacy pivot — final-mile checklist](https://github.com/kristenmartino/sift/issues/98)** *(tier-v1.5, effort-weeks)*. The canonical "what's left to close the pivot" tracker. Active.
+2. **[#56 Perf: convert /news first-paint to Server Components + streaming](https://github.com/kristenmartino/sift/issues/56)** *(tier-v1.5, effort-week)*. Mobile LCP floor of 5.5s is the blocker. Server-component conversion + streaming is the path to breaking through it.
+3. **[PR #100 github-projects MCP server for Projects v2 tools](https://github.com/kristenmartino/sift/pull/100)** *(open PR, inferred priority)*. Building an MCP for managing the GitHub Project boards. Tangentially relevant to the state-mgmt work in [sift-mcp#5](https://github.com/kristenmartino/sift-mcp/pull/5) — that MCP, once shipped, makes the per-repo Project board manipulation scriptable.
+
+## Blocked-on
+
+Nothing engineering-blocked. v2 (native clients) is gated on civic-literacy pivot completion + demand signal.
+
+## Recent decisions
+
+- **Repositioned Sift framing around aggregator + civic-literacy layer** (#96, #97). The two-layer narrative is now the public framing — the aggregator surface is foundation, the civic-literacy surface is the differentiator.
+- **Primer terms link to dossiers via entity_links** (#90). Closes the loop between the "what you should know first" panel above an article and the structured dossier graph underneath. Phase 3.G.4.
+- **Federal agencies as a distinct OrgType** (#91, paired with sift-api#49). Agencies needed their own representation — not corporations, not advocacy groups. 15 agency dossiers shipped on the backend.
+- **Mobile polish: external-link rows stack + chip tap target bumped** (#94). Mobile is a heavy and growing share; polish here pays back across the whole experience.
+
+## Where things live
+
+### Code
+
+- `app/api/` — Next.js API routes (`news/`, `compare/`, `bookmarks/`, `cron/`)
+- `components/` — UI primitives + the main `NewsAggregator.tsx` monolith (extraction tracked in [#59](https://github.com/kristenmartino/sift/issues/59))
+- `lib/db.ts` — feed queries — **the slow path users wait on**; see [sift-api/CLAUDE.md](https://github.com/kristenmartino/sift-api/blob/main/CLAUDE.md#where-the-slow-path-actually-is) for the index map
+- `lib/constants.ts` — `API_TIMEOUT_MS = 10_000` plus categories / gradients
+- `lib/hooks.ts` — useNewsLoader, useBookmarks, useTheme, useTopicSearch, useCompare
+- `docs/FEATURE_SPECS.md` — 2400+ lines of product intent. Useful for what / why; not for where-does-X-live (read code instead)
+
+### Planning + state
+
+- **STATUS.md** (this file) — top-of-mind: active focus, open questions, Next 3, blockers, recent decisions
+- **BACKLOG.md** — everything deferred, in prose
+- **GitHub issues** — formally tracked work. See [`gh issue list`](https://github.com/kristenmartino/sift/issues).
+- **GitHub Project** ([Sift](https://github.com/users/kristenmartino/projects/3)) — board spanning sift, sift-api, sift-mcp.
+
+Discovery order: `gh issue list` → `cat BACKLOG.md` → `git log --oneline` → ask.


### PR DESCRIPTION
## Summary

Greenfield state-management scaffolding for `sift`. Mirrors the template established in [sift-mcp#5](https://github.com/kristenmartino/sift-mcp/pull/5) and [sift-api#57](https://github.com/kristenmartino/sift-api/pull/57), adapted to this repo's labels and lifecycle stage.

## What's in this PR

### New files

- **`STATUS.md`** — Active focus (civic-literacy pivot final-mile), 3 open strategic questions (pivot-done criterion + v2 trigger, per-paragraph primer timing, observation-vs-labeling in compare), Next 3 priorities from existing work, Where things live.
- **`BACKLOG.md`** — Stub with sections (Stretch / Bugs / Considered-and-rejected). Empty for now; populate as items surface.
- **`CLAUDE.md`** — This repo didn't have one. Covers: pre-session ritual, the two-repo split with `sift-api`, where the slow path lives (`lib/db.ts`), where-to-file decision tree, and end-of-PR doc-impact check.

## What's not in this PR

- **No new labels.** sift already has `effort-day` / `effort-week` / `effort-weeks` and `tier-v1` / `tier-v1.5` / `tier-v2` — the right conventions for a repo with a shipped v1, an in-flight v1.5 pivot, and v2 native clients planned.
- **No new issues.** Next 3 pulled from already-open issues + PR (#98, #56, PR #100). Adding inferred priorities would be noise.

## Joining the Sift Project

The 3 Next-3 items will be added to the [Sift](https://github.com/users/kristenmartino/projects/3) GitHub Project (already spans sift-mcp + sift-api).

## Test plan

- [ ] `cat STATUS.md` returns the active focus + 3 open questions on top
- [ ] CLAUDE.md pre-session ritual commands all work from a fresh shell
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)