### PR TITLE
docs: decide topic-search AI ownership moves to sift-api

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ When you discover something during a session that's worth tracking, use this to 
 
 Commits do **not** cross repos — a "push the branch" request usually means just this one. Confirm before touching siblings.
 
+**Architecture note (D35):** new AI / search / write work belongs in **sift-api** (it owns the AI + write path). The one current exception — the topic-search AI fallback in `app/api/news/topic/route.ts` — is grandfathered and being migrated to sift-api (Slice 1 = sift-api#79). See [`docs/DECISIONS.md`](./docs/DECISIONS.md) D35.
+
 ## See also
 
 - [`docs/PRD.md`](./docs/PRD.md) — original product vision

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Browser --> Vercel (Next.js) --reads--> Neon Postgres (pgvector)
                 +----- /api/compare ---> Railway
 ```
 
-- **sift** (this repo): Next.js 15 frontend on Vercel — reads from Postgres, serves UI
+- **sift** (this repo): Next.js 15 frontend on Vercel — reads from Postgres, serves UI. *(One grandfathered exception being migrated out: the topic-search AI fallback still runs AI + writes here — see [`docs/DECISIONS.md`](docs/DECISIONS.md) D35.)*
 - **sift-api**: Python FastAPI + LangGraph on Railway — background pipeline + comparison workflow
 - **Database**: Neon Postgres (pgvector) — shared source of truth
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -40,6 +40,7 @@
 | D32 | iOS plan v1 status | Under review — parity-shaped scope, premature canonical API, missing KPIs | $0 | OPEN (May 2026) |
 | D33 | Canonical /v1/* mobile API in sift-api | Deferred — reuse Next.js routes for now, collapse later | $0 | DEFERRED (May 2026) |
 | D34 | github-projects MCP server | Installed via .mcp.json + .claude/settings.json (Projects v2 tools for future sessions) | $0 | SETTLED (May 2026) |
+| D35 | Topic-search AI ownership | Move AI calls + DB writes to `sift-api`, phased; current Next.js route grandfathered | $0 | SETTLED (May 2026) |
 
 **Total estimated monthly cost: ~$30-50/mo**
 
@@ -622,6 +623,28 @@ The next four decisions are added after the v1 production launch. They steer v1.
 **Cost:** $0 — uses GitHub Copilot API quota (free for personal accounts within reasonable limits).
 
 **Naming:** server named `github-projects` (not `github`) to coexist with the existing harness server without name collision.
+
+---
+
+### D35. Topic-search AI ownership — AI + writes move to `sift-api` (phased)
+**Decision (status: SETTLED, May 2026):** Topic-search AI (Claude web-search fallback, Voyage embedding/classification) and the DB writes it performs move into `sift-api`, **phased**. `sift` keeps presentation/SSE streaming and the Postgres *read* (vector search) until the full search API exists. The current `sift/app/api/news/topic/route.ts` is **grandfathered, not the target architecture** — no new AI / search / write work goes in the frontend.
+
+**Why:**
+- The route violates the documented split (D2, D7, D30): the Next.js frontend holds both AI keys (`ANTHROPIC_API_KEY`, `VOYAGE_API_KEY`), calls Claude + Voyage on the request path, and **writes articles to Postgres** (`insertArticle`) — the write path `sift-api` owns.
+- **Android v1 + Ask Sift** (sift-api#63, approved v1.5) ship native; a native client can't run Next.js route handlers, so AI-in-the-frontend forces Android to couple to the web deployment or duplicate the logic. A `sift-api` search API serves web *and* Android.
+- **Cost ceiling** (sift-api#70) instruments one place instead of the backend pipeline plus two frontend AI routes.
+- Moving AI off Vercel shrinks the secret surface and removes the latent Vercel `maxDuration` trap from the AI path.
+
+**Phasing:**
+- **Slice 1 — sift-api#79:** `POST /v1/search/fallback` — Claude fallback + embed/classify + article writes move to `sift-api`; the frontend route relays. Removes `ANTHROPIC_API_KEY` + all DB writes from `sift`. Fixes the `published_date: new Date()` freshness bug as part of the move.
+- **Slice 2 — sift-api#80:** full `POST /v1/search` (query embedding + vector search) when Android / Ask Sift needs a clean API; frontend becomes a thin SSE relay. Removes `VOYAGE_API_KEY` from `sift`. Gated; likely post-Sprint-2.
+- **Not the migration:** the `/api/news/topic` `maxDuration` Vercel-timeout fix (sift#124) is an immediate, independent frontend bug — ship it now.
+
+**Related:** `sift/app/api/topics/generate/route.ts` is a second frontend-AI route (custom-topic generation via Claude) — revisit under this same principle when its slice comes up. `sift-api`'s own README/CLAUDE split wording reconciles when the code moves (Slice 1).
+
+**Reconsider when:** never for "keep AI in the frontend"; the only open variable is the *timing* of Slice 2, gated on native-client work.
+
+**Cost:** $0 to decide. Slices ~1 effort-week each.
 
 ---
 


### PR DESCRIPTION
## What
Records the architectural decision for **sift-api#68** (topic-search AI ownership): **move AI + writes into sift-api, phased** — not merely document the current split.

**Decision/doc-only — no runtime code, no endpoints, no env changes.**

## Why move (not document)
`sift/app/api/news/topic/route.ts` currently runs the Claude web-search fallback, Voyage embed/classify, **and writes articles to Postgres** — inside the Next.js frontend, holding both AI keys. That violates the documented split (sift-api owns AI + writes), and crucially it **blocks Android v1 / Ask Sift** (sift-api#63): a native client can't run Next.js route handlers, so AI-in-the-frontend forces Android to couple to the web app or duplicate the logic. Moving it also lets the cost ceiling (sift-api#70) instrument one place and shrinks the Vercel secret surface.

## Changes (3 docs)
- **`docs/DECISIONS.md`** — new **D35** (summary-table row + ADR entry): the decision, the phasing, and the rationale. Marks the current route **grandfathered, not the target**.
- **`README.md`** — notes the grandfathered topic-search exception to the "reads from Postgres, serves UI" framing.
- **`CLAUDE.md`** — architecture note routing new AI/search/write work to sift-api, so future sessions don't add more AI to the frontend.

## Phased implementation (filed, not started)
- **Slice 1 — sift-api#79:** `/v1/search/fallback` (move Claude fallback + embed/classify + writes; removes `ANTHROPIC_API_KEY` + DB writes from sift; fixes the `published_date: new Date()` freshness bug).
- **Slice 2 — sift-api#80:** full `/v1/search` (query embedding + vector search), gated on Android/Ask Sift; removes `VOYAGE_API_KEY` from sift.
- **Immediate, independent:** **sift#124** — add `maxDuration` to `/api/news/topic` (same Vercel timeout trap as compare).
- **Related:** `app/api/topics/generate/route.ts` is a second frontend-AI route to revisit under the same principle; sift-api's own README/CLAUDE wording reconciles with Slice 1.

## Note
Decides **kristenmartino/sift-api#68** (cross-repo — closing-keyword won't fire, so I'll close it on merge with a pointer to D35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
