### PR TITLE
chore: enable Dependabot for npm + GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds `.github/dependabot.yml` enabling weekly, grouped dependency-update PRs.

## What this does

- **npm** (`/`): updates grouped into `production-dependencies` and `development-dependencies`, each covering `minor` + `patch` update types. `open-pull-requests-limit: 10`.
- **github-actions** (`/`): weekly checks for action version bumps.

Grouping keeps the noise down — related minor/patch bumps land in a single PR per group rather than one PR per package.

Config-only; no application code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)