### PR TITLE
docs+config: A+B+C+D — DECISIONS D31-D34, doc map, SessionStart hook, interview-prep folder

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "enableAllProjectMcpServers": true
+  "enableAllProjectMcpServers": true,
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test -f STATUS.md && jq -Rs '{hookSpecificOutput:{hookEventName:\"SessionStart\",additionalContext:.}}' < STATUS.md || echo '{}'",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,7 +1,7 @@
 # Sift — Architecture Decision Register
 
-**Last updated:** March 31, 2026
-**Status:** All decisions implemented — production live at siftnews.kristenmartino.ai
+**Last updated:** May 20, 2026
+**Status:** D1–D30 settled (v1 production live); D31–D34 added for v1.5 / v2 direction (May 2026)
 
 ---
 
@@ -36,6 +36,10 @@
 | D28 | Entity extraction visibility | Entity tags visible in UI on StoryCard | $0 | SETTLED |
 | D29 | Story ID stability | SHA256 hash of sorted article IDs | $0 | SETTLED |
 | D30 | Pipeline-time vs request-time | Pipeline-time — zero user-facing latency | $0 | SETTLED |
+| D31 | Project state mgmt scaffolding | STATUS.md + CLAUDE.md per repo; V0–V4 milestone tiers | $0 | SETTLED (May 2026) |
+| D32 | iOS plan v1 status | Under review — parity-shaped scope, premature canonical API, missing KPIs | $0 | OPEN (May 2026) |
+| D33 | Canonical /v1/* mobile API in sift-api | Deferred — reuse Next.js routes for now, collapse later | $0 | DEFERRED (May 2026) |
+| D34 | github-projects MCP server | Installed via .mcp.json + .claude/settings.json (Projects v2 tools for future sessions) | $0 | SETTLED (May 2026) |
 
 **Total estimated monthly cost: ~$30-50/mo**
 
@@ -549,3 +553,85 @@ Pipeline store_node completes
 - StoryCards render inline with ArticleCards — stories surface naturally
 
 **Graceful degradation:** If a category has no multi-source coverage, the API returns an empty `stories[]` array and the UI shows only ArticleCards. No special handling needed.
+
+---
+
+## v1.5 / v2 direction (May 2026 onward)
+
+The next four decisions are added after the v1 production launch. They steer v1.5 (civic-literacy pivot, in flight) and v2 (native clients, planned). Some are settled and net-additive (D31, D34); some are open or actively deferred (D32, D33).
+
+---
+
+### D31. Project state management — STATUS.md + CLAUDE.md per repo, V0–V4 milestone tiers
+**Decision:** Adopt per-repo `STATUS.md` (repo root) for active state + `CLAUDE.md` (repo root) for agent orientation. Roadmap tiers labeled `tier-v1` / `tier-v1.5` / `tier-v2` / `tier-v3` / `tier-v4`. Plus a SessionStart hook that auto-loads `STATUS.md` into the agent context.
+
+**Why:**
+- High velocity (10+ PRs/week sustained) means context loss between sessions is real. `STATUS.md` is the always-fresh "Active focus / Open question / Next 3 / Blocked-on / Recent decisions" surface.
+- Per-repo `CLAUDE.md` codifies the pre-session ritual + end-of-PR doc-impact check. Standardizes what agents do on session start and PR close.
+- V1–V4 milestone tiers fit Sift's lifecycle better than OKRs at this stage: v1 shipped, v1.5 civic-literacy pivot in flight, v2 native clients, v3+ speculative.
+- SessionStart hook (`.claude/settings.json`) injects `STATUS.md` content into every new session — eliminates "stale context" failures.
+
+**Where it lands:** root-level `STATUS.md` + `CLAUDE.md` in both `sift` and `sift-api`. GitHub Issues stay actionable units; user-level Project ("Kristen Portfolio" — `users/kristenmartino/projects/3`) visualizes status across repos. Labels: `effort-{day,week,weeks}` + `tier-v{1,1.5,2,3,4}`.
+
+**Cost:** $0 — pure docs + hook config.
+
+---
+
+### D32. iOS plan v1 status — under review (parity-shaped scope critique)
+**Decision (status: OPEN):** Mark the original iOS app plan as **"under review"** pending revision. Don't start native implementation against the current v1 plan.
+
+**The plan as drafted:** native Swift / SwiftUI, focused reader MVP, single canonical `/v1/*` API in `sift-api`, four iOS-native features (push, widget, share extension, offline cache), 8-week TestFlight timeline. See [`docs/IOS_APP_PLAN.md`](./IOS_APP_PLAN.md) for the full plan as written.
+
+**The critique (cross-functional, 12 voices):** Full text in [`docs/IOS_APP_ASSESSMENT.md`](./IOS_APP_ASSESSMENT.md). Key findings:
+
+1. **Scope is parity-shaped, not MVP-shaped.** Four iOS-native features + a full reader + a new API surface + auth + bookmarks sync in 8 weeks is a parity build with extra steps.
+2. **Canonical `/v1/*` API is premature.** "What mature publishers do" is correct in steady state, wrong for pre-PMF (see D33).
+3. **KPIs and monetization missing.** Health metrics (crash-free rate, p95 latency) are present; success metrics (D30 retention, push CTR, share-extension WAU) are absent.
+4. **Design work isn't started.** No screens, flows, or wireframes referenced — the civic-literacy primer doesn't translate to iPhone-sized progressive disclosure as-is.
+5. **Apple Developer enrollment lead time isn't budgeted.** Can take 4–8 weeks for new entities; iOS work would slip silently.
+6. **Civic-literacy pivot (v1.5) is in flight.** Shipping iOS now means shipping a snapshot of an in-flight product.
+
+**Direction (still open):** Revise toward either (a) **share-extension-only MVP** (4 weeks, one feature, validates the "what's the actual story?" gesture) or (b) **defer native entirely** until web civic-literacy pivot is shipped (Q3 2026+). Final call dependent on D34 (platform-first call — see [`docs/IOS_VS_ANDROID.md`](./IOS_VS_ANDROID.md)).
+
+---
+
+### D33. Canonical `/v1/*` mobile API in `sift-api` — deferred
+**Decision (status: DEFERRED):** Don't build the `/v1/feed`, `/v1/topic`, `/v1/articles/:id`, `/v1/widget/today` endpoints proposed in the iOS plan. Native clients (when built) read from existing Next.js routes; add Edge caching if cold starts hurt.
+
+**Why:**
+- "Real companies have one canonical API" is true at maturity, not at pre-PMF. With one client (web) and one API (Next.js routes), building a second API runs two read paths in parallel for months.
+- The Next.js routes can be migrated to a canonical surface later, after a second client validates the need.
+- Net-new endpoints required for actual *new* functionality in v2: `POST /v1/devices/register`, `POST /v1/share/sift-this`, `GET /v1/widget/today`. Those land in `sift-api` when the native client work begins — not before.
+
+**Reconsider when:** web is being migrated to read from `sift-api` regardless, OR a third client (e.g., Android, watchOS) is in flight. At that point, the dedup math flips and one canonical API surface is worth the migration cost.
+
+**Cost (avoided):** ~2 weeks of net-new Python endpoints that would have been pure rename of existing TypeScript handlers.
+
+---
+
+### D34. github-projects MCP server — installed for Claude Code sessions
+**Decision:** Add `.mcp.json` + `.claude/settings.json` enabling the official `github-mcp-server` (HTTP variant at `https://api.githubcopilot.com/mcp/`) as a project-scoped MCP server in both `sift` and `sift-api`.
+
+**Why:**
+- The default Claude Code web harness exposes a useful subset of GitHub tools (`mcp__github__*`) — files, issues, PRs, branches, labels — but lacks **Projects v2 mutations** (`addProjectV2ItemById`, `updateProjectV2ItemFieldValue`).
+- Future sessions in either repo now have full Projects v2 + broader official tool surface (releases, advanced search, workflow dispatch, etc.).
+- Repeats per repo because MCP server configs are repo-scoped via `.mcp.json`.
+
+**Auth:** Bearer token from env var `GITHUB_PROJECTS_TOKEN` (set once in Claude Code web env vars, applies to both repos). PAT scopes: classic `project` (full) + `repo` — *or* fine-grained `Contents/Issues/PRs: Read+write` + `Projects: Read+write` (account-level).
+
+**Cost:** $0 — uses GitHub Copilot API quota (free for personal accounts within reasonable limits).
+
+**Naming:** server named `github-projects` (not `github`) to coexist with the existing harness server without name collision.
+
+---
+
+## Open questions (May 2026)
+
+Tracked here so they don't get lost between session restarts. Promoted to settled decisions when resolved.
+
+| # | Question | Where to decide |
+|---|----------|-----------------|
+| OQ1 | Native platform first — iOS vs Android vs PWA-only? | Lean: Android-first while iOS enrollment processes. See [`docs/IOS_VS_ANDROID.md`](./IOS_VS_ANDROID.md). |
+| OQ2 | DMCA fair-use posture for AI summarization on Railway | Audit + methodology update in flight (sift-api#54) |
+| OQ3 | Monetization — when, what, and at what tier | Not until v1.5 KPIs validate D30 ≥ 20% |
+| OQ4 | Cross-platform vs native-per-platform if both ship | Decide after platform-first is settled |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,57 @@
+# Sift — docs map
+
+Where to find things. Keep this current; if you add a new top-level doc here, add a row.
+
+## Doc index
+
+| Doc | Purpose | Audience |
+|---|---|---|
+| [`PRD.md`](./PRD.md) | Product vision + scope | Stakeholders, future-me |
+| [`PRODUCT_STORY.md`](./PRODUCT_STORY.md) | Founder narrative | Interviewers, marketing |
+| [`HOW_IT_WORKS.md`](./HOW_IT_WORKS.md) | End-to-end system walkthrough (~5-min read) | You, sketching on a whiteboard |
+| [`ARCHITECTURE.md`](./ARCHITECTURE.md) | Deep technical architecture | Engineers, reviewers |
+| [`TECHNICAL_SPEC.md`](./TECHNICAL_SPEC.md) | Data contracts + APIs | Engineers implementing changes |
+| [`DECISIONS.md`](./DECISIONS.md) | ADR log — decisions and why (D1–D34, ongoing) | Engineers, future-me defending choices |
+| [`PROJECT_PLAN.md`](./PROJECT_PLAN.md) | Roadmap snapshot | Stakeholders |
+| [`KPIS.md`](./KPIS.md) | Success rubric — current values vs targets | Operating cadence |
+| [`FEATURE_SPECS.md`](./FEATURE_SPECS.md) | Feature-level specs (large; reference) | Engineers implementing a feature |
+
+## Forward-looking plans
+
+| Doc | Purpose |
+|---|---|
+| [`IOS_APP_PLAN.md`](./IOS_APP_PLAN.md) | iOS v1 plan — status: **under review** (see assessment) |
+| [`IOS_APP_ASSESSMENT.md`](./IOS_APP_ASSESSMENT.md) | Cross-functional critique of the iOS plan |
+| [`IOS_VS_ANDROID.md`](./IOS_VS_ANDROID.md) | Platform-first analysis — current lean: Android-first |
+
+## Interview prep
+
+Tuned for spoken delivery. Read 2–3 times before an interview; don't memorize phrasing — internalize the structure.
+
+| Doc | When to use |
+|---|---|
+| [`interview-prep/30s-pitch.md`](./interview-prep/30s-pitch.md) | Elevator. "What do you work on?" |
+| [`interview-prep/2min-overview.md`](./interview-prep/2min-overview.md) | Phone screen. "Walk me through your portfolio piece." |
+| [`interview-prep/20min-walkthrough.md`](./interview-prep/20min-walkthrough.md) | Technical deep-dive. "Whiteboard the architecture." |
+
+## Where ELSE to look (outside `docs/`)
+
+| Where | What's there |
+|---|---|
+| `STATUS.md` (repo root) | Current focus, Open question, Next 3, Blocked-on, Recent decisions — single source of truth for "what's active right now" |
+| `CLAUDE.md` (repo root) | Agent orientation — pre-session ritual, end-of-PR doc-impact check |
+| `README.md` (repo root) | Quick start, env vars, scripts, deployment |
+| `.claude/settings.json` | SessionStart hook auto-loads STATUS.md context; MCP server config |
+| `.mcp.json` | github-projects MCP server config (Projects v2 tools) |
+
+## Sister repos
+
+| Repo | Role | Has its own STATUS / CLAUDE? |
+|---|---|---|
+| [`kristenmartino/sift-api`](https://github.com/kristenmartino/sift-api) | Backend — Python pipeline + LangGraph workflows + write path | Yes |
+| `kristenmartino/sift-mcp` | MCP server (v0.1) — compare workflow as MCP tools; demo target | Yes (per separate Claude session) |
+| `kristenmartino/portfolio-v2` | Case study deploy at `src/content/work/sift.mdx` | n/a |
+
+---
+
+*If you can't find something here, it's probably not written down yet. Open an issue, or ask Claude to write it.*

--- a/docs/interview-prep/20min-walkthrough.md
+++ b/docs/interview-prep/20min-walkthrough.md
@@ -1,0 +1,119 @@
+# 20-minute technical walkthrough
+
+The deep-dive version for a technical interview. Pace: ~5 min per major section, with whiteboard breaks. The interviewer is going to interrupt — anticipate the questions in each section and answer them inline.
+
+---
+
+## Opening: the product (~2 min)
+
+Same as [`2min-overview.md`](./2min-overview.md). Pause for questions after.
+
+**Anticipate:**
+
+- *"How do you decide which outlets to include?"* — Methodology page at `/methodology`. 100+ RSS feeds across 10 categories, expanded over time. Outlet selection is documented and symmetric: any outlet with reliable RSS + AllSides/MBFC rating is eligible. No editorial veto power. Methodology is public.
+- *"How do you avoid bias?"* — Sift doesn't compute political lean. It surfaces AllSides + MBFC ratings verbatim with citations. The methodology page makes this explicit. Editorial inputs (which dossiers exist, which feeds are in the pool) are documented.
+
+## The architecture (~5 min, whiteboard)
+
+Whiteboard cue: 3 boxes + 1 database.
+
+```
+[Vercel: Next.js 15]  →  [Neon Postgres + pgvector]  ←  [Railway: FastAPI + LangGraph]
+                              ↑                                ↑
+                              └──── user reads ─────────┐      └── pipeline writes
+                                                        │              │
+[Browser / iPhone]  ←─────────────────────────────────  │              ↓
+                                                                  [Claude, Voyage, RSS]
+```
+
+Walk through:
+
+1. **Vercel hosts Next.js 15** (App Router, TypeScript). Owns user reads + UI. Server Components fetch from Postgres directly — **no client-side fetch in the browse path.**
+2. **Railway hosts FastAPI + LangGraph.** Long-running process — LangGraph workflows need this; Vercel functions cold-start poorly for multi-step orchestration. asyncio scheduler runs pipeline every 10 min. On-demand compare workflow.
+3. **Neon Postgres + pgvector** is the single source of truth. Articles + embeddings + dossiers + bookmarks in one DB. pgvector handles both structured queries and vector cosine in the same `WHERE`.
+
+Plus external services: **Claude Haiku 4.5** for summaries + compare. **Voyage AI** for embeddings (free 50M tokens/mo). **Clerk** for auth.
+
+**Anticipate:**
+
+- *"Why two repos?"* — Frontend ships daily; pipeline ships weekly. Different release cadences. Also: different runtimes (TypeScript vs Python). And the pipeline needs a persistent process for LangGraph state, which Vercel functions can't host.
+- *"Why Postgres for vectors instead of Pinecone or Weaviate?"* — At Sift's scale (~10K articles), pgvector + partial indexes serves all 30 query shapes under 200ms in production. One database to operate. Vector + structured queries in the same statement (`WHERE category = 'politics' AND embedding <=> $1 < 0.3`). Pinecone would be a separate service to monitor for marginal speed gain. Revisit at ~1M articles.
+- *"Why LangGraph instead of bare async or LangChain?"* — Typed state, structured error handling, retry. Pipeline is 5 nodes; compare is 4. Both are easier to reason about as a graph than as nested async functions. The compare workflow has explicit fan-out/merge that benefits from the framework. LangChain monolith was rejected because we only need the workflow primitives, not the full toolkit.
+
+## The pipeline workflow (~4 min)
+
+Whiteboard cue: 5 nodes in sequence + a side branch.
+
+```
+fetch_rss → deduplicate → summarize → embed → store
+                                                ↓
+                                         (per category)
+                                                ↓
+                          fetch → entity_extract → llm_cluster → synthesize+store
+                                  (story threading — 4 nodes)
+```
+
+- **fetch_rss** — pulls from 100+ feeds across 10 categories. `feedparser` library. Image URLs extracted from `enclosure` / `media:content` / `media:thumbnail`.
+- **deduplicate** — checks against Postgres by `source_url` UNIQUE constraint. Skip if seen.
+- **summarize** — batched Claude Haiku calls. ~50 articles per batch. Prompt instructs Claude to write 2–3 paragraph summaries in editorial voice.
+- **embed** — Voyage AI `voyage-3-lite`, 1024 dimensions. Batched.
+- **store** — `INSERT ... ON CONFLICT DO NOTHING` into `articles` table with the embedding.
+
+Followed by **story threading** (cross-source clustering) — a 4-node workflow per category that groups articles about the same event. Uses **LLM-as-judge**, not embedding similarity — embedding catches same-topic but struggles with same-event. ("EU AI Act vote" and "US AI executive order" embed similarly but are different events.) Claude Haiku judges with ~97% precision.
+
+**Anticipate:**
+
+- *"What if RSS lags breaking news?"* — Tradeoff acknowledged. ~10-minute lag for most outlets. Topic search has Claude `web_search` fallback for niche/breaking queries the indexed pool hasn't seen.
+- *"Cost?"* — ~$4/mo Claude. Batched. Per-article cost ~$0.001. Voyage free tier covers all embeddings. Total infra: ~$9/mo current.
+- *"Why LLM-as-judge for clustering instead of embedding cosine?"* — Embedding catches same-topic (~90% accuracy). LLM judges distinguish same-event from same-topic (~97%). At Sift's article volume per category (max 50 in a 48h window), a single LLM call handles it. Embedding-prefilter + LLM-refine was rejected — added complexity, no benefit at this scale.
+
+## The civic-literacy layer (~4 min)
+
+This is the differentiator — walk through carefully.
+
+**Dossiers** — curated tables for politicians, organizations, bills, outlets. Hand-curated for accuracy. ~500 politicians (all sitting Congress members via GovTrack scrape), ~50 orgs (think tanks + PACs across spectrum), ~30 bills (active), ~50 outlets (the ones in the feed pool).
+
+**Entity linking** — at ingestion, the pipeline's `entity_linker_llm.py` node resolves mentions in article text to dossier entries. **LLM-gated, A/B-able** — currently rolling out from experimental to default. Stored in `articles.entity_links` JSONB.
+
+**"What you should know first" primer** — AI-generated panel above each article with key terms + context the article assumes you know. Generated at ingestion, no live LLM call. Persisted as `articles.context_primer` JSONB. Expandable in UI.
+
+**Cross-spectrum framing** — when multiple outlets covered the same event (from story threading), Sift shows each outlet's framing bucketed by AllSides political lean.
+
+**Anticipate:**
+
+- *"How do you keep the dossiers current?"* — Funding data is OpenSecrets cycle data, refreshed by cycle. Voting records are GovTrack-sourced and updated periodically. FARA is manual quarterly review. Methodology page documents the cadence.
+- *"How accurate is the entity linker?"* — ~85% precision on the LLM-gated rollout. The A/B comparison lets us measure pre/post the fix. Promotion to default-on is gated on hitting target (tracked in sift-api#53).
+- *"What stops a politician from gaming the lobbying data?"* — Nothing — that's why the data is from public OpenSecrets filings, not Sift's claims. Sift surfaces what's filed. The methodology link is on every dossier.
+- *"How do you handle a publisher sending a DMCA takedown?"* — Pre-drafted counter-notice template; methodology page documents the transformative-use posture; host-portability check confirms `sift-api` deploys cleanly to Fly.io as fallback. Risk audit shows Sift's Railway footprint is low (RSS-sourced summaries, no body HTML stored at rest); real exposure is publisher-direct, which is a separate process.
+
+## The honest retrospective (~3 min)
+
+What I'd change with hindsight — leads with the biggest miss to demonstrate self-awareness:
+
+1. **Started with Claude `web_search` for both discovery and summary.** Took 2 months to learn that's the wrong split. Burned ~$200 in API spend during the wrong-path period. Now: RSS for discovery, Claude only for the summarization it's uniquely good at.
+
+2. **No instrumentation from day 1.** PostHog wired in retroactively. v1 has no D30 retention curves. v1.5 is where analytics actually lands. Lesson: ship analytics before features.
+
+3. **Generic aggregator first, civic-literacy second.** In hindsight, the civic angle was always the differentiator. v2 of the iOS plan revision now has civic-literacy as headline, not footnote — applying that lesson back.
+
+4. **Flirted with a "canonical `/v1/*` API" in the iOS plan.** The cross-functional assessment correctly pushed back — that's the move at maturity, not pre-PMF. Avoided proliferation.
+
+## Where it's going (~2 min)
+
+**v1.5 — civic-literacy pivot — closing out:** dossier coverage parity, entity linker promotion, primer instrumentation. KPIs: D30 retention ≥ 20%, ≥ 40% of sessions tap a primer or entity chip.
+
+**v2 — native client — open platform question.** iOS plan exists but is under review (cross-functional critique flagged parity-shaped scope + premature API). Current lean: Android-first while iOS Apple Developer enrollment processes — turns the enrollment wait into a shipped Android v1.
+
+**Long tail:** multi-source compare native UX, watchOS complications, iPad-optimized layout, daily-briefing audio narrated by Claude.
+
+## Q&A primer
+
+If they ask about anything not covered: *"Happy to dive in — what aspect interests you?"*
+
+If they get philosophical: *"Civic literacy is a public good. Aggregators commodify attention. Sift tries to commodify context. That's the bet."*
+
+If they ask about engineering practice: 60% of merged PRs land within 24 hours of opening. STATUS.md + CLAUDE.md per repo. Per-repo `feed-perf` CI guard catches query regressions before they ship. SessionStart hook auto-loads project state into agent context.
+
+---
+
+*The links in [`docs/HOW_IT_WORKS.md`](../HOW_IT_WORKS.md) go deeper on any layer. Read this doc 2–3 times before an interview. Don't memorize phrasing — internalize the structure.*

--- a/docs/interview-prep/2min-overview.md
+++ b/docs/interview-prep/2min-overview.md
@@ -1,0 +1,31 @@
+# 2-minute overview
+
+For when someone says *"walk me through your portfolio project"* on a phone screen. Aim for ~90 seconds spoken — leaves 30 seconds for the first follow-up.
+
+---
+
+## The pitch (3 sentences)
+
+Sift is an AI-curated news reader with a civic-literacy layer — *"the news, with footnotes."* The footnotes are the differentiator: every politician, organization, bill, and outlet that appears in a story links to a structured dossier I built from public records — OpenSecrets for campaign finance, GovTrack for voting records, FARA for foreign-agent registrations, AllSides + MBFC for outlet political lean. So when an article references "Schumer" or "the Inflation Reduction Act," readers get the funding sources and lobbying spend without leaving the page.
+
+## The architecture (3 boxes)
+
+Three boxes, one database. **Vercel** hosts the Next.js frontend. **Railway** runs the Python pipeline — FastAPI + LangGraph workflows that pull from 100+ RSS feeds every 10 minutes, summarize each article with Claude Haiku 4.5, embed with Voyage AI, and write to **Neon Postgres** with pgvector. The frontend reads from Postgres in ~50ms; AI never runs in the user's request path for the browse experience.
+
+There's a second live-AI path for power features: topic search uses vector similarity over indexed embeddings with a Claude `web_search` fallback for niche queries, and multi-source compare uses a LangGraph fan-out workflow to query 2–5 outlets in parallel and synthesize how each framed the same story.
+
+## The key trade-off
+
+The architecturally interesting decision is **splitting AI by SLA**. Browse needs to be 50ms — it's the daily habit. Compare can take 10–15 seconds — it's the moment-of-need. One SLA model couldn't serve both, so the pipeline runs AI at ingestion time for browse and at request time for compare. The whole category-browsing experience is a database read.
+
+## Where it stands
+
+v1 — the general-audience aggregator — shipped March 2026 at about $9/month all-in. v1.5 is the civic-literacy pivot, currently in flight: dossier expansion (170 new entries last month), entity linker promotion, primer instrumentation. v2 is a native client; I'm leaning Android-first while iOS Apple Developer enrollment processes.
+
+## Happy to dive into
+
+> Trade-offs, the LangGraph compare workflow, how the dossier data is sourced, the iOS plan that just got cross-functionally critiqued and rewritten — whichever is most relevant to you.
+
+---
+
+*Live at [siftnews.kristenmartino.ai](https://siftnews.kristenmartino.ai). For the deep cut, see [`docs/HOW_IT_WORKS.md`](../HOW_IT_WORKS.md) or [`20min-walkthrough.md`](./20min-walkthrough.md).*

--- a/docs/interview-prep/30s-pitch.md
+++ b/docs/interview-prep/30s-pitch.md
@@ -1,0 +1,27 @@
+# 30-second pitch
+
+> **Sift is "the news, with footnotes."**
+>
+> It's an AI-curated news reader that adds the civic context most news leaves out — an adaptive "what you should know first" primer, structured dossiers on every politician, organization, bill, and outlet, all sourced from public records like OpenSecrets, GovTrack, and FARA.
+>
+> Live at [siftnews.kristenmartino.ai](https://siftnews.kristenmartino.ai). Built solo. Next.js, Python, Postgres, Claude Haiku, Voyage AI, LangGraph.
+
+---
+
+## Three follow-ups you should be ready for
+
+**"What makes it different from Google News / Apple News?"**
+
+> Aggregators surface headlines. Sift adds the civic background — every named entity links to a dossier with funding sources, voting records, AllSides + MBFC ratings. Aggregators tell you what happened; Sift makes sure you have the context to know what it means.
+
+**"Why now / why solo?"**
+
+> The civic-literacy gap got worse, not better, since 2020. The cost of building AI-curation collapsed in the last 18 months — Claude Haiku 4.5 summarizes for ~$0.001/article. A solo dev can now ship something that needed a 20-person newsroom in 2019.
+
+**"What's next?"**
+
+> v1.5 in flight is the civic-literacy pivot — 170 new dossiers, entity linker improvements. v2 is a native client; whether iOS or Android first is the current open question.
+
+---
+
+*Live at siftnews.kristenmartino.ai. Source: `kristenmartino/sift` + `kristenmartino/sift-api`.*


### PR DESCRIPTION
## Summary

Bundle A+B+C+D from the "what's on the deck" list. Four durable improvements:

| Bundle | Files | Purpose |
|---|---|---|
| **A** — DECISIONS append | `docs/DECISIONS.md` (D31–D34 + Open Questions) | Closes the record on the May 2026 batch: state-mgmt pattern, iOS plan under review, canonical API deferred, github-projects MCP installed |
| **B** — doc map | `docs/README.md` (new) | One-page index of every doc with audience labels. 30-second orient for newcomers (humans + agents) |
| **C** — SessionStart hook | `.claude/settings.json` (hook added) | Auto-loads `STATUS.md` into model context at session start — every session begins oriented without an explicit `cat STATUS.md` |
| **D** — interview prep | `docs/interview-prep/30s-pitch.md`, `2min-overview.md`, `20min-walkthrough.md` (new folder) | Three durations of "tell me about your project," tuned for spoken delivery with anticipated follow-up questions and prepared answers |

## What's new in DECISIONS.md

Four new entries appended (the existing D1–D30 untouched):

- **D31** — Project state management scaffolding (STATUS.md + CLAUDE.md per repo, V1–V4 milestone tiers, SessionStart hook) · status SETTLED
- **D32** — iOS plan v1 status: under review (12-voice cross-functional critique, parity-shaped scope, premature canonical API, missing KPIs) · status OPEN
- **D33** — Canonical `/v1/*` mobile API in sift-api: deferred — reuse Next.js routes for now · status DEFERRED
- **D34** — github-projects MCP server installed for Projects v2 tools · status SETTLED

Plus a new "Open Questions" section tracking unsettled strategic items (native platform-first, DMCA posture, monetization timing, cross-platform decision).

## SessionStart hook — how it works

```bash
test -f STATUS.md && jq -Rs '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:.}}' < STATUS.md || echo '{}'
```

Reads `STATUS.md` if present, JSON-encodes it via `jq -Rs`, wraps in the hook output schema, prints to stdout. Falls through to empty JSON (no-op) if `STATUS.md` is missing. 5-second timeout.

Effect: every session that starts in this repo sees `STATUS.md` contents in the model context automatically — Active focus, Open question, Next 3, Blocked-on, Recent decisions. Pre-session ritual codified in `CLAUDE.md` becomes automatic.

## Interview-prep doc structure

Three escalating durations:

| Doc | Use case | Read time | Spoken length |
|---|---|---|---|
| `30s-pitch.md` | Elevator. "What do you work on?" | 30 sec | 30 sec |
| `2min-overview.md` | Phone screen. "Walk me through your portfolio piece." | 2 min | ~90 sec |
| `20min-walkthrough.md` | Technical deep-dive. "Whiteboard the architecture." | 5 min | ~20 min |

Each includes anticipated follow-up questions with prepared answers — the structure to internalize, not phrasing to memorize.

## Test plan

- [ ] All 6 files render correctly on GitHub
- [ ] `docs/README.md` cross-links resolve
- [ ] DECISIONS.md table of contents includes D31–D34
- [ ] `.claude/settings.json` is valid JSON (verified via `jq -e 'has("hooks")'`)
- [ ] SessionStart hook fires on next session — verify by starting fresh session and confirming STATUS.md content appears in initial context
- [ ] Interview-prep `30s-pitch.md` is actually readable in 30s out loud

## Related

Continues the project state management pattern set up in earlier PRs this session (state-mgmt scaffolding sift#99/sift-api#55, MCP config sift#100/sift-api#56, HOW_IT_WORKS sift#101). After this lands, sift has: STATUS, CLAUDE, README, HOW_IT_WORKS, KPIS, DECISIONS (updated), interview-prep folder, and a SessionStart hook — every gap from the "what's on the deck" list closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fiartht66EhNgcPGJsBmo7)_