### PR TITLE
docs: STATUS + Android v1 plan absorb Ask Sift + Refined Compare

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,43 +1,44 @@
 # Sift — STATUS
 
 **Updated:** 2026-05-20
-**Tier:** v1.5 (civic-literacy pivot, in flight)
+**Tier:** v1.5 (civic-literacy pivot, in flight) → v1.6 (Ask Sift web differentiator, planned)
 **Velocity:** High (10+ PRs / week)
 
 ## Active focus
 
-Civic-literacy pivot rollout (web). Recently shipped: 170 new dossier entries seeded (via `sift-api`); entity linker fix gated A/B-able in production; `docs/PRODUCT_STORY.md` refreshed; portfolio-v2 case study deployed. Sift-mcp v0.1 shipped (separate repo) with Loom + DM to Harish.
+Civic-literacy pivot rollout (web). Android v1 build entering Phase 0 (per [`docs/ANDROID_APP_v1.md`](./docs/ANDROID_APP_v1.md) — decisions locked, scaffold pending). Sift-mcp merge into sift-api in flight (tracked at [`sift-api#62`](https://github.com/kristenmartino/sift-api/issues/62)). Recently shipped: 170 new dossier entries seeded (via `sift-api`); entity linker fix gated A/B-able in production; `docs/PRODUCT_STORY.md` refreshed; portfolio-v2 case study deployed. Sift-mcp v0.1 shipped (separate repo) with Loom + DM to Harish.
 
 ## Open strategic question
 
-**Native platform first: iOS vs Android?**
+**Geographic scope of civic content + monetization timeline.**
 
-Apple Developer Program enrollment is requested but may take weeks (24–72h personal, 4–8 weeks for new entities). Android: $25 one-time, ~instant approval, lenient Play Store review.
-
-**Working recommendation: start Android while iOS enrollment is pending.** Converts the enrollment-delay window from zero opportunity cost into a shipped Android v1; Android validates which native features actually matter before iOS gold-plates them; the backend infra (endpoints, push registration schema, share-extension handoff) is built once and reused. See [`docs/IOS_VS_ANDROID.md`](./docs/IOS_VS_ANDROID.md).
-
-Final call open.
+Native platform direction was the previous open question; landed 2026-05-20 as **Android-first** (Path A from [`docs/IOS_VS_ANDROID.md`](./docs/IOS_VS_ANDROID.md)). What remains open is the v1 content scope (U.S.-only vs global from launch) and the monetization timeline (free indefinitely vs subscription exploration in 2027) — both shape whether Android-first holds longer-term or eventually pairs with iOS-as-second-platform. See [`docs/IOS_VS_ANDROID.md`](./docs/IOS_VS_ANDROID.md) §Decision queue.
 
 ## Next 3
 
 1. **[committed]** [#56 — SSR / streaming for `/news` first-paint](https://github.com/kristenmartino/sift/issues/56) — architectural fix to break the 5.5s mobile LCP floor. LCP element after PR #55 is hydrated text inside `NewsAggregator`, not image — `priority`/`preload` is exhausted. Tier `v1.5` · `effort-week`.
-2. **[committed]** Civic-literacy pivot — final-mile checklist (umbrella issue, see Issues tab) — entity-linker promotion to default-on, dossier coverage parity per category, primer-expand instrumentation rollout. Tier `v1.5` · `effort-weeks`.
-3. **[sketch]** Resolve native platform direction — Android-first vs iOS-first vs PWA-only. Blocks iOS-plan revision and any mobile build. Decision-only; no issue. Tier `v2` · `effort-day`.
+2. **[committed]** [#98 — Civic-literacy pivot final-mile checklist](https://github.com/kristenmartino/sift/issues/98) — entity-linker promotion to default-on, dossier coverage parity per category, primer-expand instrumentation rollout. Depends on `sift-api` #53 + #54. Tier `v1.5` · `effort-weeks`.
+3. **[committed]** Android v1 build (per [`docs/ANDROID_APP_v1.md`](./docs/ANDROID_APP_v1.md)) — Phase 0 (decisions locked, scaffold pending). Pre-week-1 design sprint → 10 weeks to production. New repo `kristenmartino/sift-android` to be created. Tier `v1.5` · `effort-weeks`.
+
+Queued behind Next-3 (web, post-Android-build kickoff):
+- **Web chat UI for Ask Sift** (`/ask` route) — Phase 2 of `sift-api` [#63](https://github.com/kristenmartino/sift-api/issues/63). Tier `v1.6` · `effort-week`. Slots in around Android build weeks 6–8.
 
 ## Blocked-on
 
-- Apple Developer Program enrollment (iOS work waits)
-- Harish demo response (sift-mcp v0.5 hardening waits, separate repo)
-- Resolution of the Open strategic question above (mobile work waits)
+- Apple Developer Program enrollment (deferred — iOS work waits behind Android v1)
+- Triage of `sift-api` #62 (merge) and #63 (Ask Sift) into the sequenced roadmap
 
 ## Recent decisions
 
-- **2026-05-20** — iOS plan v1 marked **under review**. Cross-functional assessment surfaced parity-shaped scope, premature canonical-API, and missing KPIs. See [`docs/IOS_APP_ASSESSMENT.md`](./docs/IOS_APP_ASSESSMENT.md). Plan retained as reference, not active direction.
-- **2026-05-20** — Canonical `/v1/*` API in sift-api **deferred**. For pre-PMF, reuse Next.js routes (+ Edge caching if needed); collapse later when web→mobile migration is scheduled.
-- **2026-05-20** — **Android-first leaning** (Path A) for native. Civic-literacy mission aligns with reach, not premium audience. Final decision open.
+- **2026-05-20** — **Mobile is REST-only.** Active Android v1 plan ([`docs/ANDROID_APP_v1.md`](./docs/ANDROID_APP_v1.md)) calls every backend route via REST/SSE; no MCP. `sift-mcp` #4 (hosted HTTP/SSE) deferred indefinitely. Rationale in `sift-api/docs/MOBILE_PROTOCOL_DECISION.md`.
+- **2026-05-20** — **`sift-mcp` merges into `sift-api`.** Architecture spec at `sift-api/docs/MERGE_MCP_INTO_API.md`. Tracked at `sift-api` [#62](https://github.com/kristenmartino/sift-api/issues/62) with 4 phases. Driver: duplication between web's compare path (`app/api/compare/route.ts:55` → `sift-api` `/analyze/compare`) and `sift-mcp` `compare_outlets` is already real, not theoretical. Merge consolidates handlers and unblocks the Ask Sift agent loop.
+- **2026-05-20** — **Ask Sift v0 planned as `tier-v1.6`** (web-only; mobile inherits in Android v1.1). Open-ended chat surface with the 5 sift-mcp tools wired into an internal agent loop on sift-api. Plan in `sift-api/docs/ASK_SIFT_PLAN.md`. Tracked in `sift-api` [#63](https://github.com/kristenmartino/sift-api/issues/63). Recommended slot: parallel to Android v1 weeks 6–8.
+- **2026-05-20** — iOS plan v1 marked **under review**. Cross-functional assessment surfaced parity-shaped scope, premature canonical-API, and missing KPIs. See [`docs/IOS_APP_ASSESSMENT.md`](./docs/IOS_APP_ASSESSMENT.md). Plan retained as reference; **Android-first** active direction.
+- **2026-05-20** — Canonical `/v1/*` API in sift-api **deferred** for mobile (Android uses Next.js routes); pattern now changes: MCP route mount lands on sift-api as part of the merge. See `sift-api/docs/MERGE_MCP_INTO_API.md`.
+- **2026-05-20** — **Android-first leaning** (Path A) for native. Civic-literacy mission aligns with reach, not premium audience. Active.
 - **2026-05-20** — DMCA audit: Sift's Railway footprint is **low-risk** under Railway's fair-use clause; real exposure is publisher-direct cease-and-desists, not host-mediated. Methodology page update queued in sift-api side.
 - *(sift-mcp side, separately committed in that repo: hybrid index+web architecture; 26-outlet pool with smart DB-exclusion selection; `load_dotenv(override=True)`; `compare_outlets` unified-claims-array return shape.)*
 
 ---
 
-*See also: [`docs/PROJECT_PLAN.md`](./docs/PROJECT_PLAN.md), [`docs/DECISIONS.md`](./docs/DECISIONS.md), [`docs/PRODUCT_STORY.md`](./docs/PRODUCT_STORY.md), [`CLAUDE.md`](./CLAUDE.md). Sibling repos: `sift-api` (backend), `sift-mcp` (MCP server, separate cadence).*
+*See also: [`docs/PROJECT_PLAN.md`](./docs/PROJECT_PLAN.md), [`docs/DECISIONS.md`](./docs/DECISIONS.md), [`docs/PRODUCT_STORY.md`](./docs/PRODUCT_STORY.md), [`docs/ANDROID_APP_v1.md`](./docs/ANDROID_APP_v1.md), [`CLAUDE.md`](./CLAUDE.md). Sibling repos: `sift-api` (backend), `sift-mcp` (MCP server — merging into sift-api per #62).*

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,40 +1,42 @@
 # Sift — STATUS
 
 **Updated:** 2026-05-20
-**Tier:** v1.5 (civic-literacy pivot, in flight) → v1.6 (Ask Sift web differentiator, planned)
+**Tier:** v1.5 (civic-literacy pivot + agentic surfaces in Android v1)
 **Velocity:** High (10+ PRs / week)
 
 ## Active focus
 
-Civic-literacy pivot rollout (web). Android v1 build entering Phase 0 (per [`docs/ANDROID_APP_v1.md`](./docs/ANDROID_APP_v1.md) — decisions locked, scaffold pending). Sift-mcp merge into sift-api in flight (tracked at [`sift-api#62`](https://github.com/kristenmartino/sift-api/issues/62)). Recently shipped: 170 new dossier entries seeded (via `sift-api`); entity linker fix gated A/B-able in production; `docs/PRODUCT_STORY.md` refreshed; portfolio-v2 case study deployed. Sift-mcp v0.1 shipped (separate repo) with Loom + DM to Harish.
+Civic-literacy pivot rollout (web). Android v1 build entering Phase 0 (per [`docs/ANDROID_APP_v1.md`](./docs/ANDROID_APP_v1.md) — decisions locked, scaffold pending). Sift-mcp merge into sift-api in flight (tracked at [`sift-api#62`](https://github.com/kristenmartino/sift-api/issues/62)). Ask Sift + Refined Compare agentic surfaces approved for Android v1 scope (tracked at [`sift-api#63`](https://github.com/kristenmartino/sift-api/issues/63)). Recently shipped: 170 new dossier entries seeded (via `sift-api`); entity linker fix gated A/B-able in production; `docs/PRODUCT_STORY.md` refreshed; portfolio-v2 case study deployed.
 
 ## Open strategic question
 
 **Geographic scope of civic content + monetization timeline.**
 
-Native platform direction was the previous open question; landed 2026-05-20 as **Android-first** (Path A from [`docs/IOS_VS_ANDROID.md`](./docs/IOS_VS_ANDROID.md)). What remains open is the v1 content scope (U.S.-only vs global from launch) and the monetization timeline (free indefinitely vs subscription exploration in 2027) — both shape whether Android-first holds longer-term or eventually pairs with iOS-as-second-platform. See [`docs/IOS_VS_ANDROID.md`](./docs/IOS_VS_ANDROID.md) §Decision queue.
+Native platform direction resolved 2026-05-20 as **Android-first** (Path A from [`docs/IOS_VS_ANDROID.md`](./docs/IOS_VS_ANDROID.md)). What remains open: v1 content scope (U.S.-only vs global from launch) and monetization timeline (free indefinitely vs subscription exploration in 2027). Both shape whether Android-first holds longer-term or eventually pairs with iOS-as-second-platform. See [`docs/IOS_VS_ANDROID.md`](./docs/IOS_VS_ANDROID.md) §Decision queue.
 
 ## Next 3
 
-1. **[committed]** [#56 — SSR / streaming for `/news` first-paint](https://github.com/kristenmartino/sift/issues/56) — architectural fix to break the 5.5s mobile LCP floor. LCP element after PR #55 is hydrated text inside `NewsAggregator`, not image — `priority`/`preload` is exhausted. Tier `v1.5` · `effort-week`.
+1. **[committed]** [#56 — SSR / streaming for `/news` first-paint](https://github.com/kristenmartino/sift/issues/56) — architectural fix to break the 5.5s mobile LCP floor. LCP element after PR #55 is hydrated text inside `NewsAggregator`, not image. Tier `v1.5` · `effort-week`.
 2. **[committed]** [#98 — Civic-literacy pivot final-mile checklist](https://github.com/kristenmartino/sift/issues/98) — entity-linker promotion to default-on, dossier coverage parity per category, primer-expand instrumentation rollout. Depends on `sift-api` #53 + #54. Tier `v1.5` · `effort-weeks`.
-3. **[committed]** Android v1 build (per [`docs/ANDROID_APP_v1.md`](./docs/ANDROID_APP_v1.md)) — Phase 0 (decisions locked, scaffold pending). Pre-week-1 design sprint → 10 weeks to production. New repo `kristenmartino/sift-android` to be created. Tier `v1.5` · `effort-weeks`.
+3. **[committed]** Android v1 build (per [`docs/ANDROID_APP_v1.md`](./docs/ANDROID_APP_v1.md)) — Phase 0 (decisions locked, scaffold pending). **Scope now includes Ask Sift chat + Compare button (deterministic + Refined).** Pre-week-1 design sprint → ~12 weeks to production. New repo `kristenmartino/sift-android` to be created. Tier `v1.5` · `effort-weeks`.
 
-Queued behind Next-3 (web, post-Android-build kickoff):
-- **Web chat UI for Ask Sift** (`/ask` route) — Phase 2 of `sift-api` [#63](https://github.com/kristenmartino/sift-api/issues/63). Tier `v1.6` · `effort-week`. Slots in around Android build weeks 6–8.
+Web-side in flight alongside the Android build:
+- **Web `/ask` chat UI** for Ask Sift (Phase 4 of `sift-api` [#63](https://github.com/kristenmartino/sift-api/issues/63)). Ships parallel to Android weeks 6-8. Tier `v1.5` · `effort-week`.
+- **Web Compare button gains "Focus on…" input** for Refined Compare (Phase 5 of `sift-api` [#63](https://github.com/kristenmartino/sift-api/issues/63)).
 
 ## Blocked-on
 
 - Apple Developer Program enrollment (deferred — iOS work waits behind Android v1)
-- Triage of `sift-api` #62 (merge) and #63 (Ask Sift) into the sequenced roadmap
+- Triage of `sift-api` #62 (merge) and #63 (Ask Sift + Refined Compare) into the sequenced roadmap
 
 ## Recent decisions
 
-- **2026-05-20** — **Mobile is REST-only.** Active Android v1 plan ([`docs/ANDROID_APP_v1.md`](./docs/ANDROID_APP_v1.md)) calls every backend route via REST/SSE; no MCP. `sift-mcp` #4 (hosted HTTP/SSE) deferred indefinitely. Rationale in `sift-api/docs/MOBILE_PROTOCOL_DECISION.md`.
-- **2026-05-20** — **`sift-mcp` merges into `sift-api`.** Architecture spec at `sift-api/docs/MERGE_MCP_INTO_API.md`. Tracked at `sift-api` [#62](https://github.com/kristenmartino/sift-api/issues/62) with 4 phases. Driver: duplication between web's compare path (`app/api/compare/route.ts:55` → `sift-api` `/analyze/compare`) and `sift-mcp` `compare_outlets` is already real, not theoretical. Merge consolidates handlers and unblocks the Ask Sift agent loop.
-- **2026-05-20** — **Ask Sift v0 planned as `tier-v1.6`** (web-only; mobile inherits in Android v1.1). Open-ended chat surface with the 5 sift-mcp tools wired into an internal agent loop on sift-api. Plan in `sift-api/docs/ASK_SIFT_PLAN.md`. Tracked in `sift-api` [#63](https://github.com/kristenmartino/sift-api/issues/63). Recommended slot: parallel to Android v1 weeks 6–8.
+- **2026-05-20** — **Android v1 scope expanded to include Ask Sift + Compare button.** Previously: reader + share extension only. Now: reader + share extension + Ask Sift agentic chat + Compare button (deterministic + Refined). Reasoning: without Ask Sift, native mobile is a polished reader competing with Apple News / Artifact. WITH Ask Sift, it's a civic-literacy agent on the phone. That's the wedge that justifies native. Timeline impact: ~10 weeks → ~12 weeks.
+- **2026-05-20** — **Refined Compare added to v1 scope.** Lens-driven agentic comparison via `lens` parameter on `/api/compare`. Same endpoint as the deterministic compare; backend routes based on lens presence. Plan in `sift-api/docs/REFINED_COMPARE_PLAN.md`.
+- **2026-05-20** — **Mobile is REST-only.** Even the agentic surfaces (Ask Sift, Refined Compare) call REST/SSE — the agent loop runs server-side; MCP is internal plumbing. `sift-mcp` #4 (hosted HTTP/SSE) deferred indefinitely. Rationale in `sift-api/docs/MOBILE_PROTOCOL_DECISION.md`.
+- **2026-05-20** — **`sift-mcp` merges into `sift-api`.** Architecture spec at `sift-api/docs/MERGE_MCP_INTO_API.md`. Tracked at `sift-api` [#62](https://github.com/kristenmartino/sift-api/issues/62) with 4 phases. Driver: duplication between web's compare path (`app/api/compare/route.ts:55` → `sift-api` `/analyze/compare`) and `sift-mcp` `compare_outlets` is already real. Merge consolidates handlers and unblocks the agentic surfaces.
 - **2026-05-20** — iOS plan v1 marked **under review**. Cross-functional assessment surfaced parity-shaped scope, premature canonical-API, and missing KPIs. See [`docs/IOS_APP_ASSESSMENT.md`](./docs/IOS_APP_ASSESSMENT.md). Plan retained as reference; **Android-first** active direction.
-- **2026-05-20** — Canonical `/v1/*` API in sift-api **deferred** for mobile (Android uses Next.js routes); pattern now changes: MCP route mount lands on sift-api as part of the merge. See `sift-api/docs/MERGE_MCP_INTO_API.md`.
+- **2026-05-20** — Canonical `/v1/*` API for mobile **deferred**. Android uses Next.js routes + 4 net-new endpoints in sift-api (`/v1/share/sift-this`, `/v1/devices/register`, `/api/ask`, `/api/compare` with `lens`).
 - **2026-05-20** — **Android-first leaning** (Path A) for native. Civic-literacy mission aligns with reach, not premium audience. Active.
 - **2026-05-20** — DMCA audit: Sift's Railway footprint is **low-risk** under Railway's fair-use clause; real exposure is publisher-direct cease-and-desists, not host-mediated. Methodology page update queued in sift-api side.
 - *(sift-mcp side, separately committed in that repo: hybrid index+web architecture; 26-outlet pool with smart DB-exclusion selection; `load_dotenv(override=True)`; `compare_outlets` unified-claims-array return shape.)*

--- a/docs/ANDROID_APP_v1.md
+++ b/docs/ANDROID_APP_v1.md
@@ -2,9 +2,11 @@
 
 **Date:** 2026-05-20
 **Status:** Active — phase 0 (decisions locked, scaffold pending)
-**Companion docs:** [`IOS_VS_ANDROID.md`](./IOS_VS_ANDROID.md) (platform-first analysis), [`IOS_APP_ASSESSMENT.md`](./IOS_APP_ASSESSMENT.md) (the critique that shaped these decisions), [`HOW_IT_WORKS.md`](./HOW_IT_WORKS.md) (system end-to-end)
+**Companion docs:** [`IOS_VS_ANDROID.md`](./IOS_VS_ANDROID.md) (platform-first analysis), [`IOS_APP_ASSESSMENT.md`](./IOS_APP_ASSESSMENT.md) (the critique that shaped these decisions), [`HOW_IT_WORKS.md`](./HOW_IT_WORKS.md) (system end-to-end), `sift-api/docs/ASK_SIFT_PLAN.md`, `sift-api/docs/REFINED_COMPARE_PLAN.md`
 **Sibling repos:** `kristenmartino/sift` (frontend) · `kristenmartino/sift-api` (backend) · `kristenmartino/sift-mcp` (MCP) · **`kristenmartino/sift-android`** *(new — to be created)*
 **Stack:** Kotlin + Jetpack Compose + Material 3. Min SDK 26 (Android 8.0). Target SDK 35 (Android 15).
+
+> **Amendment 2026-05-20:** v1 scope expanded to include Ask Sift agentic chat + Compare button (deterministic + Refined with lens). Timeline grew from ~10 weeks to ~12 weeks. Reasoning: without Ask Sift, native mobile is a polished reader competing with generic news apps; WITH Ask Sift it's a civic-literacy agent on the phone — the wedge that justifies native vs PWA. See updated v1 scope below.
 
 > This plan is built from the iOS critique forward, not the iOS plan forward. Same surface, different lens: KPIs are at the top, monetization paragraph is in writing, design work is a named blocker, and the scope is justified explicitly — not inherited from a "feature parity" instinct.
 
@@ -15,12 +17,13 @@
 | Decision | Choice | Why |
 |---|---|---|
 | **Platform first** | **Android** | Apple Developer enrollment in flight; window has zero opportunity cost. Civic-literacy mission aligns with reach. Per `IOS_VS_ANDROID.md` Path A. |
-| **Scope** | **Reader + share extension (full v1)** | User choice over MVP-only recommendation. ~8–10 week build. Bigger risk than share-only, but bigger surface to learn from. |
+| **Scope** | **Reader + share extension + Ask Sift agent chat + Compare button (deterministic + Refined)** | Civic-literacy differentiator goes native. ~10–12 week build. The agent chat is what justifies native vs PWA. |
 | **Stack** | Native Kotlin + Jetpack Compose + Material 3 | Same reasoning as iOS native: best feel, full native API access. Not Compose Multiplatform — that was explicitly rejected in `IOS_VS_ANDROID.md`. |
-| **API** | Reuse Next.js routes (per D33 in `DECISIONS.md`) + 2 net-new endpoints in `sift-api` (`/v1/share/sift-this`, `/v1/devices/register`) | Don't proliferate a canonical API until a third client validates the surface. |
+| **API** | Reuse Next.js routes (per D33 in `DECISIONS.md`) + 4 net-new endpoints in `sift-api` (`/v1/share/sift-this`, `/v1/devices/register`, `/api/ask`, `/api/compare` with `lens`) | Don't proliferate a canonical API until a third client validates the surface. |
 | **Min / Target SDK** | 26 / 35 | API 26 covers ~96% of active devices; gives us notification channels, scoped storage, share-target improvements. API 35 required by Play Store. |
 | **Auth** | Clerk Android SDK | Matches web + future iOS. Same `Authorization: Bearer <jwt>` posture. |
 | **Distribution** | Google Play Console (internal → closed → production) | $25 one-time fee, ~instant approval. No 4–8wk enrollment wait. |
+| **Agent loop architecture** | **Server-side** (sift-api hosts the agent; mobile streams SSE) | Cost control + system-prompt iteration + Anthropic-key safety all easier server-side. Mobile never embeds an LLM key. |
 
 ## North-star KPIs (set from the start)
 
@@ -35,28 +38,38 @@ The single biggest lesson from the iOS plan critique: targets before code. These
 | Web → Android install rate (via universal-link banner) | ≥ 8% | Month 2 onward |
 | Android share of total WAU within 6 mo of launch | ≥ 30% | Month 6 |
 | % sessions with ≥ 1 primer expand OR entity chip tap | ≥ 40% | Day 1 onward |
+| **Ask Sift sessions per WAU** | **≥ 1** | **Month 1 onward** |
+| **Ask Sift conversation completion rate** | **≥ 60%** | **First 90 days** |
+| **Compare button taps per WAU** | **≥ 2** | **Month 1 onward** |
+| **Refined Compare usage / total Compare usage** | **≥ 25%** | **First 90 days** |
+| **Citation tap-through rate (from agent responses)** | **≥ 15%** | **Month 1 onward** |
 | Crash-free session rate | ≥ 99.5% | Continuous |
 
 ## Monetization stance (set from the start)
 
-Sift is **free through 2026**. Subscription exploration in 2027 contingent on hitting D30 ≥ 20%. Until then, every Android user is a net infra cost (~$0 fixed + per-user Claude inference on shares).
+Sift is **free through 2026**. Subscription exploration in 2027 contingent on hitting D30 ≥ 20%. Until then, every Android user is a net infra cost (~$0 fixed + per-user Claude inference on shares + agent loop conversations).
 
 **Cost guardrails baked into v1:**
-- `share-this-url` per-user daily cap of **20 calls** (lower than iOS plan's 50 — calibrated to expected Android usage patterns)
+- `share-this-url` per-user daily cap of **20 calls**
+- **Ask Sift / Refined Compare per-user-day cap: $5 signed, $2 anon** (shared budget pool); global daily ceiling $50 with alarm at $30
+- **Per-turn hard cap $0.50** on agent loop (defense against runaway tool calls)
 - Daily budget alarm at $30/day in Claude spend from sift-api Anthropic dashboard
 - Push notification ceiling: max 5/day/user, max 1/15min/category
+- Kill-switch env `ASK_SIFT_DISABLED=true` disables both `/api/ask` and the Refined Compare path instantly without a redeploy
 
 ---
 
 ## v1 scope
 
-### In v1 (reader + share extension, full)
+### In v1 (reader + share extension + agentic surfaces)
 
 - **Feed across 10 categories** — Top, Technology, Business, Science, Energy, World, Health, Politics, Sports, Entertainment. Pull-to-refresh; pagination via opaque cursor.
 - **Article detail** — title, summary, civic-literacy primer panel (expandable Material 3 ExpansionPanel), inline glossary chips (SuggestionChips with bottom-sheet tooltip), outlet badge (AllSides + MBFC ratings), entity-link chips. "Read at source" opens Custom Tabs (Chrome Custom Tabs, not WebView).
 - **Topic search** — vector + Claude `web_search` fallback. SSE consumer via OkHttp's `EventSource`. Match-quality + fallback chips identical to web.
 - **Bookmarks** — synced via Clerk + sift-api. Local-first via Room; sync queue for offline writes.
 - **Theming** — Newsprint (light) + Late Edition (dark), tracking system appearance by default, with Settings override.
+- **Ask Sift agentic chat** (new in v1 scope) — native Compose chat screen at the bottom-nav "Ask" tab. Sends user messages to `POST /api/ask`; consumes SSE stream with tool-call visibility ("Searching articles…" inline chips) and citation rendering (every tool-derived claim links to article detail). Stop-generation button, cap-hit / rate-limit / error states. Anonymous trial; Clerk-signed-in for sustained use. See `sift-api/docs/ASK_SIFT_PLAN.md`.
+- **Compare button (deterministic + Refined)** (new in v1 scope; previously v1.1) — "Compare" button on `ArticleDetailScreen`. Opens a `CompareScreen` with outlet-by-outlet framing cards. The screen has a "Focus on…" text input: empty → deterministic `/api/compare` (current `compare_outlets` behavior); filled → Refined Compare agent path (lens-driven). Same endpoint, presence of `lens` parameter routes the backend. See `sift-api/docs/REFINED_COMPARE_PLAN.md`.
 
 ### iOS-native equivalent features for Android
 
@@ -66,16 +79,18 @@ Sift is **free through 2026**. Subscription exploration in 2027 contingent on hi
 | "Today on Sift" widget | **Glance widget (Compose-based)** in v1.1 | Deferred from v1 — adds a week and isn't a primary engagement surface. v1 has Quick Tile (Android equivalent of iOS Control Center) only. |
 | "Sift this URL" share extension | **Share-target Activity** | `<intent-filter>` for `ACTION_SEND` with `text/plain` and `text/x-uri`. Receives URL, opens Sift, calls `/v1/share/sift-this`. |
 | Offline cached feed | **Room cache + WorkManager periodic sync** | Same stale-while-revalidate behavior. 7-day cache, 50MB cap. |
+| Ask Sift on iOS (future) | **Same architecture** | When iOS lands (Q4 2026), it inherits Ask Sift via the same REST/SSE endpoint. The agent backend is platform-agnostic. |
 
 ### Explicitly *not* in v1 — see [Backlog](#backlog-for-v11)
 
 - Glance home-screen widget (v1.1 — earns its place once base reader has signal)
-- Multi-source compare native UI (port from sift-mcp later; web link in v1)
 - Civic dossier index (`/civic` equivalent) — chips link to web dossier in Custom Tabs
 - Live Activities equivalent (Android Live Updates landed in API 35 but tooling is immature)
 - Wear OS companion
 - Tablet-optimized layout (works on tablets, just not designed for them in v1)
 - Daily-briefing audio (TalkBack-friendly text-to-speech reading; v1.2)
+- Conversation persistence for Ask Sift (history of past chats) — v1.1
+- Multi-lens Refined Compare (lens is single-string in v0)
 
 ---
 
@@ -88,7 +103,7 @@ Sift is **free through 2026**. Subscription exploration in 2027 contingent on hi
 | UI | Jetpack Compose + Material 3 | Standard for new projects since 2024. Faster iteration than XML+View. |
 | Architecture pattern | Single Activity + Compose Navigation, ViewModels with `StateFlow` (MVI-ish) | Convention. Easy testing. Clear lifecycle. |
 | DI | Hilt | De-facto Android standard. Compile-time validation. Solo-dev cost is low. |
-| Networking | Retrofit + OkHttp + kotlinx.serialization | Battle-tested. Coroutines-first. OkHttp's `EventSource` handles SSE. kotlinx.serialization mirrors the JSON shapes from `sift/lib/types.ts` cleanly. |
+| Networking | Retrofit + OkHttp + kotlinx.serialization | Battle-tested. Coroutines-first. OkHttp's `EventSource` handles SSE for both topic search AND Ask Sift agent streams. |
 | Persistence | Room (with KSP) | Better tooling than SQLDelight for Android-only. Type-safe queries. |
 | Image loading | Coil 3 | Kotlin-first, Compose-native, smaller footprint than Glide for new projects. |
 | Concurrency | Kotlin coroutines + Flow | Standard. No RxJava. |
@@ -117,10 +132,10 @@ sift-android/
 │       │   │   ├── SiftApplication.kt          # @HiltAndroidApp; Sentry + PostHog init
 │       │   │   ├── MainActivity.kt             # Single activity, ComponentActivity, sets Compose content
 │       │   │   ├── data/
-│       │   │   │   ├── api/                    # Retrofit interfaces + SSE clients
+│       │   │   │   ├── api/                    # Retrofit interfaces + SSE clients (topic search, Ask Sift, Refined Compare)
 │       │   │   │   ├── db/                     # Room database + DAOs
 │       │   │   │   ├── model/                  # Domain models (mirror sift/lib/types.ts)
-│       │   │   │   └── repository/             # ArticleRepository, BookmarkRepository, etc.
+│       │   │   │   └── repository/             # ArticleRepository, BookmarkRepository, AgentRepository, CompareRepository
 │       │   │   ├── di/                         # Hilt modules — NetworkModule, DatabaseModule, etc.
 │       │   │   ├── nav/                        # Compose Navigation (NavGraph, Destinations)
 │       │   │   ├── ui/
@@ -128,10 +143,12 @@ sift-android/
 │       │   │   │   ├── feed/                   # FeedScreen, FeedViewModel, components
 │       │   │   │   ├── article/                # ArticleDetailScreen, primer, entity chips
 │       │   │   │   ├── search/                 # TopicSearchScreen, SSE consumer wiring
+│       │   │   │   ├── ask/                    # AskScreen (Ask Sift chat) — streaming consumer, tool-call chips, citations
+│       │   │   │   ├── compare/                # CompareScreen, outlet cards, Focus-on input (Refined Compare)
 │       │   │   │   ├── bookmarks/              # BookmarksScreen, sync state UI
 │       │   │   │   ├── share/                  # ShareTargetActivity — receives ACTION_SEND
 │       │   │   │   ├── settings/               # SettingsScreen — theme override, notif prefs, sign-out
-│       │   │   │   └── common/                 # SiftCard, OutletBadge, GlossaryChip, etc.
+│       │   │   │   └── common/                 # SiftCard, OutletBadge, GlossaryChip, ToolCallChip, CitationLink, etc.
 │       │   │   ├── push/                       # FCMService, device-registration sync
 │       │   │   ├── work/                       # WorkManager workers (sync feed cache, sync bookmarks)
 │       │   │   └── auth/                       # Clerk Android SDK wrapper
@@ -150,6 +167,8 @@ sift-android/
 └── .github/workflows/android-ci.yml
 ```
 
+New directories vs original plan: `ui/ask/` (Ask Sift chat UI) and `ui/compare/` (Compare screen with Refined Compare integration).
+
 ### Data model
 
 Domain models are Kotlin data classes mirroring `sift/lib/types.ts`. Same JSON shape, same field names (kotlinx.serialization with `@SerialName` for camel/snake mapping where needed).
@@ -157,6 +176,10 @@ Domain models are Kotlin data classes mirroring `sift/lib/types.ts`. Same JSON s
 Source of truth: `sift/lib/types.ts`. Kept in sync by:
 1. A unit test that decodes a recorded fixture from each API endpoint into the Kotlin model — fails loudly when the API ships an unexpected shape.
 2. A `make sync-models` script that prints a TS↔Kotlin field diff. Cheap heuristic, not codegen.
+
+New domain models for v1:
+- `AskMessage`, `AskRequest`, `AskSSEEvent` (text / tool_use / tool_result / done / error) for Ask Sift
+- `CompareRequest` (with optional `lens` field), `CompareResponse` (refined: `outlets[]`, `summary`, `lens_coverage_quality`, etc.)
 
 Codegen via OpenAPI is deferred to v1.1 once the field count crosses ~50 and manual drift starts hurting.
 
@@ -175,11 +198,11 @@ object SiftColors {
 }
 ```
 
-Values **copied, not computed** — design drift between web and Android is intentional, not accidental. Future v1.2 task: extract the palette into a JSON token file in `sift/` that both web and Android consume. (Same task forward-declared in the iOS plan.)
+Values **copied, not computed** — design drift between web and Android is intentional, not accidental. Future v1.2 task: extract the palette into a JSON token file in `sift/` that both web and Android consume.
 
 ### Civic-literacy translation to Android
 
-The biggest design risk from the iOS critique: civic-literacy doesn't translate to phone-sized progressive disclosure as-is. Same risk on Android.
+The biggest design risk from the iOS critique: civic-literacy doesn't translate to phone-sized progressive disclosure as-is. Same risk on Android. With Ask Sift + Compare, civic-literacy now has THREE touchpoints, not one:
 
 **v1 design pattern (informed by Material 3 conventions):**
 
@@ -187,20 +210,22 @@ The biggest design risk from the iOS critique: civic-literacy doesn't translate 
 - **Glossary chips** (terms inside primer) — Material 3 SuggestionChips. Tap opens a ModalBottomSheet with definition + "Open full dossier" CTA → Custom Tabs to `/dossier/...` on the web (native dossier pages are v1.2).
 - **Entity chips** (`articles.entity_links`) — same SuggestionChip pattern, distinct color (uses the article's category accent). Tap → Custom Tabs to the dossier page.
 - **Outlet badge** (AllSides / MBFC ratings) — Material 3 Badge below the source name. Tap → outlet dossier in Custom Tabs.
+- **Ask Sift screen** — bottom-nav "Ask" tab. Chat surface with streaming response, inline tool-call chips, citation links to article detail. Empty state shows 3 example prompts ("Compare how outlets covered the most recent FERC ruling", "Who funds Senator X's campaign?", "What happened in energy policy this week?").
+- **Compare screen** — reached from article detail "Compare" button. Outlet-by-outlet cards. "Focus on…" text input above the cards: empty → deterministic (all claims grouped); filled → Refined Compare via agent loop (lens-driven framings).
 
-**Design sprint**: 1 week before week 1 of engineering. Wireframes for the four touchpoints above + the share-target receiver flow. Anti-pattern to avoid: a wall of text under a sticky header. Use the sprint output as the visual reference; defer Figma-to-code production until week 2.
+**Design sprint**: 1 week before week 1 of engineering. Wireframes for the SIX touchpoints above + the share-target receiver flow + the new Ask + Compare screens. Anti-pattern to avoid: a wall of text under a sticky header. Use the sprint output as the visual reference; defer Figma-to-code production until week 2.
 
 ### Auth — Clerk Android SDK
 
 - Sign-in flow opens Clerk's SDK-provided UI (Apple, Google, email — same providers web allows).
-- Post-sign-in, SDK exposes session JWT. Every authenticated request to `/v1/*` carries `Authorization: Bearer <jwt>`.
-- Anonymous browsing supported: feed + topic search work without sign-in. Bookmarks, push registration, "Sift this URL" require sign-in.
+- Post-sign-in, SDK exposes session JWT. Every authenticated request to `/v1/*` and `/api/ask` and `/api/compare` carries `Authorization: Bearer <jwt>`.
+- Anonymous browsing supported: feed, topic search, and limited Ask Sift / Refined Compare work without sign-in (with aggressive per-IP rate limits). Bookmarks, push registration, "Sift this URL", and full Ask Sift / Refined Compare quota require sign-in.
 
 ---
 
 ## API contract
 
-Per [`DECISIONS.md#D33`](./DECISIONS.md), we don't build a canonical `/v1/*` API in `sift-api` for this client. Android reads from the existing Next.js routes; the only net-new endpoints in `sift-api` are share + device registration.
+Per [`DECISIONS.md#D33`](./DECISIONS.md), we don't build a canonical `/v1/*` API in `sift-api` for this client. Android reads from the existing Next.js routes; net-new endpoints in `sift-api` are scoped to genuinely new functionality.
 
 | Method | Path | Owner | Auth | Purpose |
 |---|---|---|---|---|
@@ -211,8 +236,10 @@ Per [`DECISIONS.md#D33`](./DECISIONS.md), we don't build a canonical `/v1/*` API
 | `DELETE` | `https://siftnews.kristenmartino.ai/api/bookmarks/:id` | sift (Next.js) | Clerk JWT | Remove bookmark |
 | `POST` | `https://sift-api-production.up.railway.app/v1/share/sift-this` | **sift-api (new)** | Clerk JWT (or anon w/ rate limit) | Process arbitrary URL via pipeline |
 | `POST` | `https://sift-api-production.up.railway.app/v1/devices/register` | **sift-api (new)** | Clerk JWT | Register FCM token + topic/category prefs |
+| `POST` | `https://sift-api-production.up.railway.app/api/ask` (SSE) | **sift-api (new)** | Clerk JWT (or anon w/ rate limit) | Ask Sift agentic chat. Body: `{messages, session_id?}`. Returns SSE stream (text, tool_use, tool_result, done, error). |
+| `POST` | `https://sift-api-production.up.railway.app/api/compare` | **sift-api (new path on existing endpoint)** | Clerk JWT (or anon w/ rate limit) | Outlet comparison. Body: `{topic, lens?, outlets?}`. Empty `lens` → deterministic path; filled → Refined Compare agent loop. |
 
-The two new endpoints in sift-api are scoped to the Android work — they're the genuinely new functionality. Everything else is reused.
+The four new endpoints in sift-api are scoped to the Android work + the agentic surfaces — they're the genuinely new functionality. Everything else is reused.
 
 ### Conventions
 
@@ -222,6 +249,7 @@ The two new endpoints in sift-api are scoped to the Android work — they're the
 - Errors: `{ "error": string, "details"?: string }` — matches `NewsApiError`.
 - Android sends `User-Agent: Sift-Android/1.0` + `X-Sift-Client: android/1.0`.
 - API base URL is configurable per build variant (debug → staging if/when we add one; release → prod).
+- SSE event shapes for `/api/ask` documented in `sift-api/docs/ASK_SIFT_PLAN.md`.
 
 ---
 
@@ -229,13 +257,13 @@ The two new endpoints in sift-api are scoped to the Android work — they're the
 
 | Repo | What changes | Status |
 |---|---|---|
-| **`kristenmartino/sift-android`** *(new)* | Entire codebase: app, share-target, FCM service, tests, CI. ~15k LOC at v1 ship estimate. | To be created |
-| **`kristenmartino/sift-api`** | Add `POST /v1/share/sift-this`, `POST /v1/devices/register` endpoints. Add `device_registrations` + `share_artifacts` tables. Add `push_dispatcher` workflow node + FCM sender. | Net-new — weeks 6–7 of phasing below |
-| **`kristenmartino/sift`** | Optional: "Get it on Google Play" banner; Android App Link verification (`/.well-known/assetlinks.json`) so `siftnews.kristenmartino.ai/article/:id` opens the app when installed. | Optional, low priority — won't block ship |
+| **`kristenmartino/sift-android`** *(new)* | Entire codebase: app, share-target, FCM service, **Ask screen + Compare screen**, tests, CI. ~15–18k LOC at v1 ship estimate. | To be created |
+| **`kristenmartino/sift-api`** | Add `POST /v1/share/sift-this`, `POST /v1/devices/register`, **`POST /api/ask` (agent endpoint, SSE)**, **`POST /api/compare` with `lens` param (Refined Compare agent path)**. Add `device_registrations` + `share_artifacts` tables. Add `push_dispatcher` workflow node + FCM sender. Land merge of sift-mcp into sift-api (handlers used by both agent loops). | Net-new — weeks 5–8 of phasing below |
+| **`kristenmartino/sift`** | Web `/ask` chat UI; Compare button gains "Focus on…" input (Refined Compare). Optional: "Get it on Google Play" banner; Android App Link verification (`/.well-known/assetlinks.json`). | Web `/ask` + Compare input land alongside backend in weeks 6–8; banner/App Link optional |
 
 ### Google Play prerequisites
 
-Order these in week 1 of engineering so they don't bottleneck week 9.
+Order these in week 1 of engineering so they don't bottleneck week 11.
 
 1. **Google Play Developer Account** — $25 one-time. Apple wishes its enrollment were this fast.
 2. **FCM project** — Firebase console, register app, download `google-services.json`. Free up to 100M messages/day.
@@ -243,16 +271,17 @@ Order these in week 1 of engineering so they don't bottleneck week 9.
 4. **App Links verification** — Generate the digital asset links JSON. Host at `siftnews.kristenmartino.ai/.well-known/assetlinks.json` (sift repo task).
 5. **Privacy policy URL** — Required by Play Store. The existing `/privacy` page suffices; verify it covers Android-specific data collection (FCM token, device identifier).
 6. **Data safety form** — Play Console's privacy questionnaire. Sift collects: account info (Clerk), device identifier (FCM token), product interaction (PostHog), crash data (Sentry). Pre-fill answers.
+7. **AI-summarization disclosure** — Reviewer notes explain Ask Sift's grounding policy (tools query Sift's index; no training-data assertions about real entities; citations enforced). Methodology page linked.
 
 ---
 
 ## Phasing & milestones
 
-8–10 weeks to closed beta, 12 to production. Assumes 1 full-time solo dev or 2 part-time. Bracketed estimates include design sprint pre-week-1.
+10–12 weeks to closed beta, 12–14 to production. Assumes 1 full-time solo dev or 2 part-time. Bracketed estimates include design sprint pre-week-1.
 
 ### Pre-week 1 — design sprint (1 week)
 
-- Wireframes for: feed grid, article detail with primer + entity chips, topic search, bookmarks list, share-target receiver flow, settings.
+- Wireframes for: feed grid, article detail with primer + entity chips, topic search, bookmarks list, share-target receiver flow, settings, **Ask Sift chat screen, Compare screen with Focus-on input**.
 - Theme tokens documented (mirror web Newsprint / Late Edition).
 - Loaner Android device or emulator setup (Pixel 9 image is the test target).
 
@@ -284,29 +313,34 @@ Order these in week 1 of engineering so they don't bottleneck week 9.
 - Match-quality / fallback chips identical to web.
 - Bookmarks UI; Room schema; sync with `/api/bookmarks`.
 
-### Week 5 — auth
+### Week 5 — auth + sift-api merge backbone
 
 - Clerk Android SDK integration.
 - Sign-in flow + JWT carry on protected endpoints.
 - Anonymous browsing path verified.
+- **Backend**: `sift-api` #62 Phase 0 (merge source) + Phase 1 (cost caps) ships. Handlers now live in sift-api ready for agent loop integration.
 
-### Week 6 — offline cache
+### Week 6 — offline cache + Ask Sift backend
 
-- Room schema for cached articles (matching `Article` domain model).
+- Room schema for cached articles.
 - Stale-while-revalidate on app launch.
 - "Last updated" UI; offline banner.
 - WorkManager periodic sync (15-min intervals, only on unmetered network unless user opts in to "always sync").
+- **Backend**: `POST /api/ask` agent endpoint ships. Anthropic Messages API + 5 tools wired. SSE streaming. Cost cap integration. Eval set initial pass (50 prompts).
 
-### Week 7 — share target + sift-api endpoint
+### Week 7 — Ask Sift Android UI + share target
 
+- **`AskScreen`** with OkHttp EventSource SSE consumer. Streaming text + inline tool-call chips + citation links to `ArticleDetailScreen`. Empty state with 3 example prompts. Stop-generation button. Cap-hit / error states.
 - `<intent-filter android:name="android.intent.action.SEND" />` on a dedicated `ShareTargetActivity`.
 - `sift-api`: `POST /v1/share/sift-this` — fetch URL → summarize → primer → entity-link, return `Article` shape, store in `share_artifacts` table (per-user, 7-day cache).
-- Anonymous rate limit, signed-in rate limit (20/day per user — tighter than iOS plan's 50).
+- Anonymous rate limit, signed-in rate limit (20/day per user).
 
-### Week 8 — push (FCM)
+### Week 8 — Refined Compare (backend + UI) + push (FCM)
 
-- `sift-api`: `device_registrations` table, `POST /v1/devices/register`, `push_dispatcher` workflow node, FCM sender.
-- Android: `FirebaseMessagingService` subclass, notification channels per category, permission request post-intent (not first launch).
+- **Backend**: `POST /api/compare` gains `lens` parameter; agent path implementation. Reuses Ask Sift backbone (Anthropic SDK, tool layer, cost caps).
+- **Android**: `CompareScreen` reached from article detail. Outlet cards. "Focus on…" input that toggles deterministic ↔ Refined Compare paths. Citation rendering.
+- **Backend**: `device_registrations` table, `POST /v1/devices/register`, `push_dispatcher` workflow node, FCM sender.
+- **Android**: `FirebaseMessagingService` subclass, notification channels per category, permission request post-intent (not first launch).
 - E2E test: insert flagged article via psql, observe FCM delivery on a real device.
 
 ### Week 9 — polish + Play Console listing
@@ -316,23 +350,31 @@ Order these in week 1 of engineering so they don't bottleneck week 9.
 - App Links verification deployed.
 - App icon (diamond mark adaptive icon), splash screen.
 - Internal testing track populated (you + 5 friends).
+- AI-summarization reviewer notes drafted (Ask Sift grounding policy, methodology link).
 
 ### Week 10 — closed beta
 
 - Open beta via "Closed testing" track (up to 100 testers).
 - Bug-fix from internal feedback.
 - Performance sweep — verify cold start ≤ 1.5s on Pixel 9, p95 frame time ≤ 16ms on feed scroll.
+- **Eval set check**: 50-prompt Ask Sift eval re-run; verify ≥ 90% citation rate, no uncited entity claims in spot check.
 
-### Weeks 11–12 — production submission
+### Weeks 11–12 — polish + agent-loop hardening
 
 - Bug-fix from closed beta.
-- Screenshots for Play Store (phone 6", tablet 7" + 10" — Play requires more sizes than App Store).
-- Reviewer notes; demo account.
+- Tune Ask Sift system prompt based on real user transcripts (privacy-safe sampling).
+- Refined Compare eval (30 lens+topic pairs) re-run; verify lens-relevance ratio ≥ 0.9.
+- Cost telemetry validated: per-conversation cost surfacing, cap-hit rates within expected bounds.
+
+### Weeks 13–14 — production submission
+
+- Screenshots for Play Store (phone 6", tablet 7" + 10").
+- Reviewer notes; demo account; AI-summarization disclosure.
 - Submit to production. Play Store review: typically 1–3 days, expect 1 round of resubmission.
 
 ### Post-launch
 
-- Watch crash-free-session rate (≥ 99.5%), cold start p95, push delivery rate (FCM dashboard), web→app install rate (Branch.io or in-app banner attribution).
+- Watch crash-free-session rate (≥ 99.5%), cold start p95, push delivery rate (FCM dashboard), web→app install rate, **Ask Sift session-per-WAU, Compare button taps, citation tap-through rate**, agent loop cost trajectory.
 - Read user reviews daily for first 2 weeks; mine for v1.1 priorities.
 
 ---
@@ -341,15 +383,20 @@ Order these in week 1 of engineering so they don't bottleneck week 9.
 
 | Risk / question | Mitigation / next step |
 |---|---|
-| **Solo dev burnout on a 10-week build.** | Time-box by week. If week 4 isn't done by end of week 5, cut topic search to v1.1 and ship without it. |
+| **Solo dev burnout on a 12-week build.** | Time-box by week. If week 4 isn't done by end of week 5, cut topic search to v1.1. If week 8 (Refined Compare) is slipping, ship Compare as deterministic-only and add lens path post-launch. |
 | **API drift between this client and `sift/lib/types.ts`.** | Contract test in `sift-android/app/src/test/` decodes recorded fixtures. Runs on every PR. |
-| **Civic-literacy UX doesn't translate.** | Design sprint pre-week-1 is non-negotiable. If wireframes don't pass a "would I read this on a phone" sniff test, redesign before code. |
-| **FCM cost runaway from `/v1/share/sift-this`.** | 20/day/user signed-in cap. Daily $30 Anthropic budget alarm. Per-user `share_artifacts` 7-day cache (repeat URLs return cached result). |
-| **Play Store rejects AI-summarization app under content rights.** | Methodology page + per-article source attribution + Custom Tabs for "Read at source." Play Store has rejected fewer AI summarizers than App Store in 2026, but not zero — methodology + transparency is the defense. |
-| **Civic data shape changes during v1.5 web pivot.** | Models tolerate optional fields (`contextPrimer?`, `outlet?`, `entityLinks` defaulting to `[]`). API contract test catches drift. We freeze v1 Android against web shapes as of week 1; treat civic-pivot field additions as additive only. |
+| **Civic-literacy UX doesn't translate.** | Design sprint pre-week-1 is non-negotiable. Six touchpoints to wireframe; defer anything that doesn't pass a "would I read this on a phone" sniff test. |
+| **FCM cost runaway from `/v1/share/sift-this`.** | 20/day/user signed-in cap. Daily $30 Anthropic budget alarm. Per-user `share_artifacts` 7-day cache. |
+| **Ask Sift cost runaway from abusive users.** | Per-turn $0.50 hard cap. Per-user-day $5 signed / $2 anon. Global $50/day ceiling with alarm at $30. Kill-switch env `ASK_SIFT_DISABLED=true` for instant disable. Email-gated signin for sustained use. |
+| **Ask Sift hallucination on civic content.** | System prompt mandates tool-grounded answers. Output filter strips uncited entity claims. Citation density target ≥ 1 per real-entity claim. 50-prompt eval set with weekly regression check. Methodology paragraph public. |
+| **Refined Compare lens-relevance drift.** | 30 lens+topic eval pairs. Lens-relevance ratio target ≥ 0.9. Schema enforcement via Pydantic; agent retries up to 2x if output invalid. |
+| **Play Store rejects AI-summarization app under content rights.** | Methodology page + per-article source attribution + Custom Tabs for "Read at source." Reviewer notes explain grounding policy. Play Store has been more permissive than App Review on AI summarizers in 2026 but not zero-friction. |
+| **Play Store rejects AI chat under content moderation.** | Reviewer notes pre-emptively cover: agent only references Sift's curated index (no general LLM Q&A); grounding policy + citation enforcement; cost caps prevent abuse; kill-switch documented. |
+| **Civic data shape changes during v1.5 web pivot.** | Models tolerate optional fields. Contract test catches drift. Freeze v1 Android against web shapes as of week 1; treat civic-pivot field additions as additive only. |
+| **Latency complaints on Ask Sift (5–30s per turn).** | Streaming progress (tokens within ~2s). Inline tool-call chips so users see the agent is grounded, not stuck. Cap turn at 30s; surface cost-cap-hit messages clearly. |
 | **Open question: cross-platform reuse when iOS lands.** | None of v1 is shared. By the time iOS starts (Q4 2026), KMP / Compose Multiplatform may have matured enough to factor common Kotlin into a shared module. Reassess at iOS week 0. |
 | **Open question: Glance widget priority.** | v1 deliberately defers Glance widget. Decide at v1.1 based on whether feed engagement signals demand it. |
-| **Open question: WorkManager periodic sync battery cost.** | 15-min interval is aggressive. Pixel battery saver kicks in around 30-min intervals as default. Watch user complaints; back off to 30-min if needed. |
+| **Open question: Ask Sift conversation persistence.** | Out of v1 scope. session_id field reserved in API for v1.1 add. |
 
 ---
 
@@ -357,9 +404,12 @@ Order these in week 1 of engineering so they don't bottleneck week 9.
 
 Tracked here so v1 scope discussions have a destination for cut features. None of these block v1.
 
-- **Multi-source compare native UI** — port from sift-mcp behavior.
 - **Native civic dossier views** — politicians, orgs, bills, outlets. Today they open in Custom Tabs.
 - **Glance home-screen widget** ("Today on Sift") — small + medium sizes.
+- **Ask Sift conversation persistence** — saved threads, history.
+- **Ask Sift voice input** — speech-to-text → chat.
+- **Multi-lens Refined Compare** — compare on multiple lenses simultaneously.
+- **Lens templates / saved-lens shortcuts** for Refined Compare.
 - **Wear OS companion** — glance + complications.
 - **Tablet-optimized layout** — three-pane (categories / feed / detail).
 - **Live Updates** (Android 15 API 35) — for developing stories.
@@ -373,9 +423,9 @@ Tracked here so v1 scope discussions have a destination for cut features. None o
 
 ## File inventory at v1 ship (estimated)
 
-- `sift-android` — ~100 Kotlin source files, ~12–15k LOC (app + share-target + FCM service + tests).
-- `sift-api` — +2 net-new endpoints, +2 tables (`share_artifacts`, `device_registrations`), +1 workflow node (push_dispatcher), +FCM sender. ~1,200 net-new LOC.
-- `sift` — optional: 1 Get-on-Google-Play banner + `.well-known/assetlinks.json`. ~50 LOC.
+- `sift-android` — ~120 Kotlin source files, ~15–18k LOC (app + share-target + FCM service + Ask + Compare screens + tests).
+- `sift-api` — +4 net-new endpoints (`/v1/share/sift-this`, `/v1/devices/register`, `/api/ask`, `/api/compare` w/ lens), +2 tables (`share_artifacts`, `device_registrations`), +1 workflow node (push_dispatcher), +FCM sender, +sift-mcp merge. ~2,500 net-new LOC.
+- `sift` — web `/ask` chat UI, Compare button gains "Focus on…" input. ~1,500 net-new LOC. Plus optional: 1 Get-on-Google-Play banner + `.well-known/assetlinks.json`.
 
 ---
 
@@ -385,14 +435,15 @@ Quick reference for the cross-functional critique that shaped this doc:
 
 | iOS plan v1 issue | How Android v1 addresses it |
 |---|---|
-| KPIs in appendix | KPIs in §2, before architecture |
-| No monetization paragraph | §3 Monetization stance — explicit "free through 2026, subscription explore in 2027 contingent on D30 ≥ 20%" |
-| No design sprint budgeted | Pre-week-1 design sprint named as non-negotiable; specific anti-patterns called out |
+| KPIs in appendix | KPIs in §2, before architecture; includes Ask Sift + Compare engagement metrics |
+| No monetization paragraph | §3 Monetization stance — explicit "free through 2026, subscription explore in 2027 contingent on D30 ≥ 20%", with shared budget pool for Ask Sift + Refined Compare |
+| No design sprint budgeted | Pre-week-1 design sprint named as non-negotiable; six touchpoints called out including Ask Sift + Compare screens |
 | Apple Developer enrollment lead time understated | Google Play account is $25/instant; week 1 task |
-| Parity-shaped 4-feature scope | Reader + share extension (user-chosen, larger). Widgets / Live Updates deferred to v1.1 with named criteria |
-| Premature canonical `/v1/*` API | Reuse Next.js routes; only 2 genuinely new endpoints in sift-api |
-| Civic-literacy as feature, not headline | Civic-literacy translation (primer, chips, dossiers) has its own §, called out as "biggest design risk" |
+| Parity-shaped 4-feature scope | Reader + share extension + Ask Sift chat + Compare button (deterministic + Refined). Ask Sift is the differentiator that justifies native vs PWA. |
+| Premature canonical `/v1/*` API | Reuse Next.js routes; 4 net-new endpoints in sift-api (share, device-register, ask, compare-with-lens) |
+| Civic-literacy as feature, not headline | Civic-literacy translation has six touchpoints (primer, glossary chips, entity chips, outlet badge, **Ask Sift chat**, **Compare screen**); called out as "biggest design risk" |
 | Lawyer review only at submission | Lawyer 30-min consult before "Sift this URL" ships (week 7), not at week 12 |
+| Generic news app risk | Ask Sift agentic chat as the v1 wedge — civic-literacy agent on the phone, not just a reader |
 
 ---
 


### PR DESCRIPTION
## Summary

Two doc updates that reflect the 2026-05-20 decisions on Android v1 scope expansion + cross-repo merge + agentic surfaces.

### `STATUS.md`

- **Tier line:** v1.5 (civic-literacy + agentic surfaces in Android v1) — removed the v1.5/v1.6 split since Ask Sift moved to v1.5
- **Active focus:** added merge + Ask Sift + Refined Compare alongside civic-literacy work; called out Android v1 build entering Phase 0
- **Next 3:** updated item 3 from sketch ("resolve native platform direction") to committed Android v1 build with expanded scope; added web `/ask` + Compare-with-Focus-on as parallel work
- **Recent decisions:** added 7 new 2026-05-20 entries covering the expansion

### `docs/ANDROID_APP_v1.md`

Major amendment for the v1 scope expansion. Highlights:

- **TL;DR table:** scope row updated to include Ask Sift + Compare button (deterministic + Refined); timeline 10→12 weeks; added "Agent loop architecture" row (server-side)
- **KPIs:** +5 new metrics (Ask Sift sessions/WAU, completion rate, Compare button taps/WAU, Refined Compare adoption, citation tap-through)
- **Monetization:** shared cost caps for Ask Sift + Refined Compare; kill-switch env documented
- **v1 scope:** Ask Sift agentic chat + Compare button (deterministic + Refined with lens) added; Multi-source compare native UI removed from v1.1+ backlog
- **Architecture:** `ui/ask/` + `ui/compare/` directories added; civic-literacy translation gains TWO touchpoints (now six total)
- **API contract:** +`POST /api/ask` (SSE), +`POST /api/compare` with `lens` param. sift-api now has 4 net-new endpoints (was 2)
- **Cross-repo work:** sift-api gains agent endpoints + merge work; sift gains web `/ask` UI + Compare `Focus on…` input
- **Phasing:** extended to 12-14 weeks; weeks 5-8 absorb agent backend + Android UI work; weeks 11-12 add eval-set re-checks
- **Risks:** added LLM cost / hallucination / Play Store-for-AI-chat risks
- **Backlog:** removed compare native UI; added Ask Sift v1.1+ items (persistence, voice, multi-lens compare, lens templates)

## Test plan

Docs-only PR; no code paths to test.

- [ ] Cross-check `ANDROID_APP_v1.md` matches `sift-api/docs/ASK_SIFT_PLAN.md` and `sift-api/docs/REFINED_COMPARE_PLAN.md` (PR #61) on:
  - Cost cap numbers ($0.50 per-turn, $5/$2 per-user-day, $50 global)
  - Endpoint paths (`/api/ask`, `/api/compare` with `lens`)
  - Eval set targets (≥ 90% citation rate, ≥ 0.9 lens-relevance ratio)
  - Phase numbering
- [ ] Confirm Android v1 timeline expansion (10 → 12 weeks) is acceptable

## Related

- Companion PR: `sift-api` #61 — adds `ASK_SIFT_PLAN.md`, `REFINED_COMPARE_PLAN.md`, updates `MOBILE_PROTOCOL_DECISION.md`, updates `STATUS.md`
- Companion PR: `sift-mcp` #13 — STATUS update reflecting tool surface serves multiple internal LLM clients
- New tracking issues: `sift-api` #62 (merge), `sift-api` #63 (Ask Sift + Refined Compare, retiered v1.5)
- `sift-api/docs/MOBILE_PROTOCOL_DECISION.md` — confirms even agentic surfaces are REST/SSE on mobile