### PR TITLE
fix: add maxDuration to topic search route

### DIFF
--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -24,6 +24,13 @@ import type { Article, CategoryId } from "@/lib/types";
 import { rateLimit } from "@/lib/rate-limit";
 import { logUsage } from "@/lib/usage-tracker";
 
+// Temporary safety fix while the topic-search AI fallback still lives in this
+// Next.js route (grandfathered — see docs/DECISIONS.md D35; migrating to
+// sift-api in #79). The Claude web_search fallback runs ~10–15s, well past
+// Vercel's ~10s default function timeout, so without this the route can be
+// platform-killed mid-stream. Hobby max is 60s.
+export const maxDuration = 60; // seconds — Vercel Hobby maximum
+
 const BAD_SUMMARIES = ["unable to provide summary"];
 
 function cleanSummary(raw: string | null): string {


### PR DESCRIPTION
## What
Adds `export const maxDuration = 60` to `/api/news/topic` so the Claude web-search fallback isn't killed by Vercel's default function timeout.

Closes #124

## Why
The topic route had **no `maxDuration`**, so on Vercel it ran on the **~10s default** — but the Claude `web_search` fallback runs **~10–15s**, so slow/fallback topic searches could be platform-killed mid-stream. Same latent trap fixed for `/api/compare` in #122.

This is an **immediate safety fix** for the *current* implementation. The decision to move topic-search AI into sift-api is recorded (**DECISIONS D35** / #125) and sliced (**sift-api#79**); this PR is **not** that migration — it just protects the grandfathered route while the move waits.

## Change (frontend-only, tiny)
- `app/api/news/topic/route.ts`: `export const maxDuration = 60;` (Vercel Hobby max) + a comment tying it to D35 / the Claude fallback. **No behavior change** — search, ranking, fallback logic, DB writes, and SSE event shape untouched.

## Validation
- ✅ `tsc --noEmit` clean
- ✅ `npm test` — 324/324 pass
- ✅ `npm run build` against the pgvector fixture — exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
