### PR TITLE
docs: normalize frontend pipeline cadence to 30 min

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ```
 Browser --> Vercel (Next.js) --reads--> Neon Postgres (pgvector)
                 |
-                +----- cron /10min ----> Railway (FastAPI + LangGraph) --writes--> Neon Postgres
+                +----- refresh /30min --> Railway (FastAPI + LangGraph) --writes--> Neon Postgres
                 +----- /api/compare ---> Railway
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -94,7 +94,7 @@ User types "AI policy in European healthcare"
 
 ---
 
-## Data flow: background pipeline (every 10 min)
+## Data flow: background pipeline (every 30 min)
 
 ```
 Railway asyncio scheduler fires (or Vercel cron fallback)

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -24,7 +24,7 @@
 | D13 | Streaming | Build as part of initial launch (SSE article delivery) | $0 | SETTLED |
 | D14 | Embedding provider | Voyage AI (free 50M tokens/mo) | $0 | SETTLED |
 | D15 | Image handling | RSS feed images only — no OG scraping, no proxy | $0 | SETTLED |
-| D16 | Background refresh | Railway asyncio scheduler (every 10 min) + Vercel cron fallback | $0 | SETTLED |
+| D16 | Background refresh | Railway asyncio scheduler (every 30 min) + Vercel cron fallback | $0 | SETTLED |
 | D17 | Model selection | Haiku 4.5 (upgrade to Sonnet is one-line change) | ~$4/mo | SETTLED |
 | D22 | Compare source picker | Collapsed-by-default chip selector, 12 curated outlets | $0 | SETTLED |
 | D23 | Compare source list | Curated outlets, not freeform input | $0 | SETTLED |
@@ -325,7 +325,7 @@ RSS feeds include image URLs via `enclosure`, `media:content`, or `media:thumbna
 **Decision:** Railway asyncio scheduler (primary) + Vercel cron route (fallback)
 **Changed from:** Vercel Cron (requires Pro plan)
 
-Railway's FastAPI service runs an asyncio background task that refreshes every 10 minutes in production. A Vercel cron route also exists as a manual fallback. This avoids the $20/mo Vercel Pro requirement.
+Railway's FastAPI service runs an asyncio background task that refreshes every 30 minutes in production. A Vercel cron route also exists as a manual fallback. This avoids the $20/mo Vercel Pro requirement.
 
 ---
 

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -22,7 +22,7 @@ flowchart LR
   end
 
   subgraph Railway[Railway - FastAPI + LangGraph]
-    Sched["asyncio scheduler<br/>every 10 min"]
+    Sched["asyncio scheduler<br/>every 30 min"]
     PipeWF[Pipeline workflow]
     CmpWF[Compare workflow]
   end

--- a/docs/KPIS.md
+++ b/docs/KPIS.md
@@ -42,7 +42,7 @@ The "Read at source" band has a top end on purpose — too many click-throughs m
 |---|---|---|---|
 | `/api/news` p95 latency (server) | ~150ms per `feed-perf` CI | ≤ 200ms | Healthy |
 | `/news` mobile LCP (end-to-end) | 5.5s after PR #55 wins | ≤ 2.5s | Blocked on [sift#56](https://github.com/kristenmartino/sift/issues/56) (SSR + streaming) |
-| Pipeline run duration (10-min cron) | ~90s avg | ≤ 5 min | Healthy; ample margin |
+| Pipeline run duration (30-min scheduler) | ~90s avg | ≤ 5 min | Healthy; ample margin |
 | Pipeline failure rate (Sentry) | < 1% | < 1% | Healthy |
 | Monthly cost | ~$9 (current) | < $100 through v1.5 | On track. Projected $30–50/mo at growth. |
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -62,7 +62,7 @@ Two services, one database:
 - **Python FastAPI + LangGraph on Railway** — background pipeline: primer generation, entity extraction, entity linking to dossiers, summarization, story synthesis, story clustering, civic context generation, batched API client, cross-source comparison workflow, usage tracking.
 - **Neon Postgres + pgvector** — single source of truth for articles, embeddings, entity dossiers, bookmarks.
 
-Pipeline runs every 10 minutes via asyncio scheduler on Railway. User requests never touch Claude — they read from Postgres in <50ms.
+Pipeline runs every 30 minutes via asyncio scheduler on Railway. User requests never touch Claude — they read from Postgres in <50ms.
 
 Full technical details: `ARCHITECTURE.md` and `TECHNICAL_SPEC.md`.
 
@@ -105,7 +105,7 @@ Full technical details: `ARCHITECTURE.md` and `TECHNICAL_SPEC.md`.
 - Not a chatbot interface. Browse, don't interrogate.
 - Not a trust-judgment layer. Sift surfaces AllSides + MBFC ratings verbatim; it does not compute its own.
 - Not a propaganda decoder. (Different product, different corpus, different audience.)
-- Not a real-time ticker. Refreshes every 10–15 minutes.
+- Not a real-time ticker. Refreshes every 30 minutes.
 - Not a full-text reader. Links to original sources.
 - Not a social platform. No comments, no voting.
 

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -34,7 +34,7 @@
 | RSS feeds | 100+ feeds across 10 categories | **Live** |
 | Claude Haiku 4.5 | Batch summaries + comparison analysis + web search | **Live** |
 | Voyage AI embeddings | voyage-3-lite, 1024-dim | **Live** |
-| Background refresh | asyncio scheduler, every 10 minutes | **Live** |
+| Background refresh | asyncio scheduler, every 30 minutes | **Live** |
 | CI/CD | GitHub Actions (ruff + pytest) + Railway auto-deploy | **Live** |
 
 ### Database — Neon Postgres (free tier)

--- a/docs/TECHNICAL_SPEC.md
+++ b/docs/TECHNICAL_SPEC.md
@@ -14,7 +14,7 @@ Two services + one database:
 | Service | Platform | Language | Purpose |
 |---------|----------|----------|---------|
 | sift-web | Vercel (Hobby) | TypeScript (Next.js 15) | Frontend, API routes (DB reads), Clerk auth, SSE streaming |
-| sift-api | Railway | Python (FastAPI + LangGraph) | Background pipeline (10-min scheduler), multi-source comparison |
+| sift-api | Railway | Python (FastAPI + LangGraph) | Background pipeline (30-min scheduler), multi-source comparison |
 | sift-db | Neon (free tier) | PostgreSQL 17 + pgvector | Shared database, single source of truth |
 
 ---
@@ -535,4 +535,4 @@ httpx>=0.28.0
 
 ### Background refresh
 
-Pipeline refresh runs via Railway's asyncio background scheduler (every 10 minutes in production). A Vercel cron route (`/api/cron/refresh`) exists as a manual fallback but is not actively scheduled (avoids Vercel Pro requirement). `vercel.json` is empty (`{}`).
+Pipeline refresh runs via Railway's asyncio background scheduler (every 30 minutes in production). A Vercel cron route (`/api/cron/refresh`) exists as a manual fallback but is not actively scheduled (avoids Vercel Pro requirement). `vercel.json` is empty (`{}`).

--- a/docs/interview-prep/20min-walkthrough.md
+++ b/docs/interview-prep/20min-walkthrough.md
@@ -29,7 +29,7 @@ Whiteboard cue: 3 boxes + 1 database.
 Walk through:
 
 1. **Vercel hosts Next.js 15** (App Router, TypeScript). Owns user reads + UI. Server Components fetch from Postgres directly — **no client-side fetch in the browse path.**
-2. **Railway hosts FastAPI + LangGraph.** Long-running process — LangGraph workflows need this; Vercel functions cold-start poorly for multi-step orchestration. asyncio scheduler runs pipeline every 10 min. On-demand compare workflow.
+2. **Railway hosts FastAPI + LangGraph.** Long-running process — LangGraph workflows need this; Vercel functions cold-start poorly for multi-step orchestration. asyncio scheduler runs pipeline every 30 min. On-demand compare workflow.
 3. **Neon Postgres + pgvector** is the single source of truth. Articles + embeddings + dossiers + bookmarks in one DB. pgvector handles both structured queries and vector cosine in the same `WHERE`.
 
 Plus external services: **Claude Haiku 4.5** for summaries + compare. **Voyage AI** for embeddings (free 50M tokens/mo). **Clerk** for auth.
@@ -63,7 +63,7 @@ Followed by **story threading** (cross-source clustering) — a 4-node workflow 
 
 **Anticipate:**
 
-- *"What if RSS lags breaking news?"* — Tradeoff acknowledged. ~10-minute lag for most outlets. Topic search has Claude `web_search` fallback for niche/breaking queries the indexed pool hasn't seen.
+- *"What if RSS lags breaking news?"* — Tradeoff acknowledged. ~30-minute lag for most outlets. Topic search has Claude `web_search` fallback for niche/breaking queries the indexed pool hasn't seen.
 - *"Cost?"* — ~$4/mo Claude. Batched. Per-article cost ~$0.001. Voyage free tier covers all embeddings. Total infra: ~$9/mo current.
 - *"Why LLM-as-judge for clustering instead of embedding cosine?"* — Embedding catches same-topic (~90% accuracy). LLM judges distinguish same-event from same-topic (~97%). At Sift's article volume per category (max 50 in a 48h window), a single LLM call handles it. Embedding-prefilter + LLM-refine was rejected — added complexity, no benefit at this scale.
 

--- a/docs/interview-prep/2min-overview.md
+++ b/docs/interview-prep/2min-overview.md
@@ -10,7 +10,7 @@ Sift is an AI-curated news reader with a civic-literacy layer — *"the news, wi
 
 ## The architecture (3 boxes)
 
-Three boxes, one database. **Vercel** hosts the Next.js frontend. **Railway** runs the Python pipeline — FastAPI + LangGraph workflows that pull from 100+ RSS feeds every 10 minutes, summarize each article with Claude Haiku 4.5, embed with Voyage AI, and write to **Neon Postgres** with pgvector. The frontend reads from Postgres in ~50ms; AI never runs in the user's request path for the browse experience.
+Three boxes, one database. **Vercel** hosts the Next.js frontend. **Railway** runs the Python pipeline — FastAPI + LangGraph workflows that pull from 100+ RSS feeds every 30 minutes, summarize each article with Claude Haiku 4.5, embed with Voyage AI, and write to **Neon Postgres** with pgvector. The frontend reads from Postgres in ~50ms; AI never runs in the user's request path for the browse experience.
 
 There's a second live-AI path for power features: topic search uses vector similarity over indexed embeddings with a Claude `web_search` fallback for niche queries, and multi-source compare uses a LangGraph fan-out workflow to query 2–5 outlets in parallel and synthesize how each framed the same story.
 


### PR DESCRIPTION
## What
Normalize the **frontend docs** to the canonical pipeline refresh cadence — **30 min** (the backend `REFRESH_INTERVAL = 30 * 60`, synced in sift-api#72). 14 stale "10 min" references across 10 docs. **Docs-only — no runtime code touched.**

Companion to **sift-api#72** / **sift-api#65**; part of the Trust & Contracts stabilization sprint (**#110**).

## Changed (before → after)
| File | Before → After |
|---|---|
| `README.md` | architecture diagram `cron /10min` → `refresh /30min` (also drops the misleading Vercel-cron framing — the real trigger is Railway's asyncio scheduler) |
| `docs/ARCHITECTURE.md` | "background pipeline (every 10 min)" → 30 min |
| `docs/HOW_IT_WORKS.md` | mermaid `asyncio scheduler / every 10 min` → 30 min |
| `docs/KPIS.md` | "Pipeline run duration (10-min cron)" → "(30-min scheduler)" |
| `docs/PRD.md` | "runs every 10 minutes" → 30; "Refreshes every 10–15 minutes" → "every 30 minutes" |
| `docs/PROJECT_PLAN.md` | "asyncio scheduler, every 10 minutes" → 30 |
| `docs/TECHNICAL_SPEC.md` | "(10-min scheduler)" → "(30-min scheduler)"; "(every 10 minutes in production)" → 30 |
| `docs/interview-prep/20min-walkthrough.md` | "every 10 min" → 30; "~10-minute lag" → "~30-minute lag" |
| `docs/interview-prep/2min-overview.md` | "every 10 minutes" → 30 |
| `docs/DECISIONS.md` | D16 "SETTLED" summary row 10 → 30 min; "refreshes every 10 minutes in production" → 30 |

## Deliberately left alone
- **Compare/topic latency `~10–15s`** (README, PRD, PRODUCT_STORY, HOW_IT_WORKS, DESIGN_SPRINT, 2min-overview) — that's request latency, not refresh cadence.
- **`docs/DECISIONS.md` original cron-based ADR flow diagrams** (D7 / lines 65, 202) — it's the *historical* decision log; those record the original Vercel-cron design and are correctly framed as past. Current state is reflected in the D16 row + prose that I did update.
- **`.tsx` runtime/copy** (the docs-only boundary for this PR):
  - `app/opengraph-image.tsx` — already fixed; "10 min" survives only in a comment explaining what was removed. ✅
  - `app/colophon/page.tsx:110` — **user-facing** architecture diagram still renders `cron / 10 min`, while line 27 of the same page already says "every 30 minutes" (self-contradiction). Belongs with colophon issue **#112**.
  - ISR-window comments (`app/page.tsx`, `methodology`, `civic`, `politician`, `outlet`) say "every 10 minutes" — that's the ISR `revalidate = 600` (genuinely 10 min); only the "same heartbeat as the pipeline" clause is now stale. Belongs with homepage/ISR issue **#111**.

## Notes
- No `Closes` keyword — the cadence issue (sift-api#65) lives in the backend repo and is closed by sift-api#72; this is its frontend companion.
- Markdown-only; no build/runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
