### PR TITLE
fix: stop the landing masthead from going stale under ISR

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,9 +12,10 @@ export const metadata: Metadata = {
     "Sift reads from ~50 vetted outlets across the political spectrum and adds the civic context, cross-spectrum framing, and money trail the news assumes you already know. Every claim links to a public record.",
 };
 
-// ISR: re-render at most once every 10 minutes — same heartbeat as the
-// pipeline cron. The lead story above the fold stays at-most-one-cycle stale
-// without paying a DB round-trip on every visit.
+// ISR: re-render at most once every 10 minutes. This bounds staleness of the
+// server-fetched lead story + outlet list only — the masthead carries no
+// date/issue stamp (see LandingMasthead), so nothing time-sensitive freezes
+// into the ISR cache. The background pipeline refreshes content every ~30 min.
 export const revalidate = 600;
 
 export default async function Home() {

--- a/components/landing/LandingMasthead.tsx
+++ b/components/landing/LandingMasthead.tsx
@@ -7,40 +7,24 @@ import { useTheme } from "@/lib/hooks";
 import SiftLogo from "@/components/SiftLogo";
 import type { CategoryId } from "@/lib/types";
 
-const LAUNCH_DATE = new Date("2025-02-23T00:00:00Z");
-
-function issueNumber(now: Date): number {
-  const ms = now.getTime() - LAUNCH_DATE.getTime();
-  const weeks = Math.max(0, Math.floor(ms / (7 * 24 * 60 * 60 * 1000)));
-  return weeks + 1;
-}
-
-function formatMasthead(now: Date): string {
-  return new Intl.DateTimeFormat("en-US", {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-  })
-    .format(now)
-    .toUpperCase();
-}
-
 export default function LandingMasthead() {
   const { dark: darkMode, toggle: toggleDark, mounted } = useTheme();
-  const now = new Date();
 
   return (
     <header className="border-b border-[var(--border)] bg-[var(--nav-bg)]">
-      {/* Dateline strip */}
+      {/* Dateline strip — intentionally NOT time-stamped. The issue number and
+          date here were computed from `new Date()`, which froze stale into the
+          ISR-prerendered HTML: a cold visitor saw the date from the last
+          revalidation (weeks old), not today, until client hydration corrected
+          it. The masthead now carries no freshness claim; real "last updated"
+          state belongs with the feed (pipeline_state), not the marketing
+          masthead. See sift#111. */}
       <div className="border-b border-[var(--border-subtle)]">
         <div className="max-w-[1200px] mx-auto px-6 h-9 flex items-center justify-between gap-4">
           <p className="font-body text-outlet uppercase text-[var(--text-secondary)] truncate">
-            <span>Issue №{String(issueNumber(now)).padStart(3, "0")}</span>
-            <span className="mx-2 text-[var(--text-muted)]">·</span>
-            <span>{formatMasthead(now)}</span>
+            <span>{COPY.header.tagline}</span>
             <span className="mx-2 text-[var(--text-muted)] hidden sm:inline">·</span>
-            <span className="hidden sm:inline">{COPY.header.tagline}</span>
+            <span className="hidden sm:inline">{COPY.header.dateline}</span>
           </p>
 
           <div className="flex items-center gap-3 shrink-0">

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -11,6 +11,11 @@ import type { StoryFraming } from "./types";
 export const COPY = {
   header: {
     tagline: "The news, with footnotes",
+    // Non-time-sensitive masthead dateline. Deliberately carries no date or
+    // issue number — those were computed from new Date() and froze stale into
+    // the ISR-prerendered HTML (see LandingMasthead). Real freshness belongs
+    // with the feed, not the marketing masthead.
+    dateline: "Curated civic context for the day's news",
   },
   footer: {
     main: "Sift reads from ~50 vetted outlets across the political spectrum, surfaces the civic context the news assumes you already know, and shows you who's behind every story. Every link goes to the original.",


### PR DESCRIPTION
## What
The landing masthead's **issue number + date went stale for cold visitors**. This removes the brittle time-stamp so the homepage is truthful — with no new moving parts.

Closes #111

## Root cause
`LandingMasthead.tsx` is a **client component** that called `const now = new Date()` in render and derived `Issue №{weeks since LAUNCH_DATE}` and the dateline date. The page is **ISR** (`revalidate = 600`), so `new Date()` evaluated during the server prerender **froze into the static HTML**. A cold visitor / crawler / link-unfurl / pre-hydration paint saw the date from the *last revalidation* (e.g. weeks old); it only corrected after client hydration, with a hydration mismatch in between. The masthead renders on **7 surfaces** (landing, methodology, civic, colophon, 4 dossiers), so it was stale on all of them.

## Fix (Option A — remove brittle claims, per the agreed bias)
Neither value is backed by real data, so they're removed, not re-stamped:
- **`components/landing/LandingMasthead.tsx`** — drop `LAUNCH_DATE` / `issueNumber` / `formatMasthead` and the `new Date()` call. The dateline now shows a **non-time-sensitive** line: `{tagline} · {dateline}`. No hydration mismatch; nothing time-sensitive to freeze.
- **`lib/copy.ts`** — `COPY.header.dateline = "Curated civic context for the day's news"`.
- **`app/page.tsx`** — corrected the ISR comment (it claimed *"every 10 minutes — same heartbeat as the pipeline cron"*; the scheduler runs ~30 min and the masthead no longer carries a time stamp). `revalidate = 600` kept — it now bounds only lead-story/outlet freshness, well under the 30-min pipeline cadence.

**The masthead copy is one line (`COPY.header.dateline`)** — say the word if you'd prefer different wording.

## Deliberately out of scope
- Real "last updated" from `pipeline_state` belongs **with the feed**, not the marketing masthead — natural follow-up (`getLastRefreshed` already exists); kept out to avoid new moving parts on the homepage.
- No SourceColophon (#112, merged), no compare allowlist, no zero-vector backend.
- The footer `© {new Date().getFullYear()}` is the same pattern but trivial (off only by the ISR window around New Year) — left as-is.

## Validation (local, CI-faithful)
- ✅ `tsc --noEmit` clean
- ✅ `npm test` — 318/318 pass
- ✅ `npm run build` exits 0 against the empty `pgvector` fixture DB — `/` + `/methodology` prerender static, ISR preserved, **and the masthead no longer bakes a stale date into the prerendered HTML** (the whole point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
