### PR TITLE
ci: require Next.js production build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,24 @@ jobs:
     name: Type Check & Test
     runs-on: ubuntu-latest
 
+    # Throwaway Postgres used ONLY by the production-build prerender step below.
+    # Schema comes from ci/build-db-schema.sql (empty tables) — no production
+    # data and no secrets. See that file for why the build needs a DB at all.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sift_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
 
@@ -27,6 +45,21 @@ jobs:
 
       - name: Type check
         run: npx tsc --noEmit
+
+      # Give `next build` an empty, throwaway DB so the three DB-backed ISR
+      # pages (/, /methodology, /civic) can prerender in CI without a live
+      # database. Queries return zero rows; runtime behavior is unchanged.
+      - name: Initialize CI build database
+        env:
+          PGPASSWORD: postgres
+        run: |
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-client
+          psql -h localhost -U postgres -d sift_ci -v ON_ERROR_STOP=1 -f ci/build-db-schema.sql
+
+      - name: Production build
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/sift_ci
+        run: npm run build
 
       - name: Test
         run: npm test -- --ci --coverage

--- a/ci/build-db-schema.sql
+++ b/ci/build-db-schema.sql
@@ -1,0 +1,86 @@
+-- Minimal CI schema for the Next.js production build prerender.
+--
+-- This is NOT the production migration source of truth — that lives in the
+-- sift-api repo (init.sql + app/db.py migrations). It exists only so that
+-- `next build` can prerender the three DB-backed ISR pages against an empty,
+-- throwaway Postgres in CI instead of a live database. No production secrets,
+-- no real data.
+--
+-- The build PRERENDERS (static, ISR) "/" and "/methodology", which read:
+--   getTopStoryForLanding -> articles          (app/page.tsx)
+--   getAllOutletProfiles  -> outlet_profiles   (app/methodology/page.tsx)
+-- "/civic" currently renders DYNAMICALLY (it reads searchParams), so its
+-- queries run at request time, not at build. Its tables are included
+-- defensively so this fixture stays valid if /civic becomes static again:
+--   listAllPoliticiansLite -> politician_profiles  (app/civic/page.tsx)
+--   listAllOrgsLite        -> org_profiles         (app/civic/page.tsx)
+--   listAllBillsLite       -> bill_profiles        (app/civic/page.tsx)
+-- Keep in sync with those query functions in sift/lib/db.ts.
+--
+-- Tables are intentionally EMPTY: prerender only needs the queries to execute
+-- (returning zero rows), not real data. Only the columns each query selects,
+-- filters, or orders by are declared.
+
+-- "/" landing lead story — getTopStoryForLanding()
+CREATE TABLE IF NOT EXISTS articles (
+  id               TEXT PRIMARY KEY,
+  title            TEXT,
+  summary          TEXT,
+  source_url       TEXT,
+  source_name      TEXT,
+  image_url        TEXT,
+  category         TEXT,
+  published_date   TIMESTAMPTZ,
+  read_time        INTEGER,
+  why_it_matters   TEXT,
+  importance_score NUMERIC,
+  context_primer   JSONB,
+  reading_levels   JSONB,
+  created_at       TIMESTAMPTZ,
+  from_search      BOOLEAN
+);
+
+-- "/methodology" outlet list — getAllOutletProfiles()
+CREATE TABLE IF NOT EXISTS outlet_profiles (
+  slug                  TEXT PRIMARY KEY,
+  name                  TEXT,
+  parent_company        TEXT,
+  parent_company_url    TEXT,
+  founded_year          INTEGER,
+  funding_model         TEXT,
+  allsides_rating       TEXT,
+  allsides_url          TEXT,
+  allsides_last_checked  DATE,
+  mbfc_factual          TEXT,
+  mbfc_url              TEXT,
+  mbfc_last_checked     DATE,
+  major_funders         JSONB,
+  external_links        JSONB,
+  notes                 TEXT
+);
+
+-- "/civic" politician index — listAllPoliticiansLite()
+CREATE TABLE IF NOT EXISTS politician_profiles (
+  bioguide_id TEXT PRIMARY KEY,
+  name        TEXT,
+  party       TEXT,
+  state       TEXT,
+  chamber     TEXT
+);
+
+-- "/civic" organization index — listAllOrgsLite()
+CREATE TABLE IF NOT EXISTS org_profiles (
+  slug           TEXT PRIMARY KEY,
+  name           TEXT,
+  type           TEXT,
+  political_lean TEXT
+);
+
+-- "/civic" bill index — listAllBillsLite()
+CREATE TABLE IF NOT EXISTS bill_profiles (
+  bill_id         TEXT PRIMARY KEY,
+  congress        INTEGER,
+  short_title     TEXT,
+  status          TEXT,
+  introduced_date DATE
+);


### PR DESCRIPTION
## What
Adds `npm run build` (Next.js production build) to CI as a required step, so production-only build failures are caught pre-merge. **Command added:** `npm run build`, in the existing `Type Check & Test` job, ordered **typecheck → build → test**.

Closes #113

## Why it needs a DB (and why CI gets a throwaway one)
`next build` prerenders two **static ISR** pages that read Postgres at build time:
- `/` → `getTopStoryForLanding()` (table `articles`)
- `/methodology` → `getAllOutletProfiles()` (table `outlet_profiles`)

And `lib/db.ts` deliberately **throws** if `DATABASE_URL` is unset (`:20`) and **re-throws connection errors** (only `"does not exist"` is swallowed). So a no-DB CI build hard-fails at prerender with `ECONNREFUSED`.

Per the agreed approach (isolated CI fixture — **not** the prod Neon DB, no app-behavior change, ISR stays ISR):
- a throwaway `pgvector/pgvector:pg16` **service** runs in the job,
- `ci/build-db-schema.sql` creates the **minimal empty tables** the build-time queries touch,
- the build step points `DATABASE_URL` at the local service. Queries return zero rows → pages prerender empty → **runtime behavior unchanged**.

## Files
- `.github/workflows/ci.yml` — adds the `postgres` service + an "Initialize CI build database" step + a "Production build" step (order: typecheck → build → test).
- `ci/build-db-schema.sql` — minimal empty schema (5 tables, only the referenced columns). Header documents that it is **not** the prod schema source of truth.

## Local validation (CI-faithful)
Ran against an empty `pgvector/pgvector:pg16` container with `.env.local` removed and only the CI `DATABASE_URL` set:
- ✅ `npm run build` exits **0**
- ✅ `/methodology` prerenders as static (ISR `10m` preserved)
- ✅ no production secrets, no real data

## Notes
- **`/civic` renders dynamically** (it reads `searchParams`), so its queries run at request time, not build — only `articles` + `outlet_profiles` are strictly build-time-required. The three civic tables (`politician_profiles`, `org_profiles`, `bill_profiles`) are included defensively (and per the agreed fixture spec) so the schema stays valid if `/civic` ever becomes static.
- **No `DATABASE_URL` is given to the typecheck or test steps** — they behave exactly as before (jest uses mocks).
- The build runs inside the existing required **Type Check & Test** check, so it gates merges immediately — no branch-protection change needed. If you'd prefer a distinct **Build** check, I can split it into its own job.
- **Future follow-up:** long-term, generate this fixture from the backend schema (sift-api `init.sql` / migrations) or fold it into shared contract tests so it can't drift from the real columns. For now the isolated fixture is the right-sized fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
