### PR TITLE
draft: homepage reskin and dark-mode band fix

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Sift — STATUS
 
-**Updated:** 2026-05-20
+**Updated:** 2026-05-31
 **Tier:** v1.5 (civic-literacy pivot + agentic surfaces in Android v1)
 **Velocity:** High (10+ PRs / week)
 
@@ -31,6 +31,7 @@ Web-side in flight alongside the Android build:
 
 ## Recent decisions
 
+- **2026-05-31** — **Homepage (`/`) reskinned to the editorial "news, with footnotes" identity.** Site-wide font swap → Fraunces (display) / Hanken Grotesk (body) / DM Mono. Homepage-scoped recolor (warm-paper light + dark, vermillion accent) scoped under `.sift-landing` so `/news` and other surfaces keep the stone/indigo palette and inherit fonts only. Preserved: live Postgres lead story + data path, the existing dark-mode toggle, and the shared `LandingMasthead` (untouched). Hero chips resolve real AllSides/MBFC via the canonical `getOutletProfilesMap`/`resolveOutletForSourceName` path; omitted when unresolved (never fabricated). The manifesto / CTA / footer accent bands are pinned dark in both themes (they don't invert — fixes a dark-mode CTA-button contrast bug). Open: "How outlets framed it" is static — `TODO(live-compare)`.
 - **2026-05-20** — **Android v1 scope expanded to include Ask Sift + Compare button.** Previously: reader + share extension only. Now: reader + share extension + Ask Sift agentic chat + Compare button (deterministic + Refined). Reasoning: without Ask Sift, native mobile is a polished reader competing with Apple News / Artifact. WITH Ask Sift, it's a civic-literacy agent on the phone. That's the wedge that justifies native. Timeline impact: ~10 weeks → ~12 weeks.
 - **2026-05-20** — **Refined Compare added to v1 scope.** Lens-driven agentic comparison via `lens` parameter on `/api/compare`. Same endpoint as the deterministic compare; backend routes based on lens presence. Plan in `sift-api/docs/REFINED_COMPARE_PLAN.md`.
 - **2026-05-20** — **Mobile is REST-only.** Even the agentic surfaces (Ask Sift, Refined Compare) call REST/SSE — the agent loop runs server-side; MCP is internal plumbing. `sift-mcp` #4 (hosted HTTP/SSE) deferred indefinitely. Rationale in `sift-api/docs/MOBILE_PROTOCOL_DECISION.md`.

--- a/__tests__/SourceColophon.test.tsx
+++ b/__tests__/SourceColophon.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from "@testing-library/react";
 import SourceColophon from "@/components/landing/SourceColophon";
 import { COPY } from "@/lib/copy";
 
+const S = COPY.landingReskin.sources;
+
 describe("SourceColophon", () => {
   it("renders the curated outlet names it is given", () => {
     render(
@@ -16,26 +18,31 @@ describe("SourceColophon", () => {
     expect(screen.getByText("Reuters")).toBeInTheDocument();
     expect(screen.getByText("Politico")).toBeInTheDocument();
     expect(screen.getByText("Wired")).toBeInTheDocument();
-    // Heading + summary always render.
-    expect(screen.getByText(COPY.landing.colophonHeading)).toBeInTheDocument();
-    expect(screen.getByText(COPY.landing.colophonSummary)).toBeInTheDocument();
+    // Section eyebrow + exclusions list always render.
+    expect(screen.getByText(S.eyebrow)).toBeInTheDocument();
+    expect(screen.getByText(S.exclusionsLabel)).toBeInTheDocument();
   });
 
   it("does not bake in a hardcoded source list — only renders provided outlets", () => {
-    render(<SourceColophon outlets={[{ slug: "npr", name: "NPR" }]} />);
+    const { container } = render(
+      <SourceColophon outlets={[{ slug: "npr", name: "NPR" }]} />,
+    );
     expect(screen.getByText("NPR")).toBeInTheDocument();
-    // "The Athletic" was in the old hardcoded array; it must not appear unless
+    // "The Athletic" was in an old hardcoded array; it must not appear unless
     // it is present in the curated data passed in. Guards against list drift.
     expect(screen.queryByText("The Athletic")).not.toBeInTheDocument();
+    // The live outlet list is the only place outlet names are rendered.
+    expect(container.querySelector("ul.sl-outlets")).not.toBeNull();
   });
 
   it("degrades gracefully when no outlets are available (DB miss/empty)", () => {
     const { container } = render(<SourceColophon outlets={[]} />);
-    // Prose still renders so the landing never breaks or shows a stale list...
-    expect(screen.getByText(COPY.landing.colophonHeading)).toBeInTheDocument();
-    expect(screen.getByText(COPY.landing.colophonDescription)).toBeInTheDocument();
-    expect(screen.getByText(COPY.landing.colophonSummary)).toBeInTheDocument();
-    // ...and no outlet grid is rendered.
-    expect(container.querySelector("ul")).toBeNull();
+    // The section still renders (eyebrow, exclusions, methodology link) so the
+    // landing never breaks or shows a stale list...
+    expect(screen.getByText(S.eyebrow)).toBeInTheDocument();
+    expect(screen.getByText(S.exclusionsLabel)).toBeInTheDocument();
+    expect(screen.getByText(S.methodologyCta)).toBeInTheDocument();
+    // ...and the live outlet list is omitted entirely (no stale names).
+    expect(container.querySelector("ul.sl-outlets")).toBeNull();
   });
 });

--- a/app/colophon/page.tsx
+++ b/app/colophon/page.tsx
@@ -17,7 +17,7 @@ const STACK = [
   { name: "Voyage AI", role: "Embeddings for semantic topic search" },
   { name: "Clerk", role: "Auth & user management" },
   { name: "Tailwind CSS", role: "Design system & theming" },
-  { name: "next/font", role: "Self-hosted Playfair Display & Source Sans 3" },
+  { name: "next/font", role: "Self-hosted Fraunces, Hanken Grotesk & DM Mono" },
 ];
 
 const ARCHITECTURE = [
@@ -74,9 +74,11 @@ export default function ColophonPage() {
             Set in
           </p>
           <p className="font-body text-[16px] text-[var(--text-secondary)] leading-[1.7] max-w-[60ch] mb-7">
-            Sift is set in <strong className="text-[var(--text)] font-semibold">Playfair Display</strong>{" "}
-            and <strong className="text-[var(--text)] font-semibold">Source Sans 3</strong>, served from
-            same-origin via <code className="font-body text-[14px]">next/font</code>. The cover star{" "}
+            Sift is set in <strong className="text-[var(--text)] font-semibold">Fraunces</strong>{" "}
+            and <strong className="text-[var(--text)] font-semibold">Hanken Grotesk</strong>, with{" "}
+            <strong className="text-[var(--text)] font-semibold">DM Mono</strong> for labels and
+            captions, served from same-origin via{" "}
+            <code className="font-body text-[14px]">next/font</code>. The cover star{" "}
             <SiftLogo variant="mark" size={16} className="inline-block align-[-3px]" />{" "}
             is a vector diamond, sized to scale across PWA icons, OG cards, and tab favicons.
           </p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -295,3 +295,1060 @@ html[data-theme="light"] .story-highlight {
     scroll-behavior: auto !important;
   }
 }
+
+/* ══════════════════════════════════════════════════════════════════════
+   HOMEPAGE RESKIN — "The news, with footnotes"
+   Warm-paper editorial identity, scoped to the homepage via `.sift-landing`
+   so the rest of the app keeps its Late Edition / Newsprint palette. Both the
+   light and dark token sets are driven by the EXISTING [data-theme] toggle
+   (lib/hooks.ts useTheme → data-theme on <html>). All component classes are
+   `sl-`-prefixed and live inside `.sift-landing`, so none of this leaks into
+   /news, /civic, etc. Ports the component styling from the design reference
+   (sift-landing-page.html); font literals are mapped to the next/font vars
+   (--font-heading=Fraunces, --font-body=Hanken Grotesk, --font-mono=DM Mono).
+   ══════════════════════════════════════════════════════════════════════ */
+
+/* Light tokens (default) */
+.sift-landing {
+  --paper: #fbf8f1;
+  --paper-2: #f3ecdd;
+  --paper-3: #ece3d0;
+  --surface: #fffdf8;
+  --surface-2: #f7f1e5;
+  --ink: #17130e;
+  --ink-soft: #4c4438;
+  --ink-faint: #8a8071;
+  --accent: #e0492a;
+  --accent-deep: #ae3417;
+  --line: rgba(23, 19, 14, 0.14);
+  --line-soft: rgba(23, 19, 14, 0.08);
+  --grain-op: 0.4;
+  --grain-blend: multiply;
+  --shadow: rgba(23, 19, 14, 0.9);
+}
+
+/* Dark tokens — same toggle, flipped palette */
+html[data-theme="dark"] .sift-landing {
+  --paper: #15120c;
+  --paper-2: #1c1813;
+  --paper-3: #241f18;
+  --surface: #1f1a12;
+  --surface-2: #262017;
+  --ink: #f2ecde;
+  --ink-soft: #b9b1a0;
+  --ink-faint: #867d6c;
+  --accent: #ec5b39;
+  --accent-deep: #f0805e;
+  --line: rgba(242, 236, 222, 0.15);
+  --line-soft: rgba(242, 236, 222, 0.07);
+  --grain-op: 0.06;
+  --grain-blend: normal;
+  --shadow: rgba(0, 0, 0, 0.6);
+}
+
+/* Smooth-scroll the anchor nav, but only on the homepage (scoped via :has so
+   /news etc. are unaffected). Reduced-motion override above resets this. */
+html:has(.sift-landing) {
+  scroll-behavior: smooth;
+}
+
+.sift-landing {
+  min-height: 100vh;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-body), system-ui, sans-serif;
+  font-size: 17px;
+  line-height: 1.6;
+  letter-spacing: -0.01em;
+  position: relative;
+  overflow-x: hidden;
+  transition: background 0.4s ease, color 0.2s ease;
+}
+.sift-landing a {
+  color: inherit;
+  text-decoration: none;
+}
+.sift-landing ::selection {
+  background: var(--accent);
+  color: var(--paper);
+}
+.sift-landing h1,
+.sift-landing h2,
+.sift-landing h3 {
+  font-family: var(--font-heading), Georgia, serif;
+  font-weight: 600;
+  line-height: 1.04;
+  letter-spacing: -0.02em;
+}
+
+/* Film-grain overlay — dials down in dark via --grain-op */
+.sift-landing::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none;
+  opacity: var(--grain-op);
+  mix-blend-mode: var(--grain-blend);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+}
+
+.sift-landing .sl-wrap {
+  max-width: 1180px;
+  margin-inline: auto;
+  padding-inline: 28px;
+}
+
+/* eyebrows */
+.sift-landing .sl-eyebrow {
+  font-family: var(--font-mono), monospace;
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent-deep);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.sift-landing .sl-eyebrow::before {
+  content: "";
+  width: 26px;
+  height: 1px;
+  background: var(--accent);
+  display: inline-block;
+}
+.sift-landing sup.sl-fn {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.56em;
+  color: var(--accent-deep);
+  font-weight: 500;
+  vertical-align: super;
+  padding-left: 1px;
+}
+
+/* buttons — offset hard-shadow on hover */
+.sift-landing .sl-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-body), sans-serif;
+  font-weight: 600;
+  font-size: 15px;
+  padding: 14px 24px;
+  border-radius: 2px;
+  cursor: pointer;
+  border: 1px solid var(--ink);
+  transition: transform 0.25s cubic-bezier(0.2, 0.8, 0.2, 1), background 0.25s,
+    color 0.25s, box-shadow 0.25s, border-color 0.25s;
+}
+.sift-landing .sl-btn .sl-arrow {
+  transition: transform 0.25s ease;
+}
+.sift-landing .sl-btn:hover .sl-arrow {
+  transform: translateX(4px);
+}
+.sift-landing .sl-btn-solid {
+  background: var(--ink);
+  color: var(--paper);
+}
+.sift-landing .sl-btn-solid:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--paper);
+  transform: translateY(-2px);
+  box-shadow: 6px 8px 0 var(--shadow);
+}
+.sift-landing .sl-btn-ghost {
+  background: transparent;
+  color: var(--ink);
+}
+.sift-landing .sl-btn-ghost:hover {
+  background: var(--ink);
+  color: var(--paper);
+  transform: translateY(-2px);
+}
+
+/* header / nav */
+.sift-landing .sl-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: color-mix(in srgb, var(--paper) 86%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--line);
+  transition: background 0.4s;
+}
+.sift-landing .sl-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 72px;
+}
+.sift-landing .sl-brand {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  font-family: var(--font-heading), serif;
+  font-weight: 700;
+  font-size: 25px;
+  letter-spacing: -0.03em;
+  color: var(--ink);
+}
+.sift-landing .sl-diamond {
+  width: 22px;
+  height: 22px;
+  flex: none;
+}
+.sift-landing .sl-nav-links {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+}
+.sift-landing .sl-nav-links a {
+  font-size: 14.5px;
+  font-weight: 500;
+  color: var(--ink-soft);
+  position: relative;
+  padding: 4px 0;
+  transition: color 0.2s;
+}
+.sift-landing .sl-nav-links a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 1.5px;
+  background: var(--accent);
+  transition: width 0.28s ease;
+}
+.sift-landing .sl-nav-links a:hover {
+  color: var(--ink);
+}
+.sift-landing .sl-nav-links a:hover::after {
+  width: 100%;
+}
+.sift-landing .sl-nav-cta {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.sift-landing .sl-toggle {
+  width: 38px;
+  height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  background: transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-soft);
+  transition: border-color 0.2s, color 0.2s, transform 0.3s;
+}
+.sift-landing .sl-toggle:hover {
+  border-color: var(--ink-soft);
+  color: var(--ink);
+  transform: rotate(18deg);
+}
+.sift-landing .sl-toggle svg {
+  width: 17px;
+  height: 17px;
+}
+.sift-landing .sl-menu-btn {
+  display: none;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: var(--font-mono), monospace;
+  font-size: 13px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+
+/* hero */
+.sift-landing .sl-hero {
+  position: relative;
+  padding: 80px 0 84px;
+}
+.sift-landing .sl-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.55;
+  background-image: repeating-linear-gradient(
+    90deg,
+    transparent,
+    transparent calc(8.333% - 1px),
+    var(--line-soft) calc(8.333% - 1px),
+    var(--line-soft) 8.333%
+  );
+  -webkit-mask-image: linear-gradient(180deg, transparent, #000 18%, #000 82%, transparent);
+  mask-image: linear-gradient(180deg, transparent, #000 18%, #000 82%, transparent);
+}
+.sift-landing .sl-hero-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1.04fr 0.96fr;
+  gap: 56px;
+  align-items: center;
+}
+.sift-landing .sl-hero-copy > * {
+  display: block;
+}
+.sift-landing .sl-hero .sl-eyebrow {
+  margin-bottom: 24px;
+}
+.sift-landing .sl-hero h1 {
+  font-size: clamp(3rem, 6.2vw, 5.4rem);
+  margin-bottom: 22px;
+  color: var(--ink);
+}
+.sift-landing .sl-hero h1 .sl-ul {
+  position: relative;
+  white-space: nowrap;
+  color: var(--accent);
+}
+.sift-landing .sl-hero h1 .sl-ul svg {
+  position: absolute;
+  left: 0;
+  bottom: -0.14em;
+  width: 100%;
+  height: 0.3em;
+  color: var(--accent);
+  overflow: visible;
+}
+.sift-landing .sl-lede {
+  font-size: clamp(1.05rem, 1.45vw, 1.24rem);
+  color: var(--ink-soft);
+  max-width: 34ch;
+  margin-bottom: 32px;
+  line-height: 1.55;
+}
+.sift-landing .sl-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 13px;
+  align-items: center;
+}
+.sift-landing .sl-hero-foot {
+  margin-top: 28px;
+  font-family: var(--font-mono), monospace;
+  font-size: 11.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.sift-landing .sl-hero-foot .sl-pip {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+/* footnoted story card (the live lead story) */
+.sift-landing .sl-card {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--ink);
+  border-radius: 6px;
+  box-shadow: 14px 18px 0 var(--shadow);
+  overflow: hidden;
+}
+.sift-landing .sl-card-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface-2);
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--ink-faint);
+}
+.sift-landing .sl-card-bar .sl-diamond {
+  width: 13px;
+  height: 13px;
+}
+.sift-landing .sl-card-bar .sl-badge {
+  margin-left: auto;
+  color: var(--accent-deep);
+}
+.sift-landing .sl-card-body {
+  padding: 22px;
+}
+.sift-landing .sl-chip-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+.sift-landing .sl-chip {
+  font-family: var(--font-mono), monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.05em;
+  padding: 4px 9px;
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  color: var(--ink-soft);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.sift-landing .sl-chip .sl-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ink-faint);
+}
+.sift-landing .sl-chip.sl-src {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+.sift-landing .sl-card h3.sl-lead {
+  font-size: 1.55rem;
+  line-height: 1.16;
+  margin-bottom: 14px;
+  color: var(--ink);
+  transition: color 0.2s;
+}
+.sift-landing a.sl-lead-link {
+  display: block;
+}
+.sift-landing a.sl-lead-link:hover h3.sl-lead {
+  color: var(--accent);
+}
+.sift-landing .sl-primer {
+  border-left: 2px solid var(--accent);
+  background: var(--surface-2);
+  padding: 13px 15px;
+  border-radius: 0 4px 4px 0;
+  margin-bottom: 16px;
+}
+.sift-landing .sl-primer .sl-label {
+  font-family: var(--font-mono), monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent-deep);
+  margin-bottom: 6px;
+}
+.sift-landing .sl-primer p {
+  font-size: 13px;
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+.sift-landing .sl-notes {
+  border-top: 1px dashed var(--line);
+  padding-top: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+.sift-landing .sl-note {
+  display: flex;
+  gap: 9px;
+  font-size: 12px;
+  color: var(--ink-soft);
+  line-height: 1.45;
+}
+.sift-landing .sl-note .sl-m {
+  font-family: var(--font-mono), monospace;
+  font-size: 10px;
+  color: var(--accent-deep);
+  flex: none;
+  padding-top: 1px;
+}
+.sift-landing .sl-note b {
+  color: var(--ink);
+  font-weight: 600;
+  font-family: var(--font-body), sans-serif;
+}
+.sift-landing .sl-card-summary {
+  font-size: 13.5px;
+  color: var(--ink-soft);
+  line-height: 1.55;
+}
+.sift-landing .sl-float-note {
+  position: absolute;
+  font-family: var(--font-mono), monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink);
+  background: var(--accent);
+  padding: 6px 11px;
+  border: 1px solid var(--ink);
+  border-radius: 2px;
+  box-shadow: 3px 4px 0 var(--shadow);
+  transform: rotate(3deg);
+  z-index: 3;
+  right: -6px;
+  top: -14px;
+}
+
+/* principle strip */
+.sift-landing .sl-strip {
+  border-top: 1px solid var(--line-soft);
+  border-bottom: 1px solid var(--line-soft);
+  background: var(--paper-2);
+}
+.sift-landing .sl-strip .sl-strip-inner {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding-block: 18px;
+  flex-wrap: wrap;
+  font-family: var(--font-mono), monospace;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: var(--ink-soft);
+}
+.sift-landing .sl-strip .sl-sep {
+  color: var(--ink-faint);
+}
+.sift-landing .sl-strip b {
+  color: var(--accent-deep);
+  font-weight: 500;
+}
+
+/* section scaffolding */
+.sift-landing .sl-band {
+  padding: 90px 0;
+}
+.sift-landing .sl-sec-head {
+  max-width: 680px;
+  margin-bottom: 50px;
+}
+.sift-landing .sl-sec-head h2 {
+  font-size: clamp(2.1rem, 4vw, 3.1rem);
+  margin-top: 18px;
+  color: var(--ink);
+}
+.sift-landing .sl-sec-head h2 .sl-it {
+  font-style: italic;
+  font-weight: 500;
+  color: var(--accent);
+}
+.sift-landing .sl-sec-head p {
+  color: var(--ink-soft);
+  margin-top: 16px;
+  font-size: 1.06rem;
+  max-width: 56ch;
+}
+
+/* manifesto — pinned dark in BOTH themes (does NOT invert). Background + neutral
+   text use constant dark-palette values so light/dark render identically; only
+   the accent (--accent/--accent-deep) stays theme-driven — both vermillion
+   shades read fine on the dark band. */
+.sift-landing .sl-manifesto {
+  background: #15120c;
+  color: #f2ecde;
+  padding: 88px 0;
+}
+.sift-landing .sl-manifesto .sl-eyebrow {
+  color: var(--accent);
+}
+.sift-landing .sl-manifesto .sl-eyebrow::before {
+  background: var(--accent);
+}
+.sift-landing .sl-manifesto-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 56px;
+  align-items: center;
+}
+.sift-landing .sl-manifesto h2 {
+  font-size: clamp(2rem, 3.6vw, 3rem);
+  color: #f2ecde;
+  margin-top: 18px;
+}
+.sift-landing .sl-manifesto h2 em {
+  font-style: italic;
+  color: var(--accent);
+}
+.sift-landing .sl-manifesto p {
+  color: color-mix(in srgb, #f2ecde 78%, transparent);
+  font-size: 1.08rem;
+  margin-top: 18px;
+  max-width: 46ch;
+}
+
+/* spectrum bar */
+.sift-landing .sl-spectrum {
+  margin-top: 4px;
+}
+.sift-landing .sl-spectrum .sl-bar {
+  display: flex;
+  height: 46px;
+  border-radius: 4px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+.sift-landing .sl-spectrum .sl-seg {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  color: #f2ecde;
+  border-right: 1px solid rgba(0, 0, 0, 0.25);
+}
+.sift-landing .sl-spectrum .sl-seg:last-child {
+  border-right: 0;
+}
+.sift-landing .sl-spectrum .sl-leg {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 12px;
+  font-family: var(--font-mono), monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #867d6c;
+}
+.sift-landing .sl-spectrum .sl-cap {
+  margin-top: 14px;
+  font-size: 13px;
+  color: color-mix(in srgb, #f2ecde 64%, transparent);
+  line-height: 1.5;
+}
+
+/* what sift adds */
+.sift-landing .sl-adds {
+  background: var(--paper-2);
+}
+.sift-landing .sl-add-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  border: 1px solid var(--ink);
+}
+.sift-landing .sl-add {
+  padding: 32px 30px;
+  border-right: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  background: var(--paper);
+  transition: background 0.3s, color 0.3s;
+}
+.sift-landing .sl-add:nth-child(2n) {
+  border-right: 0;
+}
+/* 2×2 grid: clear the bottom border from the bottom row (cards 3 & 4) so only
+   the container's outer border shows. (Reference used n+4, which left a stray
+   rule under card 3; n+3 is the intended clean grid.) */
+.sift-landing .sl-add:nth-child(n + 3) {
+  border-bottom: 0;
+}
+.sift-landing .sl-add:hover {
+  background: var(--ink);
+  color: var(--paper);
+}
+.sift-landing .sl-add:hover p {
+  color: color-mix(in srgb, var(--paper) 78%, transparent);
+}
+.sift-landing .sl-add:hover .sl-ai {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--paper);
+}
+.sift-landing .sl-add .sl-ai {
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--ink);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 18px;
+  font-family: var(--font-mono), monospace;
+  font-size: 13px;
+  transition: all 0.3s;
+}
+.sift-landing .sl-add h3 {
+  font-size: 1.34rem;
+  margin-bottom: 9px;
+}
+.sift-landing .sl-add p {
+  color: var(--ink-soft);
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+/* compare frames */
+.sift-landing .sl-compare .sl-frames {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--surface);
+}
+.sift-landing .sl-topic {
+  padding: 16px 22px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface-2);
+  font-family: var(--font-mono), monospace;
+  font-size: 11.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.sift-landing .sl-topic b {
+  color: var(--accent-deep);
+  font-weight: 500;
+}
+.sift-landing .sl-frame {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 20px;
+  padding: 20px 22px;
+  border-bottom: 1px solid var(--line-soft);
+  align-items: start;
+}
+.sift-landing .sl-frame:last-child {
+  border-bottom: 0;
+}
+.sift-landing .sl-frame .sl-out {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.sift-landing .sl-frame .sl-out .sl-nm {
+  font-family: var(--font-heading), serif;
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: var(--ink);
+}
+.sift-landing .sl-frame .sl-out .sl-ln {
+  font-family: var(--font-mono), monospace;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  color: var(--ink-faint);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.sift-landing .sl-frame .sl-out .sl-ln .sl-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ink-faint);
+}
+.sift-landing .sl-frame q {
+  font-family: var(--font-heading), serif;
+  font-style: italic;
+  font-size: 1.12rem;
+  line-height: 1.4;
+  color: var(--ink);
+  quotes: none;
+}
+.sift-landing .sl-compare .sl-note-line {
+  margin-top: 18px;
+  font-size: 14px;
+  color: var(--ink-soft);
+  font-style: italic;
+}
+
+/* sources */
+.sift-landing .sl-sources {
+  background: var(--paper-2);
+}
+.sift-landing .sl-src-grid {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 54px;
+  align-items: center;
+}
+.sift-landing .sl-src-label {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 16px;
+}
+.sift-landing .sl-excl {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.sift-landing .sl-excl li {
+  display: flex;
+  gap: 12px;
+  font-size: 15px;
+  color: var(--ink-soft);
+  line-height: 1.45;
+}
+.sift-landing .sl-excl li::before {
+  content: "\25C6";
+  color: var(--accent);
+  font-size: 11px;
+  padding-top: 5px;
+}
+.sift-landing .sl-excl li b {
+  color: var(--ink);
+  font-weight: 600;
+}
+.sift-landing .sl-outlets {
+  margin-top: 22px;
+  columns: 2;
+  column-gap: 28px;
+  list-style: none;
+}
+.sift-landing .sl-outlets li {
+  break-inside: avoid;
+  padding: 2px 0;
+  font-family: var(--font-mono), monospace;
+  font-size: 12px;
+  color: var(--ink-soft);
+}
+
+/* cta band — pinned constant vermillion + light text in BOTH themes (does NOT
+   invert). The primary button is a constant dark chip with white text in both
+   themes (previously var(--ink), which flipped to near-white in dark mode and
+   hid the white label). */
+.sift-landing .sl-cta {
+  background: #e0492a;
+  color: #fbf8f1;
+  padding: 88px 0;
+  position: relative;
+  overflow: hidden;
+}
+.sift-landing .sl-cta::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0.5;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n2'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n2)' opacity='0.45'/%3E%3C/svg%3E");
+}
+.sift-landing .sl-cta-inner {
+  position: relative;
+  z-index: 1;
+  max-width: 740px;
+}
+.sift-landing .sl-cta h2 {
+  color: #fbf8f1;
+  font-size: clamp(2.2rem, 4.6vw, 3.6rem);
+  line-height: 1.02;
+}
+.sift-landing .sl-cta h2 em {
+  font-style: italic;
+}
+.sift-landing .sl-cta p {
+  margin: 18px 0 30px;
+  font-size: 1.12rem;
+  color: color-mix(in srgb, #fff 92%, #e0492a);
+  max-width: 50ch;
+}
+.sift-landing .sl-cta .sl-btn-solid {
+  border-color: #17130e;
+  background: #17130e;
+  color: #fff;
+}
+.sift-landing .sl-cta .sl-btn-solid:hover {
+  background: #fff;
+  color: #e0492a;
+  box-shadow: 6px 8px 0 rgba(0, 0, 0, 0.3);
+}
+.sift-landing .sl-cta .sl-btn-ghost {
+  border-color: rgba(255, 255, 255, 0.5);
+  color: #fff;
+}
+.sift-landing .sl-cta .sl-btn-ghost:hover {
+  background: #fff;
+  color: #e0492a;
+}
+
+/* footer — pinned dark in BOTH themes (does NOT invert). Background + neutral
+   text use constant dark-palette values; the accent headings stay theme-driven.
+   (Pinning also fixes the near-invisible footer divider in dark mode.) */
+.sift-landing .sl-foot {
+  background: #15120c;
+  color: #f2ecde;
+  padding: 62px 0 30px;
+}
+.sift-landing .sl-foot-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 40px;
+  flex-wrap: wrap;
+  padding-bottom: 38px;
+  border-bottom: 1px solid color-mix(in srgb, #f2ecde 16%, transparent);
+}
+.sift-landing .sl-foot-brand {
+  max-width: 340px;
+}
+.sift-landing .sl-foot-brand .sl-brand {
+  color: #f2ecde;
+  margin-bottom: 14px;
+}
+.sift-landing .sl-foot-brand p {
+  color: color-mix(in srgb, #f2ecde 60%, transparent);
+  font-size: 14px;
+  line-height: 1.55;
+}
+.sift-landing .sl-foot-cols {
+  display: flex;
+  gap: 56px;
+  flex-wrap: wrap;
+}
+.sift-landing .sl-foot-col h5 {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 15px;
+  font-weight: 500;
+}
+.sift-landing .sl-foot-col a {
+  display: block;
+  color: color-mix(in srgb, #f2ecde 80%, transparent);
+  font-size: 14.5px;
+  margin-bottom: 11px;
+  transition: color 0.2s;
+}
+.sift-landing .sl-foot-col a:hover {
+  color: #f2ecde;
+}
+.sift-landing .sl-foot-bottom {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+  padding-top: 26px;
+  font-family: var(--font-mono), monospace;
+  font-size: 11.5px;
+  color: #867d6c;
+}
+.sift-landing .sl-foot-bottom a {
+  color: color-mix(in srgb, #f2ecde 70%, transparent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.sift-landing .sl-foot-bottom a:hover {
+  color: var(--accent);
+}
+
+/* reveal + hero-stagger animations — gated behind motion preference AND the
+   `sl-anim` class (added by JS after mount), so no-JS and reduced-motion both
+   render everything visible immediately. */
+@media (prefers-reduced-motion: no-preference) {
+  .sift-landing.sl-anim [data-reveal] {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.7s cubic-bezier(0.2, 0.7, 0.2, 1),
+      transform 0.7s cubic-bezier(0.2, 0.7, 0.2, 1);
+  }
+  .sift-landing.sl-anim [data-reveal].in {
+    opacity: 1;
+    transform: none;
+  }
+  .sift-landing.sl-anim .sl-hero-copy > * {
+    opacity: 0;
+    animation: sl-rise 0.8s cubic-bezier(0.2, 0.7, 0.2, 1) forwards;
+  }
+  .sift-landing.sl-anim .sl-hero-copy > *:nth-child(1) {
+    animation-delay: 0.05s;
+  }
+  .sift-landing.sl-anim .sl-hero-copy > *:nth-child(2) {
+    animation-delay: 0.16s;
+  }
+  .sift-landing.sl-anim .sl-hero-copy > *:nth-child(3) {
+    animation-delay: 0.27s;
+  }
+  .sift-landing.sl-anim .sl-hero-copy > *:nth-child(4) {
+    animation-delay: 0.38s;
+  }
+  .sift-landing.sl-anim .sl-hero-copy > *:nth-child(5) {
+    animation-delay: 0.49s;
+  }
+  .sift-landing.sl-anim .sl-card {
+    opacity: 0;
+    animation: sl-rise 0.9s cubic-bezier(0.2, 0.7, 0.2, 1) 0.42s forwards;
+  }
+  @keyframes sl-rise {
+    from {
+      opacity: 0;
+      transform: translateY(26px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+}
+
+/* responsive */
+@media (max-width: 920px) {
+  .sift-landing .sl-hero-grid,
+  .sift-landing .sl-manifesto-grid,
+  .sift-landing .sl-src-grid {
+    grid-template-columns: 1fr;
+    gap: 40px;
+  }
+  .sift-landing .sl-float-note {
+    display: none;
+  }
+}
+@media (max-width: 720px) {
+  .sift-landing .sl-nav-links {
+    display: none;
+  }
+  .sift-landing .sl-nav-cta .sl-btn {
+    display: none;
+  }
+  .sift-landing .sl-menu-btn {
+    display: block;
+  }
+  .sift-landing .sl-nav-links.sl-open {
+    display: flex;
+    position: absolute;
+    top: 72px;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    gap: 0;
+    background: var(--paper);
+    border-bottom: 1px solid var(--ink);
+    padding: 8px 28px 18px;
+  }
+  .sift-landing .sl-nav-links.sl-open a {
+    padding: 14px 0;
+    border-bottom: 1px solid var(--line);
+    width: 100%;
+  }
+  .sift-landing .sl-add-grid {
+    grid-template-columns: 1fr;
+  }
+  .sift-landing .sl-add {
+    border-right: 0 !important;
+  }
+  .sift-landing .sl-add:nth-child(3) {
+    border-bottom: 1px solid var(--ink);
+  }
+  .sift-landing .sl-frame {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+  .sift-landing .sl-outlets {
+    columns: 1;
+  }
+  .sift-landing {
+    font-size: 16px;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,25 +1,40 @@
 import type { Metadata, Viewport } from "next";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import { Playfair_Display, Source_Sans_3 } from "next/font/google";
+import { Fraunces, Hanken_Grotesk, DM_Mono } from "next/font/google";
 import "./globals.css";
 
 // Self-hosted via next/font: Next downloads the woff2s at build time, serves
 // them from /_next/static/media (same-origin, cacheable, no CSP changes), and
 // auto-injects <link rel="preload"> for the primary weights. CSS variables
-// are wired into Tailwind (font-heading, font-body) and globals.css.
-const fontHeading = Playfair_Display({
+// are wired into Tailwind (font-heading, font-body, font-mono) and globals.css.
+//
+// Fraunces is a variable font — we omit `weight` to keep the full wght range
+// and opt into the optical-size axis so large display headings get the high-
+// contrast cut while body-sized headings stay readable. Italics are pulled in
+// for the editorial accent spans (e.g. the vermillion emphasis in headings).
+const fontHeading = Fraunces({
   subsets: ["latin"],
-  weight: ["400", "600", "700", "800", "900"],
+  axes: ["opsz"],
+  style: ["normal", "italic"],
   display: "swap",
   variable: "--font-heading",
 });
 
-const fontBody = Source_Sans_3({
+const fontBody = Hanken_Grotesk({
   subsets: ["latin"],
-  weight: ["300", "400", "500", "600", "700"],
+  weight: ["400", "500", "600", "700"],
   display: "swap",
   variable: "--font-body",
+});
+
+// DM Mono is not variable — request the two cuts we use for eyebrows, labels,
+// captions, and footnote markers.
+const fontMono = DM_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  display: "swap",
+  variable: "--font-mono",
 });
 
 export const metadata: Metadata = {
@@ -47,13 +62,12 @@ export const metadata: Metadata = {
 };
 
 // Browser chrome (iOS Safari address bar, Android task switcher) follows the OS
-// color-scheme preference, not the user's in-app theme toggle. Late Edition
-// background for dark; Newsprint background for light. Matches the CSS
-// variables in app/globals.css.
+// color-scheme preference, not the user's in-app theme toggle. Warm paper for
+// light; deep ink for dark. Matches the --paper token in app/globals.css.
 export const viewport: Viewport = {
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#f5f2ed" },
-    { media: "(prefers-color-scheme: dark)", color: "#0c0a09" },
+    { media: "(prefers-color-scheme: light)", color: "#FBF8F1" },
+    { media: "(prefers-color-scheme: dark)", color: "#15120C" },
   ],
   colorScheme: "dark light",
 };
@@ -71,7 +85,7 @@ export default function RootLayout({
     <html
       lang="en"
       data-theme="dark"
-      className={`${fontHeading.variable} ${fontBody.variable}`}
+      className={`${fontHeading.variable} ${fontBody.variable} ${fontMono.variable}`}
       suppressHydrationWarning
     >
       <head>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,13 @@
 import type { Metadata } from "next";
 import LandingPage from "@/components/LandingPage";
-import { getAllOutletProfiles, getTopStoryForLanding } from "@/lib/db";
+import {
+  getAllOutletProfiles,
+  getOutletProfilesMap,
+  getTopStoryForLanding,
+  resolveOutletForSourceName,
+} from "@/lib/db";
 import { parseContextPrimer } from "@/lib/primer";
-import type { Article, CategoryId } from "@/lib/types";
+import type { Article, CategoryId, OutletProfile } from "@/lib/types";
 
 export const metadata: Metadata = {
   title: {
@@ -19,18 +24,31 @@ export const metadata: Metadata = {
 export const revalidate = 600;
 
 export default async function Home() {
-  const [lead, outletProfiles] = await Promise.all([
+  const [lead, outletProfiles, outletMap] = await Promise.all([
     getTopStoryForLanding(),
     // Curated outlet list for the source colophon. Guarded so an outlet-data
     // miss degrades to an empty list rather than breaking the landing (same
     // posture as getTopStoryForLanding returning null).
     getAllOutletProfiles().catch(() => []),
+    // source_name → OutletProfile map (module-cached, 1h TTL — shared with
+    // /api/news). Lets the hero card resolve the lead source's AllSides + MBFC
+    // ratings the same way the feed does, with no extra round-trip on a warm
+    // cache. Guarded to an empty map so a miss degrades to a card without
+    // rating chips, never a broken page.
+    getOutletProfilesMap().catch((): Map<string, OutletProfile> => new Map()),
   ]);
   const outlets = outletProfiles.map((o) => ({
     slug: o.slug,
     name: o.name,
     allSidesRating: o.allSidesRating,
   }));
+  // Resolve the lead story's source to its curated outlet (AllSides lean + MBFC
+  // tier) via the same alias path the feed uses. Null when the source isn't a
+  // curated outlet — the hero card omits the rating chips rather than inventing
+  // them (never fabricate ratings on the homepage).
+  const leadOutlet = lead
+    ? resolveOutletForSourceName(outletMap, lead.source_name)
+    : null;
   const primer = lead ? parseContextPrimer(lead.context_primer) : null;
   const leadStory: Article | null = lead
     ? {
@@ -46,6 +64,7 @@ export default async function Home() {
         whyItMatters: lead.why_it_matters ?? undefined,
         importanceScore: lead.importance_score ?? undefined,
         ...(primer ? { contextPrimer: primer } : {}),
+        ...(leadOutlet ? { outlet: leadOutlet } : {}),
       }
     : null;
 

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,12 +1,19 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { COPY } from "@/lib/copy";
-import SiftLogo from "./SiftLogo";
-import LandingMasthead from "./landing/LandingMasthead";
+import LandingHeader from "./landing/LandingHeader";
 import LeadStory from "./landing/LeadStory";
+import PrincipleStrip from "./landing/PrincipleStrip";
+import Manifesto from "./landing/Manifesto";
+import WhatSiftAdds from "./landing/WhatSiftAdds";
 import ComparisonDemo from "./landing/ComparisonDemo";
-import SourceColophon, { type SourceColophonOutlet } from "./landing/SourceColophon";
+import SourceColophon, {
+  type SourceColophonOutlet,
+} from "./landing/SourceColophon";
+import CtaBand from "./landing/CtaBand";
+import LandingFooter from "./landing/LandingFooter";
 import type { Article } from "@/lib/types";
 
 interface LandingPageProps {
@@ -16,83 +23,105 @@ interface LandingPageProps {
   outlets: SourceColophonOutlet[];
 }
 
+const HERO = COPY.landingReskin.hero;
+
 export default function LandingPage({ leadStory, outlets }: LandingPageProps) {
-  return (
-    <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
-      {/* Drop-cap rule, scoped to landing only — Sift's globals.css doesn't
-          have an equivalent yet, so we inline it here rather than touching
-          the system-wide stylesheet during a Phase A pass. */}
-      <style jsx global>{`
-        @media (min-width: 768px) {
-          [data-dropcap]::first-letter {
-            font-family: var(--font-heading), Georgia, serif;
-            font-weight: 800;
-            font-size: 4em;
-            line-height: 0.85;
-            float: left;
-            padding: 0.08em 0.12em 0 0;
-            margin-top: 0.05em;
-            color: var(--text);
+  const rootRef = useRef<HTMLDivElement>(null);
+  // `sl-anim` gates the reveal/stagger starting states. It's added only after
+  // mount, and only when motion is allowed — so SSR / no-JS / reduced-motion
+  // all render every section fully visible from first paint.
+  const [animate, setAnimate] = useState(false);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const reduceMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    const reveals = root.querySelectorAll<HTMLElement>("[data-reveal]");
+
+    if (reduceMotion || !("IntersectionObserver" in window)) {
+      reveals.forEach((el) => el.classList.add("in"));
+      return;
+    }
+
+    setAnimate(true);
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("in");
+            io.unobserve(entry.target);
           }
-        }
-      `}</style>
+        });
+      },
+      { threshold: 0.15 },
+    );
+    reveals.forEach((el) => io.observe(el));
+    return () => io.disconnect();
+  }, []);
 
-      <LandingMasthead />
+  return (
+    <div ref={rootRef} className={`sift-landing${animate ? " sl-anim" : ""}`}>
+      <LandingHeader />
 
-      <main id="main-content">
-        <LeadStory article={leadStory} />
+      <main id="top">
+        <section className="sl-hero">
+          <div className="sl-wrap sl-hero-grid">
+            <div className="sl-hero-copy">
+              <span className="sl-eyebrow">{HERO.eyebrow}</span>
+              <h1>
+                {HERO.headingLead}
+                <span className="sl-ul">
+                  {HERO.headingAccent}
+                  <svg
+                    viewBox="0 0 200 14"
+                    preserveAspectRatio="none"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M2 9 C 50 2, 150 2, 198 8"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                      fill="none"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                </span>
+                .
+              </h1>
+              <p className="sl-lede">{HERO.lede}</p>
+              <div className="sl-hero-actions">
+                <Link href="/news" className="sl-btn sl-btn-solid">
+                  {HERO.ctaPrimary}{" "}
+                  <span className="sl-arrow" aria-hidden>
+                    →
+                  </span>
+                </Link>
+                <a href="#adds" className="sl-btn sl-btn-ghost">
+                  {HERO.ctaSecondary}
+                </a>
+              </div>
+              <div className="sl-hero-foot">
+                <span className="sl-pip" aria-hidden />
+                {HERO.foot}
+              </div>
+            </div>
+
+            <LeadStory article={leadStory} />
+          </div>
+        </section>
+
+        <PrincipleStrip />
+        <Manifesto />
+        <WhatSiftAdds />
         <ComparisonDemo />
         <SourceColophon outlets={outlets} />
+        <CtaBand />
       </main>
 
-      {/* ── Colophon Footer ──────────────────────────── */}
-      <footer className="border-t border-[var(--border)] mt-8">
-        <div className="max-w-[1200px] mx-auto px-6 py-9 grid grid-cols-1 md:grid-cols-3 gap-y-6 md:gap-y-3">
-          <div className="md:order-1 flex flex-col gap-3 md:items-start items-center text-center md:text-left">
-            <SiftLogo variant="full" size={20} />
-            <p className="font-body text-[13px] text-[var(--text-muted)] max-w-[320px] leading-relaxed">
-              {COPY.footer.main}
-            </p>
-          </div>
-
-          <div className="md:order-2 flex flex-col gap-2 md:items-center items-center text-center font-body text-outlet uppercase tracking-wider">
-            <Link
-              href="/news"
-              className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline"
-            >
-              News
-            </Link>
-            <Link
-              href="/colophon"
-              className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline"
-            >
-              {COPY.landing.colophonLink}
-            </Link>
-            <Link
-              href="/methodology"
-              className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline"
-            >
-              Methodology
-            </Link>
-            <Link
-              href="/privacy"
-              className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline"
-            >
-              Privacy
-            </Link>
-            <Link
-              href="/terms"
-              className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline"
-            >
-              Terms
-            </Link>
-          </div>
-
-          <p className="md:order-3 md:text-right text-center font-body text-outlet uppercase tracking-wider text-[var(--text-muted)]">
-            © {new Date().getFullYear()} Sift · Every story links to the original.
-          </p>
-        </div>
-      </footer>
+      <LandingFooter />
     </div>
   );
 }

--- a/components/landing/ComparisonDemo.tsx
+++ b/components/landing/ComparisonDemo.tsx
@@ -1,73 +1,51 @@
-"use client";
-
-import Link from "next/link";
 import { COPY } from "@/lib/copy";
 
-// Phase 0 stub: shows side-by-side outlet headlines without tone labels.
-// Phase 2 will rebuild as <CrossSpectrumCompare> with AllSides political-lean
-// ratings and outlet provenance. See plans/sift-civic-literacy.md.
-const DEMO: { outlet: string; framing: string }[] = [
-  {
-    outlet: "Reuters",
-    framing:
-      "Powell signals patience as inflation stays sticky; Fed leaves rates unchanged.",
-  },
-  {
-    outlet: "Wall Street Journal",
-    framing:
-      "Markets read between the lines: rate cuts unlikely before the fall.",
-  },
-  {
-    outlet: "Bloomberg",
-    framing:
-      "Wall Street recalibrates as rate-cut bets fade and bond yields climb.",
-  },
-];
+const C = COPY.landingReskin.compare;
 
+/**
+ * "How outlets framed it" — a representative side-by-side of how three outlets
+ * framed one story.
+ *
+ * TODO(live-compare): this Fed example is intentionally STATIC. Wiring it to a
+ * real multi-source comparison (today's top story across outlets, with live
+ * AllSides leans) is a larger, separate build — the deterministic compare path
+ * already exists at /news and app/api/compare. Until then this stays a fixed,
+ * honest illustration of the feature, not fabricated live data.
+ */
 export default function ComparisonDemo() {
   return (
-    <section className="max-w-[1100px] mx-auto px-6 pb-20">
-      {/* Section eyebrow + title */}
-      <div className="mb-7">
-        <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-3 flex items-center">
-          <span aria-hidden className="inline-block w-7 h-px bg-[var(--border)] mr-3" />
-          {COPY.landing.compareEyebrow}
-        </p>
-        <h2 className="font-heading text-[26px] md:text-[30px] font-bold leading-tight tracking-tight text-[var(--text)]">
-          {COPY.landing.compareTitle}
-        </h2>
-        <p className="font-body text-[14px] text-[var(--text-secondary)] mt-2 max-w-[60ch]">
-          {COPY.landing.compareSubtitle}
-        </p>
-      </div>
+    <section className="sl-band sl-compare" id="compare">
+      <div className="sl-wrap">
+        <div className="sl-sec-head" data-reveal>
+          <span className="sl-eyebrow">{C.eyebrow}</span>
+          <h2>
+            {C.titleLead}
+            <span className="sl-it">{C.titleIt}</span>
+          </h2>
+          <p>{C.subtitle}</p>
+        </div>
 
-      {/* Outlet × headline rows. Phase 2 adds AllSides political-lean column. */}
-      <div className="border-t border-b border-[var(--border)]">
-        {DEMO.map((row, i) => (
-          <div
-            key={row.outlet}
-            className={`story-row flex flex-col md:grid md:grid-cols-[160px_1fr] md:items-baseline gap-x-6 gap-y-1 py-5 ${
-              i < DEMO.length - 1 ? "border-b border-[var(--border-subtle)]" : ""
-            }`}
-          >
-            <span aria-hidden className="story-row__rail" />
-            <span className="story-row__source font-body text-outlet uppercase tracking-wider text-[var(--text)] font-semibold shrink-0">
-              {row.outlet}
-            </span>
-            <span className="font-heading italic text-[17px] md:text-[18px] leading-snug text-[var(--text-secondary)]">
-              &ldquo;{row.framing}&rdquo;
-            </span>
+        <div className="sl-frames" data-reveal>
+          <div className="sl-topic">
+            {C.topicLabel} — <b>{C.topic}</b>
           </div>
-        ))}
-      </div>
+          {C.frames.map((f) => (
+            <div className="sl-frame" key={f.outlet}>
+              <div className="sl-out">
+                <span className="sl-nm">{f.outlet}</span>
+                <span className="sl-ln">
+                  <span className="sl-dot" aria-hidden />
+                  {f.lean}
+                </span>
+              </div>
+              <q>{f.quote}</q>
+            </div>
+          ))}
+        </div>
 
-      <div className="mt-5 flex justify-end">
-        <Link
-          href="/news"
-          className="font-body text-outlet uppercase tracking-wider text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors no-underline inline-flex items-center gap-1.5"
-        >
-          {COPY.landing.compareCta} <span aria-hidden>→</span>
-        </Link>
+        <p className="sl-note-line" data-reveal>
+          {C.noteLine}
+        </p>
       </div>
     </section>
   );

--- a/components/landing/CtaBand.tsx
+++ b/components/landing/CtaBand.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { COPY } from "@/lib/copy";
+
+const C = COPY.landingReskin.cta;
+
+/** Closing CTA band → /news. */
+export default function CtaBand() {
+  return (
+    <section className="sl-cta">
+      <div className="sl-wrap sl-cta-inner">
+        <h2>
+          {C.titleLead}
+          <em>{C.titleEm}</em>
+        </h2>
+        <p>{C.body}</p>
+        <div className="sl-hero-actions">
+          <Link href="/news" className="sl-btn sl-btn-solid">
+            {C.ctaPrimary}{" "}
+            <span className="sl-arrow" aria-hidden>
+              →
+            </span>
+          </Link>
+          <Link href="/methodology" className="sl-btn sl-btn-ghost">
+            {C.ctaSecondary}
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/LandingFooter.tsx
+++ b/components/landing/LandingFooter.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import { COPY } from "@/lib/copy";
+import SlDiamond from "./SlDiamond";
+
+const F = COPY.landingReskin.footer;
+
+/** Reskinned footer — real in-app routes + byline → kristenmartino.ai. */
+export default function LandingFooter() {
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="sl-foot">
+      <div className="sl-wrap">
+        <div className="sl-foot-top">
+          <div className="sl-foot-brand">
+            <a href="#top" className="sl-brand" aria-label="Sift home">
+              <SlDiamond />
+              Sift
+            </a>
+            <p>{F.blurb}</p>
+          </div>
+
+          <div className="sl-foot-cols">
+            {F.cols.map((col) => (
+              <div className="sl-foot-col" key={col.heading}>
+                <h5>{col.heading}</h5>
+                {col.links.map((l) => (
+                  <Link key={l.href} href={l.href}>
+                    {l.label}
+                  </Link>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="sl-foot-bottom">
+          <span>
+            © {year} Sift · {F.tagline}
+          </span>
+          <span>
+            {F.bylinePre}
+            <a href={F.bylineHref} target="_blank" rel="noopener noreferrer">
+              {F.bylineName}
+            </a>
+          </span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/components/landing/LandingHeader.tsx
+++ b/components/landing/LandingHeader.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { COPY } from "@/lib/copy";
+import { useTheme } from "@/lib/hooks";
+import SlDiamond from "./SlDiamond";
+
+const NAV = COPY.landingReskin.nav;
+
+/**
+ * Reskinned homepage header. Reuses the app's existing dark-mode toggle
+ * (lib/hooks.ts useTheme → data-theme on <html>) — no second theme state. The
+ * shared LandingMasthead is intentionally left untouched for the other pages
+ * (colophon, methodology, civic, dossiers); this header is homepage-only.
+ */
+export default function LandingHeader() {
+  const { dark, toggle, mounted } = useTheme();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header className="sl-header">
+      <div className="sl-wrap sl-nav">
+        <a href="#top" className="sl-brand" aria-label="Sift home">
+          <SlDiamond filled />
+          Sift
+        </a>
+
+        <nav
+          className={`sl-nav-links${open ? " sl-open" : ""}`}
+          id="sl-navlinks"
+          aria-label="Primary"
+        >
+          {NAV.links.map((l) => (
+            <a key={l.href} href={l.href} onClick={() => setOpen(false)}>
+              {l.label}
+            </a>
+          ))}
+        </nav>
+
+        <div className="sl-nav-cta">
+          <button
+            type="button"
+            className="sl-toggle"
+            onClick={toggle}
+            aria-label={
+              mounted
+                ? dark
+                  ? "Switch to light mode"
+                  : "Switch to dark mode"
+                : "Toggle dark mode"
+            }
+          >
+            {/* Gated on `mounted` so the icon matches the real (post-hydration)
+                theme rather than the server's dark default — avoids a mismatch. */}
+            {mounted && (dark ? <MoonIcon /> : <SunIcon />)}
+          </button>
+
+          <Link href="/news" className="sl-btn sl-btn-solid">
+            {NAV.cta}{" "}
+            <span className="sl-arrow" aria-hidden>
+              →
+            </span>
+          </Link>
+
+          <button
+            type="button"
+            className="sl-menu-btn"
+            aria-label="Toggle menu"
+            aria-expanded={open}
+            aria-controls="sl-navlinks"
+            onClick={() => setOpen((v) => !v)}
+          >
+            {open ? NAV.menuOpen : NAV.menuClosed}
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M2 12h2M20 12h2M5 5l1.5 1.5M17.5 17.5 19 19M19 5l-1.5 1.5M6.5 17.5 5 19" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" />
+    </svg>
+  );
+}

--- a/components/landing/LeadStory.tsx
+++ b/components/landing/LeadStory.tsx
@@ -1,123 +1,116 @@
-"use client";
-
 import Link from "next/link";
-import { CATEGORIES, CATEGORY_COLORS } from "@/lib/constants";
 import { COPY } from "@/lib/copy";
-import { timeAgo } from "@/lib/utils";
-import CardImage from "@/components/CardImage";
+import { formatAllSidesLabel, formatMbfcLabel } from "@/lib/outlet";
+import SlDiamond from "./SlDiamond";
 import type { Article } from "@/lib/types";
 
-interface LeadStoryProps {
-  article: Article | null;
-}
+const CARD = COPY.landingReskin.card;
 
-export default function LeadStory({ article }: LeadStoryProps) {
+/**
+ * The hero's footnoted story card, rendered from the LIVE lead story
+ * (app/page.tsx → getTopStoryForLanding, ISR). Civic context is shown only
+ * where the real data exists:
+ *   - primer.background  → the "what you should know first" block
+ *   - primer.terms[]     → the numbered footnotes
+ *   - outlet.allSides/mbfc → the AllSides / MBFC chips
+ * When a field is absent we omit that affordance — never fabricate a primer,
+ * a footnote, or a rating on the homepage. Falls back to LeadFallback on a
+ * DB miss so the page still renders (graceful degradation).
+ */
+export default function LeadStory({ article }: { article: Article | null }) {
+  if (!article) return <LeadFallback />;
+
+  const primer = article.contextPrimer ?? null;
+  const background = primer?.background?.trim() || "";
+  // Cap footnotes so the hero card stays a preview, not a wall of text.
+  const terms = (primer?.terms ?? []).slice(0, 2);
+  const allSides = formatAllSidesLabel(article.outlet?.allSidesRating);
+  const mbfc = formatMbfcLabel(article.outlet?.mbfcFactual);
+  const hasCivic = Boolean(background || terms.length);
+
   return (
-    <section className="max-w-[1200px] mx-auto px-6 pt-12 pb-10">
-      {article ? <LeadFromDb article={article} /> : <LeadFallback />}
+    <div className="sl-card">
+      {hasCivic && <span className="sl-float-note">…with footnotes</span>}
 
-      {/* Editorial explainer paragraph */}
-      <p className="mt-12 max-w-[60ch] mx-auto text-center font-body text-[16px] leading-[1.65] text-[var(--text-secondary)]">
-        {COPY.landing.explainer}
-      </p>
-    </section>
-  );
-}
-
-function LeadFromDb({ article }: { article: Article }) {
-  const cat = CATEGORIES.find((c) => c.id === article.category) || CATEGORIES[0];
-  const color = CATEGORY_COLORS[article.category] || CATEGORY_COLORS.top;
-
-  return (
-    <a
-      href={article.sourceUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="grid grid-cols-1 md:grid-cols-[5fr_7fr] gap-x-10 gap-y-6 group cursor-pointer no-underline pb-10 border-b border-[var(--border)]"
-    >
-      {/* Image */}
-      <div>
-        <CardImage
-          src={article.imageUrl}
-          alt={article.title}
-          featured
-          category={article.category}
-        />
-        <p className="mt-2.5 pt-2 border-t border-[var(--border)] font-body text-outlet uppercase text-[var(--text-muted)] truncate">
-          Photograph · {article.sourceName}
-        </p>
+      <div className="sl-card-bar">
+        <SlDiamond />
+        {CARD.barLabel}
+        {hasCivic && <span className="sl-badge">{CARD.badge}</span>}
       </div>
 
-      {/* Body */}
-      <div className="flex flex-col">
-        <p className="font-body text-kicker uppercase text-[var(--text-secondary)] flex items-center mb-4">
-          <span
-            aria-hidden
-            className="inline-block w-1.5 h-1.5 rounded-full mr-2.5"
-            style={{ background: color.hex }}
-          />
-          <span className="text-[var(--accent)] font-semibold">
-            {COPY.landing.leadEyebrow}
-          </span>
-          <span className="mx-2 text-[var(--text-muted)]">·</span>
-          <span>{cat.label}</span>
-        </p>
+      <div className="sl-card-body">
+        <div className="sl-chip-row">
+          <span className="sl-chip sl-src">{article.sourceName}</span>
+          {allSides && (
+            <span className="sl-chip">
+              <span className="sl-dot" aria-hidden />
+              AllSides: {allSides}
+            </span>
+          )}
+          {mbfc && <span className="sl-chip">MBFC: {mbfc}</span>}
+        </div>
 
-        <h2
-          className="font-heading text-[28px] sm:text-[34px] md:text-[40px] font-bold leading-[1.08] tracking-tight text-[var(--text)] transition-colors duration-200 group-hover:text-[var(--accent)]"
+        <a
+          href={article.sourceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="sl-lead-link"
         >
-          {article.title}
-        </h2>
+          <h3 className="sl-lead">{article.title}</h3>
+        </a>
 
-        <p className="font-body text-outlet uppercase text-[var(--text-muted)] mt-4 flex flex-wrap items-center gap-x-2">
-          <span className="text-[var(--text-secondary)] font-semibold normal-case tracking-normal text-[12px]">
-            {article.sourceName}
-          </span>
-          <span>·</span>
-          <span>{timeAgo(article.publishedDate)}</span>
-          <span>·</span>
-          <span>{article.readTime} min read</span>
-        </p>
+        {background ? (
+          <div className="sl-primer">
+            <div className="sl-label">{CARD.primerLabel}</div>
+            <p>{background}</p>
+          </div>
+        ) : (
+          // No civic primer for this story yet — show the real summary rather
+          // than invent context.
+          <p className="sl-card-summary">{article.summary}</p>
+        )}
 
-        <p
-          data-dropcap
-          className="font-body text-[16px] text-[var(--text-secondary)] mt-6 leading-[1.65] max-w-[60ch]"
-        >
-          {article.summary}
-        </p>
-
-        <p className="mt-6 font-body text-outlet uppercase text-[var(--text-muted)] inline-flex items-center gap-1.5 transition-colors group-hover:text-[var(--accent)]">
-          {COPY.landing.leadCta} <span aria-hidden>→</span>
-        </p>
+        {terms.length > 0 && (
+          <div className="sl-notes">
+            {terms.map((t, i) => (
+              <div className="sl-note" key={t.term}>
+                <span className="sl-m" aria-hidden>
+                  {i + 1}
+                </span>
+                <span>
+                  <b>{t.term}</b> — {t.definition}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
-    </a>
+    </div>
   );
 }
 
 function LeadFallback() {
   return (
-    <div className="max-w-[640px] mx-auto text-center pt-8 pb-12 border-b border-[var(--border)]">
-      <p className="font-body text-kicker uppercase text-[var(--accent)] mb-4">
-        {COPY.landing.leadEyebrow}
-      </p>
-      <h2 className="font-heading text-[clamp(28px,5vw,40px)] font-bold leading-[1.1] tracking-tight text-[var(--text)] mb-5">
-        {COPY.landing.leadFallbackTitle}
-      </h2>
-      <p className="font-body text-[16px] leading-relaxed text-[var(--text-secondary)] mb-7">
-        {COPY.landing.leadFallbackBody}
-      </p>
-      <Link
-        href="/news"
-        className="font-body text-outlet uppercase tracking-wider text-[var(--accent)] hover:opacity-80 transition-opacity no-underline inline-flex items-center gap-1.5"
-      >
-        {COPY.landing.feedCta} <span aria-hidden>→</span>
-      </Link>
+    <div className="sl-card">
+      <div className="sl-card-bar">
+        <SlDiamond />
+        {CARD.barLabel}
+      </div>
+      <div className="sl-card-body">
+        <div className="sl-chip-row">
+          <span className="sl-chip sl-src">Sift</span>
+        </div>
+        <h3 className="sl-lead">{COPY.landing.leadFallbackTitle}</h3>
+        <p className="sl-card-summary">{COPY.landing.leadFallbackBody}</p>
+        <div style={{ marginTop: 16 }}>
+          <Link href="/news" className="sl-btn sl-btn-ghost">
+            {COPY.landing.feedCta}{" "}
+            <span className="sl-arrow" aria-hidden>
+              →
+            </span>
+          </Link>
+        </div>
+      </div>
     </div>
   );
 }
-
-/* ─── CSS for drop cap ──────────────────────────────────
-   We rely on globals.css [data-dropcap]::first-letter — but that lives
-   in the-digest's globals. Sift's globals.css doesn't have it yet.
-   We inline the rule via a <style jsx global> in LandingPage instead,
-   so it's scoped to landing and doesn't affect the rest of Sift. */

--- a/components/landing/Manifesto.tsx
+++ b/components/landing/Manifesto.tsx
@@ -1,0 +1,50 @@
+import { COPY } from "@/lib/copy";
+
+const M = COPY.landingReskin.manifesto;
+
+// Spectrum segment fills, in L/C/R/Specialty order. Presentation only — the
+// labels + counts live in COPY. Reverses visually with the manifesto band,
+// which flips with the theme.
+const SEG_COLORS = ["#8A8174", "#B3AA99", "#6B5F52", "#423D35"];
+
+/**
+ * "Why Sift" manifesto band + the outlet-spectrum bar. Counts (22/24/11/20)
+ * are the real curated totals from /methodology; static here is fine.
+ */
+export default function Manifesto() {
+  return (
+    <section className="sl-manifesto">
+      <div className="sl-wrap sl-manifesto-grid">
+        <div data-reveal>
+          <span className="sl-eyebrow">{M.eyebrow}</span>
+          <h2>
+            {M.headingLead}
+            <em>{M.headingEm}</em>
+          </h2>
+          <p>{M.body}</p>
+        </div>
+
+        <div className="sl-spectrum" data-reveal>
+          <div className="sl-bar" aria-hidden="true">
+            {M.spectrum.map((s, i) => (
+              <div
+                key={s.label}
+                className="sl-seg"
+                style={{ flex: s.count, background: SEG_COLORS[i] }}
+                title={`${s.label}: ${s.count}`}
+              />
+            ))}
+          </div>
+          <div className="sl-leg">
+            {M.spectrum.map((s) => (
+              <span key={s.label}>
+                {s.label} · {s.count}
+              </span>
+            ))}
+          </div>
+          <p className="sl-cap">{M.spectrumCaption}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/PrincipleStrip.tsx
+++ b/components/landing/PrincipleStrip.tsx
@@ -1,0 +1,24 @@
+import { Fragment } from "react";
+import { COPY } from "@/lib/copy";
+
+const ITEMS = COPY.landingReskin.strip;
+
+/** The "~50 vetted outlets / Left → Center → Right / …" principle strip. */
+export default function PrincipleStrip() {
+  return (
+    <div className="sl-strip">
+      <div className="sl-wrap sl-strip-inner">
+        {ITEMS.map((item, i) => (
+          <Fragment key={item}>
+            {i > 0 && (
+              <span className="sl-sep" aria-hidden>
+                /
+              </span>
+            )}
+            {i === 0 ? <b>{item}</b> : <span>{item}</span>}
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/landing/SlDiamond.tsx
+++ b/components/landing/SlDiamond.tsx
@@ -1,0 +1,34 @@
+// Sift's diamond mark for the homepage reskin. Stroke is the vermillion accent
+// (themed via the --accent token), sized by the `.sl-diamond` CSS rule so the
+// header/footer get 22px and the card bar gets 13px. `filled` adds the faint
+// inner diamond used in the header brand.
+
+interface SlDiamondProps {
+  className?: string;
+  strokeWidth?: number;
+  filled?: boolean;
+}
+
+export default function SlDiamond({
+  className = "sl-diamond",
+  strokeWidth = 2,
+  filled = false,
+}: SlDiamondProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      style={{ color: "var(--accent)" }}
+    >
+      <path
+        d="M12 2 22 12 12 22 2 12Z"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeLinejoin="round"
+      />
+      {filled && <path d="M12 7 17 12 12 17 7 12Z" fill="currentColor" opacity={0.16} />}
+    </svg>
+  );
+}

--- a/components/landing/SourceColophon.tsx
+++ b/components/landing/SourceColophon.tsx
@@ -1,54 +1,63 @@
-"use client";
-
+import Link from "next/link";
 import { COPY } from "@/lib/copy";
 
 export interface SourceColophonOutlet {
   slug: string;
   name: string;
-  /**
-   * AllSides lean if available — threaded through for an optional future
-   * Left / Center / Right grouping. Not rendered yet: this list is alphabetical.
-   */
+  /** AllSides lean if available — threaded for a possible future L/C/R group. */
   allSidesRating?: string | null;
 }
 
-interface SourceColophonProps {
-  /**
-   * Curated outlets from `outlet_profiles` (alphabetized, server-fetched in
-   * app/page.tsx). Driving this from the database — not a hardcoded array — is
-   * the point: the public list can no longer drift from the curated data. Empty
-   * on a DB miss/empty table, in which case we degrade to the prose (no grid) so
-   * the landing never breaks and never shows a stale source list.
-   */
-  outlets: SourceColophonOutlet[];
-}
+const S = COPY.landingReskin.sources;
 
-export default function SourceColophon({ outlets }: SourceColophonProps) {
+/**
+ * "Curated & cited" — the sources/methodology block. Left column carries the
+ * pitch, the methodology link, and the LIVE curated outlet list (server-fetched
+ * from outlet_profiles in app/page.tsx; degrades to no list on a DB miss).
+ * Right column is the static exclusions list.
+ */
+export default function SourceColophon({
+  outlets,
+}: {
+  outlets: SourceColophonOutlet[];
+}) {
   return (
-    <section className="max-w-[1100px] mx-auto px-6 pb-20">
-      <div className="border-t border-b border-[var(--border)] py-9">
-        <p className="font-body text-kicker uppercase text-[var(--text-muted)] mb-4 flex items-center">
-          <span aria-hidden className="inline-block w-7 h-px bg-[var(--border)] mr-3" />
-          {COPY.landing.colophonHeading}
-        </p>
-        <p className="font-body text-[13px] text-[var(--text-secondary)] leading-relaxed max-w-[680px] mb-6">
-          {COPY.landing.colophonDescription}
-        </p>
-        {outlets.length > 0 && (
-          <ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-1.5 mb-6">
-            {outlets.map((outlet) => (
-              <li
-                key={outlet.slug}
-                className="font-body text-[13px] text-[var(--text-secondary)] tracking-tight"
-              >
-                {outlet.name}
+    <section className="sl-band sl-sources" id="sources">
+      <div className="sl-wrap sl-src-grid">
+        <div className="sl-sec-head" style={{ marginBottom: 0 }} data-reveal>
+          <span className="sl-eyebrow">{S.eyebrow}</span>
+          <h2>
+            {S.titleLead}
+            <span className="sl-it">{S.titleIt}</span>
+            {S.titleRest}
+          </h2>
+          <p>{S.body}</p>
+          <div className="sl-hero-actions" style={{ marginTop: 26 }}>
+            <Link href="/methodology" className="sl-btn sl-btn-ghost">
+              {S.methodologyCta}
+            </Link>
+          </div>
+          {outlets.length > 0 && (
+            <ul className="sl-outlets" aria-label={S.outletsLabel}>
+              {outlets.map((o) => (
+                <li key={o.slug}>{o.name}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div data-reveal>
+          <p className="sl-src-label">{S.exclusionsLabel}</p>
+          <ul className="sl-excl">
+            {S.exclusions.map((e) => (
+              <li key={e.term}>
+                <span>
+                  <b>{e.term}</b> — {e.desc}
+                </span>
               </li>
             ))}
           </ul>
-        )}
-        <p className="font-body text-outlet uppercase tracking-wider text-[var(--text-muted)] pt-5 border-t border-[var(--border-subtle)]">
-          {COPY.landing.colophonSummary}
-        </p>
+        </div>
       </div>
     </section>
   );

--- a/components/landing/WhatSiftAdds.tsx
+++ b/components/landing/WhatSiftAdds.tsx
@@ -1,0 +1,33 @@
+import { COPY } from "@/lib/copy";
+
+const A = COPY.landingReskin.adds;
+
+/** "What Sift adds" — the four footnote types, as a 2×2 card grid. */
+export default function WhatSiftAdds() {
+  return (
+    <section className="sl-band sl-adds" id="adds">
+      <div className="sl-wrap">
+        <div className="sl-sec-head" data-reveal>
+          <span className="sl-eyebrow">{A.eyebrow}</span>
+          <h2>
+            {A.titleLead}
+            <span className="sl-it">{A.titleIt}</span>
+          </h2>
+          <p>{A.subtitle}</p>
+        </div>
+
+        <div className="sl-add-grid" data-reveal>
+          {A.cards.map((c) => (
+            <div className="sl-add" key={c.title}>
+              <div className="sl-ai" aria-hidden>
+                {c.icon}
+              </div>
+              <h3>{c.title}</h3>
+              <p>{c.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -362,6 +362,167 @@ export const COPY = {
     // Footer colophon link.
     colophonLink: "Colophon",
   },
+  // ─── Homepage reskin ("The news, with footnotes") ──────
+  // Copy for the reskinned `/` sections. Kept separate from `landing` (still
+  // used by the lead-story explainer + colophon) so neither clobbers the other.
+  landingReskin: {
+    nav: {
+      links: [
+        { label: "What Sift adds", href: "#adds" },
+        { label: "Compare", href: "#compare" },
+        { label: "Sources", href: "#sources" },
+      ],
+      cta: "Open Sift",
+      menuOpen: "Close",
+      menuClosed: "Menu",
+    },
+    hero: {
+      eyebrow: "Curated civic context for the news",
+      headingLead: "The news, with ",
+      headingAccent: "footnotes",
+      lede: "Sift reads ~50 vetted outlets across the political spectrum and adds the context the news assumes you already know — the background, the people and organizations involved, and how to read each source. Every link goes to the original.",
+      ctaPrimary: "Open Sift",
+      ctaSecondary: "See what Sift adds",
+      foot: "~50 vetted outlets · Left → Center → Right",
+    },
+    card: {
+      barLabel: "Today · Top story",
+      badge: "civic context on",
+      primerLabel: "What you should know first",
+    },
+    strip: [
+      "~50 vetted outlets",
+      "Left → Center → Right",
+      "Ratings cited, never computed",
+      "Every link goes to the original",
+    ],
+    manifesto: {
+      eyebrow: "Why Sift",
+      headingLead: "The news is written for people who ",
+      headingEm: "already have the context.",
+      body: "Most reporting assumes you know the players, the precedent, and where the source is coming from. Sift adds it back — so you can read across the spectrum and judge for yourself, with the footnotes in front of you.",
+      spectrum: [
+        { label: "Left", count: 22 },
+        { label: "Center", count: 24 },
+        { label: "Right", count: 11 },
+        { label: "Specialty", count: 20 },
+      ],
+      spectrumCaption:
+        "Hand-picked to balance the spectrum and clear a factual-reporting bar. Outlets without a political-lean rating are peer-reviewed journals or sector specialists.",
+    },
+    adds: {
+      eyebrow: "What Sift adds",
+      titleLead: "A footnote on ",
+      titleIt: "every story.",
+      subtitle:
+        "Not a summary that replaces the article — context that lets you actually read it. The methodology is the product as much as the feature.",
+      cards: [
+        {
+          icon: "i",
+          title: "What you should know first",
+          body: "A short primer on the background the story takes for granted — the precedent, the stakes, why it matters now.",
+        },
+        {
+          icon: "A·z",
+          title: "Terms you may not know",
+          body: "The jargon, acronyms, and procedure defined inline, so the paragraph actually makes sense the first time through.",
+        },
+        {
+          icon: "◈",
+          title: "Who's involved",
+          body: "Dossiers on the senators, agencies, and organizations named — who they are and where they sit, without leaving the story.",
+        },
+        {
+          icon: "⇄",
+          title: "The source & the spread",
+          body: "Each outlet's AllSides lean and MBFC factual tier — cited and linked, never our own rating — plus how other outlets framed the same story.",
+        },
+      ],
+    },
+    compare: {
+      eyebrow: "How outlets framed it",
+      titleLead: "One story, ",
+      titleIt: "three angles.",
+      subtitle:
+        "Sift shows what each outlet chose to emphasize — described, not labeled “biased” or “objective.” You read; the product does the legwork.",
+      topicLabel: "Topic",
+      topic: "The Federal Reserve's May rate decision",
+      frames: [
+        {
+          outlet: "Reuters",
+          lean: "AllSides: Center",
+          quote: "Powell signals patience as inflation stays sticky; Fed leaves rates unchanged.",
+        },
+        {
+          outlet: "Wall Street Journal",
+          lean: "AllSides: Center",
+          quote: "Markets read between the lines: rate cuts unlikely before the fall.",
+        },
+        {
+          outlet: "Bloomberg",
+          lean: "AllSides: Center",
+          quote: "Wall Street recalibrates as rate-cut bets fade and bond yields climb.",
+        },
+      ],
+      noteLine:
+        "Same event, three emphases. Sift puts them side by side and lets you draw the line.",
+    },
+    sources: {
+      eyebrow: "Curated & cited",
+      titleLead: "About ",
+      titleIt: "50 outlets.",
+      titleRest: " Every rating sourced.",
+      body: "Hand-picked across Left, Center, and Right, each with a dossier: ownership, funding model, AllSides lean, and MBFC factual tier — cited verbatim with a link, reviewed quarterly, and applied symmetrically to every outlet.",
+      methodologyCta: "Read the methodology",
+      exclusionsLabel: "What never enters the pipeline",
+      exclusions: [
+        { term: "Aggregators", desc: "no original reporting." },
+        { term: "AI-content farms", desc: "synthetic articles without bylines." },
+        { term: "Low-factual outlets", desc: "regardless of political lean." },
+        { term: "Sites without", desc: "mastheads, bylines, or corrections policies." },
+        { term: "Crypto & supplement sites", desc: "dressed up as news." },
+      ],
+      outletsLabel: "Outlets Sift reads",
+    },
+    cta: {
+      titleLead: "Read today's news — ",
+      titleEm: "with the footnotes.",
+      body: "~50 vetted outlets, the civic context the news assumes you already know, and a link to the original on every story.",
+      ctaPrimary: "Open Sift",
+      ctaSecondary: "How it works",
+    },
+    footer: {
+      blurb:
+        "Sift reads from ~50 vetted outlets across the political spectrum, surfaces the civic context the news assumes you already know, and shows you who's behind every story. Every link goes to the original.",
+      cols: [
+        {
+          heading: "Read",
+          links: [
+            { label: "Today", href: "/news" },
+            { label: "Civic", href: "/civic" },
+          ],
+        },
+        {
+          heading: "About",
+          links: [
+            { label: "Methodology", href: "/methodology" },
+            { label: "Colophon", href: "/colophon" },
+          ],
+        },
+        {
+          heading: "Legal",
+          links: [
+            { label: "Privacy", href: "/privacy" },
+            { label: "Terms", href: "/terms" },
+          ],
+        },
+      ],
+      bylinePre: "Designed & built by ",
+      bylineName: "Kristen Martino",
+      bylineHref: "https://kristenmartino.ai",
+      tagline: "Every story links to the original.",
+    },
+  },
   civicIndex: {
     eyebrow: "Civic dossiers",
     headline: "Civic dossiers",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,8 +11,10 @@ const config: Config = {
     extend: {
       fontFamily: {
         // CSS variables are injected by next/font in app/layout.tsx.
+        // heading = Fraunces (display), body = Hanken Grotesk, mono = DM Mono.
         heading: ["var(--font-heading)", "Georgia", "Times New Roman", "serif"],
         body: ["var(--font-body)", "Segoe UI", "sans-serif"],
+        mono: ["var(--font-mono)", "ui-monospace", "SFMono-Regular", "monospace"],
       },
       fontSize: {
         kicker:        ["11px",   { lineHeight: "1.2",  letterSpacing: "0.12em" }],


### PR DESCRIPTION
## Summary
- Applies homepage reskin work from `homepage-reskin`
- Includes the dark-mode band fix
- Opens as Draft so the work is tracked and previewable

## Review notes
- Needs visual review on the Vercel preview
- Review both light mode and dark mode
- Pay special attention to the dark-mode band/background transitions
- This may need reconciliation with #142 after the Tailwind 4 migration

## Merge order / dependency note
Recommended order:
1. Merge #141 first — core dependency majors
2. Review #142 — Tailwind 4 visual migration
3. Rebase/update this PR as needed after #141/#142 direction is clear
4. Then decide whether the reskin is ready to merge

_Independent of #141/#142 — based on `main`, not stacked on the Tailwind draft, so it stays separately previewable._

🤖 Generated with [Claude Code](https://claude.com/claude-code)