### PR TITLE
fix: drive source colophon from curated outlet data

### DIFF
--- a/__tests__/SourceColophon.test.tsx
+++ b/__tests__/SourceColophon.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import SourceColophon from "@/components/landing/SourceColophon";
+import { COPY } from "@/lib/copy";
+
+describe("SourceColophon", () => {
+  it("renders the curated outlet names it is given", () => {
+    render(
+      <SourceColophon
+        outlets={[
+          { slug: "reuters", name: "Reuters" },
+          { slug: "politico", name: "Politico" },
+          { slug: "wired", name: "Wired" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Reuters")).toBeInTheDocument();
+    expect(screen.getByText("Politico")).toBeInTheDocument();
+    expect(screen.getByText("Wired")).toBeInTheDocument();
+    // Heading + summary always render.
+    expect(screen.getByText(COPY.landing.colophonHeading)).toBeInTheDocument();
+    expect(screen.getByText(COPY.landing.colophonSummary)).toBeInTheDocument();
+  });
+
+  it("does not bake in a hardcoded source list — only renders provided outlets", () => {
+    render(<SourceColophon outlets={[{ slug: "npr", name: "NPR" }]} />);
+    expect(screen.getByText("NPR")).toBeInTheDocument();
+    // "The Athletic" was in the old hardcoded array; it must not appear unless
+    // it is present in the curated data passed in. Guards against list drift.
+    expect(screen.queryByText("The Athletic")).not.toBeInTheDocument();
+  });
+
+  it("degrades gracefully when no outlets are available (DB miss/empty)", () => {
+    const { container } = render(<SourceColophon outlets={[]} />);
+    // Prose still renders so the landing never breaks or shows a stale list...
+    expect(screen.getByText(COPY.landing.colophonHeading)).toBeInTheDocument();
+    expect(screen.getByText(COPY.landing.colophonDescription)).toBeInTheDocument();
+    expect(screen.getByText(COPY.landing.colophonSummary)).toBeInTheDocument();
+    // ...and no outlet grid is rendered.
+    expect(container.querySelector("ul")).toBeNull();
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import LandingPage from "@/components/LandingPage";
-import { getTopStoryForLanding } from "@/lib/db";
+import { getAllOutletProfiles, getTopStoryForLanding } from "@/lib/db";
 import { parseContextPrimer } from "@/lib/primer";
 import type { Article, CategoryId } from "@/lib/types";
 
@@ -18,7 +18,18 @@ export const metadata: Metadata = {
 export const revalidate = 600;
 
 export default async function Home() {
-  const lead = await getTopStoryForLanding();
+  const [lead, outletProfiles] = await Promise.all([
+    getTopStoryForLanding(),
+    // Curated outlet list for the source colophon. Guarded so an outlet-data
+    // miss degrades to an empty list rather than breaking the landing (same
+    // posture as getTopStoryForLanding returning null).
+    getAllOutletProfiles().catch(() => []),
+  ]);
+  const outlets = outletProfiles.map((o) => ({
+    slug: o.slug,
+    name: o.name,
+    allSidesRating: o.allSidesRating,
+  }));
   const primer = lead ? parseContextPrimer(lead.context_primer) : null;
   const leadStory: Article | null = lead
     ? {
@@ -37,5 +48,5 @@ export default async function Home() {
       }
     : null;
 
-  return <LandingPage leadStory={leadStory} />;
+  return <LandingPage leadStory={leadStory} outlets={outlets} />;
 }

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -6,15 +6,17 @@ import SiftLogo from "./SiftLogo";
 import LandingMasthead from "./landing/LandingMasthead";
 import LeadStory from "./landing/LeadStory";
 import ComparisonDemo from "./landing/ComparisonDemo";
-import SourceColophon from "./landing/SourceColophon";
+import SourceColophon, { type SourceColophonOutlet } from "./landing/SourceColophon";
 import type { Article } from "@/lib/types";
 
 interface LandingPageProps {
   /** Server-fetched lead story (ISR @ 600s in app/page.tsx). Null = DB miss. */
   leadStory: Article | null;
+  /** Curated outlets from `outlet_profiles` (ISR @ 600s). Empty = DB miss/empty. */
+  outlets: SourceColophonOutlet[];
 }
 
-export default function LandingPage({ leadStory }: LandingPageProps) {
+export default function LandingPage({ leadStory, outlets }: LandingPageProps) {
   return (
     <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
       {/* Drop-cap rule, scoped to landing only — Sift's globals.css doesn't
@@ -40,7 +42,7 @@ export default function LandingPage({ leadStory }: LandingPageProps) {
       <main id="main-content">
         <LeadStory article={leadStory} />
         <ComparisonDemo />
-        <SourceColophon />
+        <SourceColophon outlets={outlets} />
       </main>
 
       {/* ── Colophon Footer ──────────────────────────── */}

--- a/components/landing/SourceColophon.tsx
+++ b/components/landing/SourceColophon.tsx
@@ -2,52 +2,50 @@
 
 import { COPY } from "@/lib/copy";
 
-// Curated source list for the colophon. Two columns on desktop, one on mobile.
-// Order roughly matches reader prominence (wires & broadsheets first, then
-// trade press by category). Drop or reorder as the source set changes.
-const SOURCES: string[] = [
-  "Reuters", "Associated Press", "BBC", "NPR",
-  "The New York Times", "The Washington Post", "The Guardian",
-  "Bloomberg", "Financial Times", "The Economist", "Wall Street Journal",
-  "Axios", "Politico", "The Atlantic", "PBS NewsHour",
-  "TechCrunch", "Ars Technica", "The Verge", "Wired", "MIT Tech Review",
-  "Hacker News", "TechMeme",
-  "CNBC", "MarketWatch", "Fortune", "Forbes",
-  "Nature", "Science", "Phys.org", "Scientific American", "NASA",
-  "Quanta Magazine",
-  "CleanTechnica", "Electrek", "Canary Media", "Carbon Brief",
-  "Grist", "Inside Climate News",
-  "Al Jazeera", "DW News", "France 24", "South China Morning Post",
-  "Foreign Policy",
-  "STAT News", "WHO", "The BMJ", "NIH", "The Lancet", "Medscape",
-  "The Hill", "FiveThirtyEight", "RealClearPolitics",
-  "ESPN", "BBC Sport", "The Athletic", "Sports Illustrated",
-  "Variety", "Hollywood Reporter", "Deadline", "Rolling Stone",
-  "Pitchfork", "IGN",
-  "Vox", "ProPublica", "Rest of World",
-];
+export interface SourceColophonOutlet {
+  slug: string;
+  name: string;
+  /**
+   * AllSides lean if available — threaded through for an optional future
+   * Left / Center / Right grouping. Not rendered yet: this list is alphabetical.
+   */
+  allSidesRating?: string | null;
+}
 
-export default function SourceColophon() {
+interface SourceColophonProps {
+  /**
+   * Curated outlets from `outlet_profiles` (alphabetized, server-fetched in
+   * app/page.tsx). Driving this from the database — not a hardcoded array — is
+   * the point: the public list can no longer drift from the curated data. Empty
+   * on a DB miss/empty table, in which case we degrade to the prose (no grid) so
+   * the landing never breaks and never shows a stale source list.
+   */
+  outlets: SourceColophonOutlet[];
+}
+
+export default function SourceColophon({ outlets }: SourceColophonProps) {
   return (
     <section className="max-w-[1100px] mx-auto px-6 pb-20">
       <div className="border-t border-b border-[var(--border)] py-9">
-        <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-5 flex items-center">
+        <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-4 flex items-center">
           <span aria-hidden className="inline-block w-7 h-px bg-[var(--border)] mr-3" />
           {COPY.landing.colophonHeading}
         </p>
-        <ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-1.5 mb-6">
-          {SOURCES.map((s) => (
-            <li
-              key={s}
-              className="font-body text-[13px] text-[var(--text-secondary)] tracking-tight"
-            >
-              {s}
-            </li>
-          ))}
-          <li className="font-body text-[13px] italic text-[var(--text-muted)]">
-            … and others
-          </li>
-        </ul>
+        <p className="font-body text-[13px] text-[var(--text-secondary)] leading-relaxed max-w-[680px] mb-6">
+          {COPY.landing.colophonDescription}
+        </p>
+        {outlets.length > 0 && (
+          <ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-1.5 mb-6">
+            {outlets.map((outlet) => (
+              <li
+                key={outlet.slug}
+                className="font-body text-[13px] text-[var(--text-secondary)] tracking-tight"
+              >
+                {outlet.name}
+              </li>
+            ))}
+          </ul>
+        )}
         <p className="font-body text-outlet uppercase tracking-wider text-[var(--text-muted)] pt-5 border-t border-[var(--border-subtle)]">
           {COPY.landing.colophonSummary}
         </p>

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -349,8 +349,11 @@ export const COPY = {
     compareSubtitle: "One story, three angles. Sift shows what each outlet chose to emphasize \u2014 described, not labeled \u201cbiased\u201d or \u201cobjective.\u201d You read; the product does the legwork.",
     compareCta: "Compare any topic",
     // Source colophon.
-    colophonHeading: "Read from",
-    colophonSummary: "~50 vetted outlets \u00b7 across the political spectrum \u00b7 refreshed every 30 minutes",
+    colophonHeading: "Curated outlets",
+    colophonDescription:
+      "Sift maintains structured outlet profiles for its curated source set, including ownership, funding model, bias-rating references, and factual-reporting references where available.",
+    colophonSummary:
+      "Outlet profiles are curated from public source metadata and updated as the source set evolves.",
     // Footer colophon link.
     colophonLink: "Colophon",
   },


### PR DESCRIPTION
## What
Replaces the landing `SourceColophon`'s **hardcoded 66-outlet array** with the **live curated outlet list** from `outlet_profiles`, so the public source list can no longer drift from the curated data. Provenance is core to Sift's promise.

Closes #112

## The drift it fixes
The hardcoded array named outlets that aren't in the real corpus — Reuters, AP, Wall Street Journal, The Athletic, IGN, etc. The list now comes from `getAllOutletProfiles()` (the same read path `/methodology` uses), alphabetized.

## Honest framing (no `is_ingested` field)
`outlet_profiles` has **no field marking actively-ingested vs dossier-only outlets**. Per the agreed guidance — filter if such a field exists, otherwise relabel and don't invent logic — the copy now describes a **curated outlet set**, not "what Sift reads":
- heading: **"Read from" → "Curated outlets"**
- description (new): *"Sift maintains structured outlet profiles for its curated source set, including ownership, funding model, bias-rating references, and factual-reporting references where available."*
- summary: dropped the active-ingestion implication (*"…refreshed every 30 minutes"*) → *"Outlet profiles are curated from public source metadata and updated as the source set evolves."*

No claim that AP/Reuters/etc. are actively ingested unless they're present in the live data.
→ The clean long-term distinction is a backend `is_ingested` / `in_feed` flag on `outlet_profiles` (would let a "Read from" heading show only ingested sources). **Deliberately not in this PR** — it needs backend schema + seed + methodology decisions. Happy to file it as a follow-up.

## Data shape
`app/page.tsx` passes a compact, serializable shape — not full `OutletProfile` objects:
```ts
interface SourceColophonOutlet { slug: string; name: string; allSidesRating?: string | null }
```
(`allSidesRating` is threaded through for an optional future L/C/R grouping; this PR renders alphabetically.)

## Changes
- `app/page.tsx` — `Promise.all([getTopStoryForLanding(), getAllOutletProfiles().catch(() => [])])`; the `.catch` guard means outlet-data failure degrades to an empty list instead of breaking the landing (same posture as the lead story returning `null`).
- `components/LandingPage.tsx` — threads `SourceColophonOutlet[]` → `SourceColophon`.
- `components/landing/SourceColophon.tsx` — renders curated outlets from props (keyed by `slug`); **hardcoded `SOURCES` array removed**; degrades to prose (heading + description + summary, no grid) when empty — no stale fallback list.
- `lib/copy.ts` — heading / description / summary per above.
- `__tests__/SourceColophon.test.tsx` — new: renders given outlets, asserts no hardcoded name (`"The Athletic"`) leaks, graceful empty fallback.

## Validation (local, CI-faithful)
- ✅ `tsc --noEmit` clean
- ✅ `npm test` — 318/318 pass (incl. new `SourceColophon.test.tsx`)
- ✅ `npm run build` exits 0 against an empty `pgvector` fixture DB (`.env.local` removed) — `/` prerenders static, ISR preserved. **`ci/build-db-schema.sql` unchanged** — `getAllOutletProfiles` selects only columns already in the fixture (`slug`, `name`, `allsides_rating`).

## Scope guardrails honored
- No `#111` ISR/freshness · no `#118` TECHNICAL_SPEC · no `sift-api#67` zero-vector · no `active_ingest`/schema work.
- Hardcoded array fully removed (not kept as a fallback — that would reintroduce drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
