### PR TITLE
fix: align frontend compare contract with backend

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -12,11 +12,17 @@ try {
   throw new Error(`Invalid SIFT_API_URL: ${SIFT_API_URL}`);
 }
 const SIFT_API_KEY = process.env.SIFT_API_KEY || "";
-const COMPARE_TIMEOUT_MS = 60_000;
+// The compare workflow runs ~20–30s (up to ~90s on the backend), far past
+// Vercel's ~10s default function timeout — without this the proxy is killed by
+// the platform before a real comparison returns. Raise it to the Hobby max so
+// the proxy can actually wait, and abort the upstream fetch a few seconds under
+// that cap so the client gets a clean 504 instead of a platform timeout.
+export const maxDuration = 60; // seconds — Vercel Hobby maximum
+const COMPARE_TIMEOUT_MS = 55_000; // abort upstream just under maxDuration
 
 const compareSchema = z.object({
   topic: z.string().min(3).max(500),
-  sources: z.array(z.string().max(200)).max(10).optional(),
+  sources: z.array(z.string().max(200)).max(5).optional(),
 });
 
 export async function POST(request: NextRequest) {
@@ -52,7 +58,7 @@ export async function POST(request: NextRequest) {
     const timeout = setTimeout(() => controller.abort(), COMPARE_TIMEOUT_MS);
 
     try {
-      const res = await fetch(`${SIFT_API_URL}/analyze/compare`, {
+      const res = await fetch(`${SIFT_API_URL}/v1/analyze/compare`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/docs/TECHNICAL_SPEC.md
+++ b/docs/TECHNICAL_SPEC.md
@@ -260,7 +260,7 @@ If `matchQuality` is `"weak"` (< 3 results above similarity threshold), the endp
 
 ### POST /api/compare
 
-Proxies to the Python service's `/analyze/compare` endpoint.
+Proxies to the Python service's `/v1/analyze/compare` endpoint. Accepts up to 5 sources (matching the backend).
 
 **Request/Response:** Same as Python service contract above.
 

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -495,7 +495,9 @@ export function useCustomTopics(userId?: string | null) {
 
 // ─── useCompare ─────────────────────────────────────────
 
-const COMPARE_TIMEOUT_MS = 65_000; // Multi-source search can take 20-30s
+// ≥ the /api/compare proxy's maxDuration (60s); the proxy returns a clean 504
+// by ~55s. Compare runs ~20–30s, up to ~55s before the proxy gives up.
+const COMPARE_TIMEOUT_MS = 65_000;
 const COMPARE_SLOW_MS = 8_000;
 
 interface CompareState {


### PR DESCRIPTION
## What
Aligns the frontend compare proxy with sift-api **and** fixes a latent Vercel timeout bug.

Closes #114

## The hidden bug (worth calling out)
`app/api/compare/route.ts` had **no `export const maxDuration`** and `vercel.json` is `{}`, so the proxy ran on Vercel's **default ~10s** function timeout — *below* the **20–30s typical (up to ~90s)** a real comparison takes. The proxy's own `COMPARE_TIMEOUT_MS = 60_000` never mattered; the **platform** killed the function first. So compares longer than ~10s have likely been failing with a platform 504, not the app's clean error. Adding `maxDuration` is the actual fix; the contract alignment rides along.

## Changes (frontend-only)
**`app/api/compare/route.ts`**
- `export const maxDuration = 60` — Vercel Hobby maximum, so the proxy can wait for a real comparison.
- `COMPARE_TIMEOUT_MS` 60s → **55s** — abort the upstream fetch a few seconds under the platform cap, so the client gets a clean `504` instead of a platform timeout.
- `sources` max **10 → 5** (matches backend; the UI already caps at `MAX_SOURCES = 5`).
- Proxy the **preferred `/v1/analyze/compare`** route (was unversioned `/analyze/compare`).

**`lib/hooks.ts`**
- Documented the client `COMPARE_TIMEOUT_MS = 65_000`'s relationship to the proxy (value unchanged — already `≥` the proxy's 60s ceiling). Ordering is now coherent: **client 65 ≥ proxy maxDuration 60 ≥ proxy upstream-abort 55**.

**`docs/TECHNICAL_SPEC.md`**
- `/api/compare` now documented as proxying `/v1/analyze/compare`, max 5 sources.

## Out of scope (flagged, not done)
- **Backend ceiling residual:** sift-api's `COMPARE_TIMEOUT = 90` still exceeds the proxy's 55s reach, so the backend can keep computing ~35s after the proxy abandons it. **Full-chain coherence** (backend ≤ proxy ≤ client) wants the backend lowered to ~50s — a **1-line sift-api follow-up**, out of this frontend PR. Happy to file it.
- Contract test (**sift#116**) left as the planned follow-up — a real route test needs Clerk-auth + CSRF + fetch mocking, not tiny enough to ride along.
- No Refined Compare / Ask Sift / Sentry / cost-ceiling / topic-ownership / zero-vector changes.

## Validation
- ✅ `tsc --noEmit` clean
- ✅ `npm test` — 318/318 pass
- ✅ `npm run build` against the empty pgvector fixture — exits 0 (`/api/compare` is a dynamic route; build unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
