### PR TITLE
draft: Phase 2 — app-wide editorial theme migration

### DIFF
--- a/SIFT_THEME_MIGRATION.md
+++ b/SIFT_THEME_MIGRATION.md
@@ -1,0 +1,133 @@
+# Sift — Phase 2: App-Wide Theme Migration Spec
+
+**Where Phase 1 left things:** the homepage `/` was reskinned to the editorial "news, with footnotes" identity (warm-paper light + warm dark, vermillion accent, Fraunces / Hanken Grotesk / DM Mono), and that reskin was deliberately **scoped under `.sift-landing`** so it wouldn't leak. Two consequences define this phase:
+1. **Fonts are already site-wide** (Fraunces/Hanken/DM Mono replaced Playfair/Source Sans everywhere). No font work here.
+2. **Color is not.** `/news`, `/civic`, `/methodology`, `/colophon`, the civic dossiers, `/privacy`, `/terms` still run the **old stone/indigo palette**. This phase brings them onto the editorial palette.
+
+Sift already has **light + dark** wired to `[data-theme]`. So there's **no "go dark?" decision** — the work is making the editorial palette correct across every surface **in both themes**, which means **two full token maps**, not one.
+
+> Don't start until you have the surface/component inventory (homepage reskin already mapped much of it). Get sign-off on §1 (un-scoping) and §2 (the token system + the rating-chip rule) before migrating components.
+
+---
+
+## 1. The migration decision: un-scope, don't fork
+The reskin's `.sift-landing` scoping was right for shipping one page safely; it's the wrong long-term structure.
+- **(A) Promote `.sift-landing` tokens to a GLOBAL semantic layer, migrate surface-by-surface, retire stone/indigo.** One system, one source of truth. **Recommended.**
+- **(B) Keep both palettes; migrate only some surfaces.** Leaves Sift permanently two-toned and doubles maintenance. Avoid.
+
+**Recommendation: (A).** Step zero: lift the scoped tokens into global semantic tokens (§2) and **re-point the already-shipped homepage at the global names with zero visual change** — verify the homepage is pixel-identical before migrating anything else. Then migrate the rest and delete the old palette.
+
+---
+
+## 2. Token architecture — two full maps (light + dark)
+Promote Phase 1's raw values to a **semantic layer** components consume (no raw hex in components), with **both** theme maps driven by the existing `[data-theme]` toggle.
+
+**Surfaces**
+
+| token | light | dark |
+|---|---|---|
+| `--surface-base` (page) | `#FBF8F1` | `#15120C` |
+| `--surface-raised` (cards) | `#FFFDF8` | `#1F1A12` |
+| `--surface-overlay` (menus/modals) | `#FFFFFF` | `#2A241B` |
+| `--surface-sunken` (inputs/wells) | `#F3ECDD` | `#1C1813` |
+
+**Text**
+
+| token | light | dark |
+|---|---|---|
+| `--text-primary` | `#17130E` | `#F2ECDE` |
+| `--text-secondary` | `#4C4438` | `#B9B1A0` |
+| `--text-tertiary` | `#8A8071` | `#867D6C` |
+| `--text-accent` (small accent text) | `#AE3417` | `#F0805E` |
+| `--text-on-accent` | meet contrast on the accent fill | meet contrast |
+
+**Borders**
+
+| | light | dark |
+|---|---|---|
+| `--border` | `rgba(23,19,14,.14)` | `rgba(242,236,222,.15)` |
+| `--border-strong` | `rgba(23,19,14,.22)` | `rgba(242,236,222,.24)` |
+| `--border-subtle` | `rgba(23,19,14,.08)` | `rgba(242,236,222,.07)` |
+
+**Accent (vermillion) + states**
+
+| | light | dark |
+|---|---|---|
+| `--accent` | `#E0492A` | `#EC5B39` |
+| `--accent-hover` | `#C13F22` | `#F06D4D` |
+| `--accent-pressed` | `#AE3417` | `#D24A2C` |
+| `--accent-subtle` (tint bg) | `rgba(224,73,42,.10)` | `rgba(236,91,57,.14)` |
+
+**Status / feedback** (search errors, empty/fallback states, toasts — deeper on light, lighter on dark)
+
+| | light | dark |
+|---|---|---|
+| `--success` | `#2E7D5B` | `#74D2A8` |
+| `--warning` | `#B5621A` | `#E89B3C` |
+| `--danger` | `#B3261E` | `#E5675A` |
+| `--info` | `#2C6E94` | `#6FB1D8` |
+
+**Focus ring:** `--ring` = the accent per theme; `:focus-visible { outline:2px solid var(--ring); outline-offset:2px }`. Never color-only.
+
+`--text-on-accent` is the value to compute per theme: pick paper/white or a near-black warm so text on the accent fill meets **AA (≥4.5:1 body, ≥3:1 large/bold)** — verify in both themes; vermillion sits near the threshold.
+
+Deliverable: one global tokens file (CSS vars under `[data-theme="light"]` / `[data-theme="dark"]` + Tailwind `extend`) and a token→value reference (both columns).
+
+---
+
+## 3. The brand-critical subsystem: rating chips & party tags (NEUTRAL)
+Sift cites AllSides/MBFC verbatim, links the source, and does not editorialize about which side is more or less reliable — applied **symmetrically**. The theme must encode that.
+
+**Hard rules:**
+- **Political lean is never hue-coded.** AllSides buckets (Left, Lean Left, Center, Lean Right, Right, Mixed) and party tags (R / D / I) render in **neutral ink** — the same `--text-secondary` for Left and Right. No red/blue. Differentiate by **label and position**, not color — e.g. a small 5-tick position glyph in neutral ink with the relevant tick filled.
+- **Every rating chip cites + links its source** (AllSides / MBFC page) with an external-link affordance, and shows the last-verified date caption (DM Mono).
+- **Factual-reporting tier** (Very High → Very Low): default **tonal/neutral** (a neutral fill-level indicator, not green-good/red-bad). Flag for sign-off if a restrained quality encoding is wanted instead.
+
+Build these as first-class primitives (`OutletChip`, `LeanGlyph`, `FactualChip`, `PartyTag`) so the reader, the comparison view, and all dossiers share one neutral, sourced treatment.
+
+---
+
+## 4. The `/news` reader — the real product, and the density story
+High-traffic, long-session surface; "density" is **dense civic metadata + long-form reading**, not charts.
+- **Reading comfort, both themes:** Fraunces headlines / Hanken body / DM Mono metadata; body measure ~60–72ch, line-height ~1.6, comfortable sizes. The warm dark (`#15120C`, not pure black) is an intentional long-reading choice — preserve the warmth.
+- **Article card:** headline, neutral `OutletChip` (lean + factual + source link), source/time meta, summary, the collapsible **"What you should know first" primer** (keep the open-event behavior the privacy policy documents), inline **term-definition footnotes**, "Read in full" → **original** (external affordance).
+- **Comparison view ("how outlets framed it"):** side-by-side framings, neutral chips, described-not-labeled.
+- **Category nav** (Today / Technology / … / Entertainment) and **topic search**: input + results + **loading / empty / fallback** states all themed.
+
+## 5. Civic + dossiers
+- **Directory pages** (politicians, orgs, bills): scannable typographic density, neutral `PartyTag`s, clear hover/focus, links to individual dossiers.
+- **Individual dossiers:** profile + (outlets) ownership/funding + ratings, (people/orgs/bills) role/status, with **citations** (GovTrack / OpenSecrets / ProPublica) in a consistent sourced/external-link style.
+
+## 6. Methodology / colophon / legal
+Long-form content pages — apply the editorial reading styles (same measure/scale as the reader's article body). `/colophon` was partly updated in Phase 1 (fonts line); finish its palette + confirm the "Set in" copy.
+
+## 7. Performance & integrity (non-negotiable)
+- CSS-only theming via the existing `[data-theme]`; **no new blocking calls**; don't regress the "<50ms article, AI in the background" posture.
+- Graceful degradation everywhere (empty/error/fallback states themed).
+- **No email capture** (write-paths live in `sift-api` per `CLAUDE.md`); no new dependencies; keep the diamond mark.
+
+---
+
+## Recommended sequence (sub-phases)
+- **2a** — Promote tokens to the global semantic layer (both maps) + **re-point the homepage at the global names with zero visual change (verify first)** + build primitives, including the §3 neutral rating-chip / party-tag subsystem.
+- **2b** — The `/news` reader (§4). Reading-comfort pass in both themes.
+- **2c** — Civic + dossiers (§5).
+- **2d** — Methodology / colophon / legal (§6) + remaining surfaces; then **delete the old stone/indigo palette** and grep to confirm nothing references it.
+- **2e** — QA: AA contrast in **both** themes, reading comfort, a **rating-chip / party-tag neutrality audit** (no partisan color anywhere), performance check, reduced-motion, responsive.
+
+**Pause after 2a** for verification of primitives + the unchanged homepage before touching the reader.
+
+## Risks
+- **The reader is the product** — both themes must be genuinely comfortable; the migration must not slow it.
+- **Neutrality is brand-critical** — any partisan color-coding on lean or party tags betrays Sift's symmetric-citation ethos. Hard rule, audited in 2e.
+- **Two-theme QA doubles the surface** — light (warm paper) and dark (warm dark) fail differently.
+- **Test breakage** — tests assert copy/markup; migrate tests to new contracts while preserving intent.
+- **Un-scoping regression** — promoting `.sift-landing` tokens globally must not change the shipped homepage; verify pixel-parity before touching other surfaces.
+
+## Done criteria
+- `tsc --noEmit`, `build`, and the test suite pass (CI parity); homepage visually unchanged after un-scoping.
+- Every surface on the **global token system in both themes**; **no stone/indigo or hardcoded colors remain** (grep).
+- Rating chips, lean glyphs, and party tags **neutral and sourced** everywhere; factual tier neutral (or sign-off-approved restrained encoding).
+- Reader comfortable for long reading in both themes; focus-visible rings present; AA contrast holds in both; `<50ms` posture and graceful-degradation states intact.
+- Responsive at ~375 / 768 / 1200; `prefers-reduced-motion` respected.
+- Summary of changed files + deferred TODOs (e.g. `TODO(live-compare)` still pending from Phase 1).

--- a/__tests__/ratingPrimitives.test.tsx
+++ b/__tests__/ratingPrimitives.test.tsx
@@ -1,0 +1,105 @@
+import { render, within } from "@testing-library/react";
+import {
+  LeanGlyph,
+  FactualChip,
+  PartyTag,
+  OutletChip,
+} from "@/components/primitives";
+import type { OutletProfile } from "@/lib/types";
+
+// Any partisan color (tailwind red/blue or the old indigo/category hexes) is a
+// §3 violation on a lean/party/factual primitive. These primitives must use
+// only neutral tokens.
+const PARTISAN =
+  /\bred-\d|\bblue-\d|#dc2626|#2563eb|#818cf8|#4338ca|#1d4ed8|#b91c1c|\bbg-red|\bbg-blue|\btext-red|\btext-blue/i;
+
+function filledTickIndex(container: HTMLElement): number {
+  const ticks = Array.from(
+    container.querySelectorAll<HTMLElement>('[role="img"] > span'),
+  );
+  return ticks.findIndex((t) => t.style.background === "var(--text-secondary)");
+}
+
+const REUTERS = {
+  slug: "reuters",
+  name: "Reuters",
+  parentCompany: null,
+  parentCompanyUrl: null,
+  foundedYear: null,
+  fundingModel: null,
+  allSidesRating: "center",
+  allSidesUrl: "https://www.allsides.com/news-source/reuters",
+  allSidesLastChecked: "2026-01-01",
+  mbfcFactual: "high",
+  mbfcUrl: "https://mediabiasfactcheck.com/reuters/",
+  mbfcLastChecked: "2026-01-01",
+  majorFunders: [],
+  externalLinks: {},
+  notes: null,
+} as OutletProfile;
+
+describe("rating primitives — §3 neutrality", () => {
+  it("LeanGlyph encodes lean by POSITION, not color (Left vs Right differ only in which tick fills)", () => {
+    const { container: left } = render(<LeanGlyph rating="left" />);
+    const { container: right } = render(<LeanGlyph rating="right" />);
+    expect(filledTickIndex(left)).toBe(0);
+    expect(filledTickIndex(right)).toBe(4);
+    expect(left.innerHTML).not.toMatch(PARTISAN);
+    expect(right.innerHTML).not.toMatch(PARTISAN);
+  });
+
+  it("LeanGlyph labels every AllSides bucket and never hue-codes", () => {
+    for (const r of [
+      "left",
+      "lean-left",
+      "center",
+      "lean-right",
+      "right",
+      "mixed",
+    ] as const) {
+      const { container } = render(<LeanGlyph rating={r} />);
+      const img = container.querySelector('[role="img"]');
+      expect(img?.getAttribute("aria-label")).toMatch(/AllSides lean/);
+      expect(container.innerHTML).not.toMatch(PARTISAN);
+    }
+  });
+
+  it("FactualChip is a neutral, cited meter (label + MBFC link, no green/red)", () => {
+    const { container } = render(
+      <FactualChip
+        rating="high"
+        url="https://mediabiasfactcheck.com/x"
+        lastChecked="2026-01-01"
+      />,
+    );
+    expect(within(container).getByText(/MBFC: High/)).toBeInTheDocument();
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(
+      "https://mediabiasfactcheck.com/x",
+    );
+    expect(container.innerHTML).not.toMatch(PARTISAN);
+  });
+
+  it("PartyTag renders a neutral letter + full label, never red/blue", () => {
+    const { container: r } = render(<PartyTag party="Republican" />);
+    const { container: d } = render(<PartyTag party="Democrat" />);
+    expect(r.querySelector("[aria-label='Republican']")?.textContent).toBe("R");
+    expect(d.querySelector("[aria-label='Democrat']")?.textContent).toBe("D");
+    expect(r.innerHTML).not.toMatch(PARTISAN);
+    expect(d.innerHTML).not.toMatch(PARTISAN);
+  });
+
+  it("OutletChip renders name + neutral lean + factual, and degrades to fallback", () => {
+    const { container } = render(
+      <OutletChip outlet={REUTERS} fallback="Reuters" />,
+    );
+    expect(within(container).getByText("Reuters")).toBeInTheDocument();
+    expect(within(container).getByText(/MBFC: High/)).toBeInTheDocument();
+    expect(container.querySelector('[role="img"]')).toBeTruthy(); // LeanGlyph
+    expect(container.innerHTML).not.toMatch(PARTISAN);
+
+    const { container: fb } = render(
+      <OutletChip outlet={null} fallback="Some Blog" />,
+    );
+    expect(fb.textContent).toContain("Some Blog");
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -289,10 +289,30 @@ html {
 }
 
 /* ─── Base Reset ───────────────────────────────────────── */
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
+/* Tailwind v4 compatibility — this universal reset MUST stay inside @layer base.
+   v4 emits utilities into native `@layer utilities`, and UNLAYERED declarations
+   win over ANY layered declaration regardless of specificity. So an unlayered
+   `* { margin:0; padding:0 }` silently overrode every `p-*` / `m-*` / `mt-auto`
+   / `space-y-*` utility once #142 migrated v3→v4 — which is exactly what broke
+   /news spacing (the homepage was unaffected because it's hand-written .sl-*
+   CSS, not Tailwind spacing utilities). Inside @layer base it still zeroes UA
+   defaults but correctly LOSES to spacing utilities, restoring v3 behavior. */
+@layer base {
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* v4 sets <button> cursor to `default` (matching the browser) instead of
+     `pointer`. Every interactive control in-app already carries an explicit
+     `cursor-pointer` utility, but third-party buttons (e.g. Clerk) do not — this
+     restores the pointer affordance for them while still losing to any explicit
+     `cursor-*` utility. */
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
 }
 
 body {

--- a/app/globals.css
+++ b/app/globals.css
@@ -175,13 +175,42 @@
 /* Default: Late Edition (matches server render and blocking script) */
 :root,
 html[data-theme="dark"] {
+  /* ── Editorial semantic tokens — Phase 2 global source of truth (dark) ── */
+  --surface-base: #15120c;
+  --surface-raised: #1f1a12;
+  --surface-overlay: #2a241b;
+  --surface-sunken: #1c1813;
+
+  --text-primary: #f2ecde;
+  --text-secondary: #b9b1a0;
+  --text-tertiary: #867d6c;
+  --text-accent: #f0805e;
+  --text-on-accent: #fbf8f1;
+
+  --border: rgba(242, 236, 222, 0.15);
+  --border-strong: rgba(242, 236, 222, 0.24);
+  --border-subtle: rgba(242, 236, 222, 0.07);
+
+  --accent: #ec5b39;
+  --accent-hover: #f06d4d;
+  --accent-pressed: #d24a2c;
+  --accent-subtle: rgba(236, 91, 57, 0.14);
+
+  --success: #74d2a8;
+  --warning: #e89b3c;
+  --danger: #e5675a;
+  --info: #6fb1d8;
+
+  --ring: var(--accent);
+
+  /* ── Legacy stone palette — un-migrated surfaces only; deleted in Phase 2d ──
+     --text-secondary / --border / --border-subtle / --accent were here with the
+     old stone/indigo values; they now resolve to the editorial tokens above.
+     Surfaces still on --bg/--card-bg/--text/--text-muted migrate in 2c–2d. */
   --bg: #0c0a09;
   --card-bg: #1c1917;
   --text: #f5f5f4;
-  --text-secondary: #a8a29e;
   --text-muted: #78716c;
-  --border: #292524;
-  --border-subtle: rgba(41, 37, 36, 0.4);
   --shadow-low: rgba(0, 0, 0, 0.18);
   --shadow-mid: rgba(0, 0, 0, 0.4);
   --shadow-high: rgba(0, 0, 0, 0.62);
@@ -191,7 +220,6 @@ html[data-theme="dark"] {
   --highlight-color: rgba(255, 255, 255, 0.025);
   --highlight-blend: screen;
   --skeleton: #292524;
-  --accent: #818cf8;
   --nav-bg: rgba(12, 10, 9, 0.92);
   --pill-active: #818cf8;
   --pill-text: #f5f5f4;
@@ -205,15 +233,41 @@ html[data-theme="dark"] {
   --dur-slow: 400ms;
 }
 
-/* Newsprint */
+/* Light */
 html[data-theme="light"] {
+  /* ── Editorial semantic tokens (light) ── */
+  --surface-base: #fbf8f1;
+  --surface-raised: #fffdf8;
+  --surface-overlay: #ffffff;
+  --surface-sunken: #f3ecdd;
+
+  --text-primary: #17130e;
+  --text-secondary: #4c4438;
+  --text-tertiary: #8a8071;
+  --text-accent: #ae3417;
+  --text-on-accent: #fbf8f1;
+
+  --border: rgba(23, 19, 14, 0.14);
+  --border-strong: rgba(23, 19, 14, 0.22);
+  --border-subtle: rgba(23, 19, 14, 0.08);
+
+  --accent: #e0492a;
+  --accent-hover: #c13f22;
+  --accent-pressed: #ae3417;
+  --accent-subtle: rgba(224, 73, 42, 0.1);
+
+  --success: #2e7d5b;
+  --warning: #b5621a;
+  --danger: #b3261e;
+  --info: #2c6e94;
+
+  --ring: var(--accent);
+
+  /* ── Legacy stone palette (light) — deleted in 2d ── */
   --bg: #f5f2ed;
   --card-bg: #ffffff;
   --text: #1c1917;
-  --text-secondary: #57534e;
   --text-muted: #8a8380;
-  --border: #e7e5e4;
-  --border-subtle: rgba(231, 229, 228, 0.6);
   --shadow-low: rgba(0, 0, 0, 0.04);
   --shadow-mid: rgba(0, 0, 0, 0.06);
   --shadow-high: rgba(0, 0, 0, 0.14);
@@ -223,7 +277,6 @@ html[data-theme="light"] {
   --highlight-color: rgba(0, 0, 0, 0.025);
   --highlight-blend: multiply;
   --skeleton: #e7e5e4;
-  --accent: #4338ca;
   --nav-bg: rgba(245, 242, 237, 0.92);
   --pill-active: #1c1917;
   --pill-text: #ffffff;
@@ -469,39 +522,20 @@ html[data-theme="light"] .story-highlight {
    (--font-heading=Fraunces, --font-body=Hanken Grotesk, --font-mono=DM Mono).
    ══════════════════════════════════════════════════════════════════════ */
 
-/* Light tokens (default) */
+/* Homepage-local tokens NOT part of the global editorial system: two extra warm
+   surface shades the reskin uses, the film-grain controls, and the offset hard-
+   shadow. (Color/text/border/accent now come from the global editorial tokens
+   above; the sl-* rules reference the global names — promoted in Phase 2a.) */
 .sift-landing {
-  --paper: #fbf8f1;
-  --paper-2: #f3ecdd;
   --paper-3: #ece3d0;
-  --surface: #fffdf8;
   --surface-2: #f7f1e5;
-  --ink: #17130e;
-  --ink-soft: #4c4438;
-  --ink-faint: #8a8071;
-  --accent: #e0492a;
-  --accent-deep: #ae3417;
-  --line: rgba(23, 19, 14, 0.14);
-  --line-soft: rgba(23, 19, 14, 0.08);
   --grain-op: 0.4;
   --grain-blend: multiply;
   --shadow: rgba(23, 19, 14, 0.9);
 }
-
-/* Dark tokens — same toggle, flipped palette */
 html[data-theme="dark"] .sift-landing {
-  --paper: #15120c;
-  --paper-2: #1c1813;
   --paper-3: #241f18;
-  --surface: #1f1a12;
   --surface-2: #262017;
-  --ink: #f2ecde;
-  --ink-soft: #b9b1a0;
-  --ink-faint: #867d6c;
-  --accent: #ec5b39;
-  --accent-deep: #f0805e;
-  --line: rgba(242, 236, 222, 0.15);
-  --line-soft: rgba(242, 236, 222, 0.07);
   --grain-op: 0.06;
   --grain-blend: normal;
   --shadow: rgba(0, 0, 0, 0.6);
@@ -515,8 +549,8 @@ html:has(.sift-landing) {
 
 .sift-landing {
   min-height: 100vh;
-  background: var(--paper);
-  color: var(--ink);
+  background: var(--surface-base);
+  color: var(--text-primary);
   font-family: var(--font-body), system-ui, sans-serif;
   font-size: 17px;
   line-height: 1.6;
@@ -531,7 +565,7 @@ html:has(.sift-landing) {
 }
 .sift-landing ::selection {
   background: var(--accent);
-  color: var(--paper);
+  color: var(--surface-base);
 }
 .sift-landing h1,
 .sift-landing h2,
@@ -566,7 +600,7 @@ html:has(.sift-landing) {
   font-size: 12px;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--accent-deep);
+  color: var(--text-accent);
   display: inline-flex;
   align-items: center;
   gap: 10px;
@@ -581,7 +615,7 @@ html:has(.sift-landing) {
 .sift-landing sup.sl-fn {
   font-family: var(--font-mono), monospace;
   font-size: 0.56em;
-  color: var(--accent-deep);
+  color: var(--text-accent);
   font-weight: 500;
   vertical-align: super;
   padding-left: 1px;
@@ -598,7 +632,7 @@ html:has(.sift-landing) {
   padding: 14px 24px;
   border-radius: 2px;
   cursor: pointer;
-  border: 1px solid var(--ink);
+  border: 1px solid var(--text-primary);
   transition: transform 0.25s cubic-bezier(0.2, 0.8, 0.2, 1), background 0.25s,
     color 0.25s, box-shadow 0.25s, border-color 0.25s;
 }
@@ -609,23 +643,23 @@ html:has(.sift-landing) {
   transform: translateX(4px);
 }
 .sift-landing .sl-btn-solid {
-  background: var(--ink);
-  color: var(--paper);
+  background: var(--text-primary);
+  color: var(--surface-base);
 }
 .sift-landing .sl-btn-solid:hover {
   background: var(--accent);
   border-color: var(--accent);
-  color: var(--paper);
+  color: var(--surface-base);
   transform: translateY(-2px);
   box-shadow: 6px 8px 0 var(--shadow);
 }
 .sift-landing .sl-btn-ghost {
   background: transparent;
-  color: var(--ink);
+  color: var(--text-primary);
 }
 .sift-landing .sl-btn-ghost:hover {
-  background: var(--ink);
-  color: var(--paper);
+  background: var(--text-primary);
+  color: var(--surface-base);
   transform: translateY(-2px);
 }
 
@@ -634,10 +668,10 @@ html:has(.sift-landing) {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: color-mix(in srgb, var(--paper) 86%, transparent);
+  background: color-mix(in srgb, var(--surface-base) 86%, transparent);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--border);
   transition: background 0.4s;
 }
 .sift-landing .sl-nav {
@@ -654,7 +688,7 @@ html:has(.sift-landing) {
   font-weight: 700;
   font-size: 25px;
   letter-spacing: -0.03em;
-  color: var(--ink);
+  color: var(--text-primary);
 }
 .sift-landing .sl-diamond {
   width: 22px;
@@ -669,7 +703,7 @@ html:has(.sift-landing) {
 .sift-landing .sl-nav-links a {
   font-size: 14.5px;
   font-weight: 500;
-  color: var(--ink-soft);
+  color: var(--text-secondary);
   position: relative;
   padding: 4px 0;
   transition: color 0.2s;
@@ -685,7 +719,7 @@ html:has(.sift-landing) {
   transition: width 0.28s ease;
 }
 .sift-landing .sl-nav-links a:hover {
-  color: var(--ink);
+  color: var(--text-primary);
 }
 .sift-landing .sl-nav-links a:hover::after {
   width: 100%;
@@ -698,19 +732,19 @@ html:has(.sift-landing) {
 .sift-landing .sl-toggle {
   width: 38px;
   height: 38px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--border);
   border-radius: 50%;
   background: transparent;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--ink-soft);
+  color: var(--text-secondary);
   transition: border-color 0.2s, color 0.2s, transform 0.3s;
 }
 .sift-landing .sl-toggle:hover {
-  border-color: var(--ink-soft);
-  color: var(--ink);
+  border-color: var(--text-secondary);
+  color: var(--text-primary);
   transform: rotate(18deg);
 }
 .sift-landing .sl-toggle svg {
@@ -726,7 +760,7 @@ html:has(.sift-landing) {
   font-size: 13px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--ink);
+  color: var(--text-primary);
 }
 
 /* hero */
@@ -745,8 +779,8 @@ html:has(.sift-landing) {
     90deg,
     transparent,
     transparent calc(8.333% - 1px),
-    var(--line-soft) calc(8.333% - 1px),
-    var(--line-soft) 8.333%
+    var(--border-subtle) calc(8.333% - 1px),
+    var(--border-subtle) 8.333%
   );
   -webkit-mask-image: linear-gradient(180deg, transparent, #000 18%, #000 82%, transparent);
   mask-image: linear-gradient(180deg, transparent, #000 18%, #000 82%, transparent);
@@ -768,7 +802,7 @@ html:has(.sift-landing) {
 .sift-landing .sl-hero h1 {
   font-size: clamp(3rem, 6.2vw, 5.4rem);
   margin-bottom: 22px;
-  color: var(--ink);
+  color: var(--text-primary);
 }
 .sift-landing .sl-hero h1 .sl-ul {
   position: relative;
@@ -786,7 +820,7 @@ html:has(.sift-landing) {
 }
 .sift-landing .sl-lede {
   font-size: clamp(1.05rem, 1.45vw, 1.24rem);
-  color: var(--ink-soft);
+  color: var(--text-secondary);
   max-width: 34ch;
   margin-bottom: 32px;
   line-height: 1.55;
@@ -803,7 +837,7 @@ html:has(.sift-landing) {
   font-size: 11.5px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--ink-faint);
+  color: var(--text-tertiary);
   display: flex;
   align-items: center;
   gap: 14px;
@@ -819,8 +853,8 @@ html:has(.sift-landing) {
 /* footnoted story card (the live lead story) */
 .sift-landing .sl-card {
   position: relative;
-  background: var(--surface);
-  border: 1px solid var(--ink);
+  background: var(--surface-raised);
+  border: 1px solid var(--text-primary);
   border-radius: 6px;
   box-shadow: 14px 18px 0 var(--shadow);
   overflow: hidden;
@@ -830,12 +864,12 @@ html:has(.sift-landing) {
   align-items: center;
   gap: 8px;
   padding: 12px 16px;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--border);
   background: var(--surface-2);
   font-family: var(--font-mono), monospace;
   font-size: 11px;
   letter-spacing: 0.04em;
-  color: var(--ink-faint);
+  color: var(--text-tertiary);
 }
 .sift-landing .sl-card-bar .sl-diamond {
   width: 13px;
@@ -843,7 +877,7 @@ html:has(.sift-landing) {
 }
 .sift-landing .sl-card-bar .sl-badge {
   margin-left: auto;
-  color: var(--accent-deep);
+  color: var(--text-accent);
 }
 .sift-landing .sl-card-body {
   padding: 22px;
@@ -860,9 +894,9 @@ html:has(.sift-landing) {
   font-size: 10.5px;
   letter-spacing: 0.05em;
   padding: 4px 9px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--border);
   border-radius: 2px;
-  color: var(--ink-soft);
+  color: var(--text-secondary);
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -871,18 +905,18 @@ html:has(.sift-landing) {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--ink-faint);
+  background: var(--text-tertiary);
 }
 .sift-landing .sl-chip.sl-src {
-  background: var(--ink);
-  color: var(--paper);
-  border-color: var(--ink);
+  background: var(--text-primary);
+  color: var(--surface-base);
+  border-color: var(--text-primary);
 }
 .sift-landing .sl-card h3.sl-lead {
   font-size: 1.55rem;
   line-height: 1.16;
   margin-bottom: 14px;
-  color: var(--ink);
+  color: var(--text-primary);
   transition: color 0.2s;
 }
 .sift-landing a.sl-lead-link {
@@ -903,16 +937,16 @@ html:has(.sift-landing) {
   font-size: 9.5px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--accent-deep);
+  color: var(--text-accent);
   margin-bottom: 6px;
 }
 .sift-landing .sl-primer p {
   font-size: 13px;
-  color: var(--ink-soft);
+  color: var(--text-secondary);
   line-height: 1.5;
 }
 .sift-landing .sl-notes {
-  border-top: 1px dashed var(--line);
+  border-top: 1px dashed var(--border);
   padding-top: 13px;
   display: flex;
   flex-direction: column;
@@ -922,24 +956,24 @@ html:has(.sift-landing) {
   display: flex;
   gap: 9px;
   font-size: 12px;
-  color: var(--ink-soft);
+  color: var(--text-secondary);
   line-height: 1.45;
 }
 .sift-landing .sl-note .sl-m {
   font-family: var(--font-mono), monospace;
   font-size: 10px;
-  color: var(--accent-deep);
+  color: var(--text-accent);
   flex: none;
   padding-top: 1px;
 }
 .sift-landing .sl-note b {
-  color: var(--ink);
+  color: var(--text-primary);
   font-weight: 600;
   font-family: var(--font-body), sans-serif;
 }
 .sift-landing .sl-card-summary {
   font-size: 13.5px;
-  color: var(--ink-soft);
+  color: var(--text-secondary);
   line-height: 1.55;
 }
 .sift-landing .sl-float-note {
@@ -948,10 +982,10 @@ html:has(.sift-landing) {
   font-size: 10.5px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--ink);
+  color: var(--text-primary);
   background: var(--accent);
   padding: 6px 11px;
-  border: 1px solid var(--ink);
+  border: 1px solid var(--text-primary);
   border-radius: 2px;
   box-shadow: 3px 4px 0 var(--shadow);
   transform: rotate(3deg);
@@ -962,9 +996,9 @@ html:has(.sift-landing) {
 
 /* principle strip */
 .sift-landing .sl-strip {
-  border-top: 1px solid var(--line-soft);
-  border-bottom: 1px solid var(--line-soft);
-  background: var(--paper-2);
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--surface-sunken);
 }
 .sift-landing .sl-strip .sl-strip-inner {
   display: flex;
@@ -975,13 +1009,13 @@ html:has(.sift-landing) {
   font-family: var(--font-mono), monospace;
   font-size: 12px;
   letter-spacing: 0.04em;
-  color: var(--ink-soft);
+  color: var(--text-secondary);
 }
 .sift-landing .sl-strip .sl-sep {
-  color: var(--ink-faint);
+  color: var(--text-tertiary);
 }
 .sift-landing .sl-strip b {
-  color: var(--accent-deep);
+  color: var(--text-accent);
   font-weight: 500;
 }
 
@@ -996,7 +1030,7 @@ html:has(.sift-landing) {
 .sift-landing .sl-sec-head h2 {
   font-size: clamp(2.1rem, 4vw, 3.1rem);
   margin-top: 18px;
-  color: var(--ink);
+  color: var(--text-primary);
 }
 .sift-landing .sl-sec-head h2 .sl-it {
   font-style: italic;
@@ -1004,7 +1038,7 @@ html:has(.sift-landing) {
   color: var(--accent);
 }
 .sift-landing .sl-sec-head p {
-  color: var(--ink-soft);
+  color: var(--text-secondary);
   margin-top: 16px;
   font-size: 1.06rem;
   max-width: 56ch;
@@ -1089,18 +1123,18 @@ html:has(.sift-landing) {
 
 /* what sift adds */
 .sift-landing .sl-adds {
-  background: var(--paper-2);
+  background: var(--surface-sunken);
 }
 .sift-landing .sl-add-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  border: 1px solid var(--ink);
+  border: 1px solid var(--text-primary);
 }
 .sift-landing .sl-add {
   padding: 32px 30px;
-  border-right: 1px solid var(--ink);
-  border-bottom: 1px solid var(--ink);
-  background: var(--paper);
+  border-right: 1px solid var(--text-primary);
+  border-bottom: 1px solid var(--text-primary);
+  background: var(--surface-base);
   transition: background 0.3s, color 0.3s;
 }
 .sift-landing .sl-add:nth-child(2n) {
@@ -1113,21 +1147,21 @@ html:has(.sift-landing) {
   border-bottom: 0;
 }
 .sift-landing .sl-add:hover {
-  background: var(--ink);
-  color: var(--paper);
+  background: var(--text-primary);
+  color: var(--surface-base);
 }
 .sift-landing .sl-add:hover p {
-  color: color-mix(in srgb, var(--paper) 78%, transparent);
+  color: color-mix(in srgb, var(--surface-base) 78%, transparent);
 }
 .sift-landing .sl-add:hover .sl-ai {
   background: var(--accent);
   border-color: var(--accent);
-  color: var(--paper);
+  color: var(--surface-base);
 }
 .sift-landing .sl-add .sl-ai {
   width: 44px;
   height: 44px;
-  border: 1px solid var(--ink);
+  border: 1px solid var(--text-primary);
   border-radius: 4px;
   display: flex;
   align-items: center;
@@ -1142,7 +1176,7 @@ html:has(.sift-landing) {
   margin-bottom: 9px;
 }
 .sift-landing .sl-add p {
-  color: var(--ink-soft);
+  color: var(--text-secondary);
   font-size: 15px;
   line-height: 1.55;
 }
@@ -1151,23 +1185,23 @@ html:has(.sift-landing) {
 .sift-landing .sl-compare .sl-frames {
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--line);
+  border: 1px solid var(--border);
   border-radius: 8px;
   overflow: hidden;
-  background: var(--surface);
+  background: var(--surface-raised);
 }
 .sift-landing .sl-topic {
   padding: 16px 22px;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--border);
   background: var(--surface-2);
   font-family: var(--font-mono), monospace;
   font-size: 11.5px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--ink-soft);
+  color: var(--text-secondary);
 }
 .sift-landing .sl-topic b {
-  color: var(--accent-deep);
+  color: var(--text-accent);
   font-weight: 500;
 }
 .sift-landing .sl-frame {
@@ -1175,7 +1209,7 @@ html:has(.sift-landing) {
   grid-template-columns: 160px 1fr;
   gap: 20px;
   padding: 20px 22px;
-  border-bottom: 1px solid var(--line-soft);
+  border-bottom: 1px solid var(--border-subtle);
   align-items: start;
 }
 .sift-landing .sl-frame:last-child {
@@ -1190,13 +1224,13 @@ html:has(.sift-landing) {
   font-family: var(--font-heading), serif;
   font-weight: 600;
   font-size: 1.05rem;
-  color: var(--ink);
+  color: var(--text-primary);
 }
 .sift-landing .sl-frame .sl-out .sl-ln {
   font-family: var(--font-mono), monospace;
   font-size: 10px;
   letter-spacing: 0.05em;
-  color: var(--ink-faint);
+  color: var(--text-tertiary);
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -1205,26 +1239,26 @@ html:has(.sift-landing) {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--ink-faint);
+  background: var(--text-tertiary);
 }
 .sift-landing .sl-frame q {
   font-family: var(--font-heading), serif;
   font-style: italic;
   font-size: 1.12rem;
   line-height: 1.4;
-  color: var(--ink);
+  color: var(--text-primary);
   quotes: none;
 }
 .sift-landing .sl-compare .sl-note-line {
   margin-top: 18px;
   font-size: 14px;
-  color: var(--ink-soft);
+  color: var(--text-secondary);
   font-style: italic;
 }
 
 /* sources */
 .sift-landing .sl-sources {
-  background: var(--paper-2);
+  background: var(--surface-sunken);
 }
 .sift-landing .sl-src-grid {
   display: grid;
@@ -1237,7 +1271,7 @@ html:has(.sift-landing) {
   font-size: 11px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--ink-faint);
+  color: var(--text-tertiary);
   margin-bottom: 16px;
 }
 .sift-landing .sl-excl {
@@ -1250,7 +1284,7 @@ html:has(.sift-landing) {
   display: flex;
   gap: 12px;
   font-size: 15px;
-  color: var(--ink-soft);
+  color: var(--text-secondary);
   line-height: 1.45;
 }
 .sift-landing .sl-excl li::before {
@@ -1260,7 +1294,7 @@ html:has(.sift-landing) {
   padding-top: 5px;
 }
 .sift-landing .sl-excl li b {
-  color: var(--ink);
+  color: var(--text-primary);
   font-weight: 600;
 }
 .sift-landing .sl-outlets {
@@ -1274,12 +1308,12 @@ html:has(.sift-landing) {
   padding: 2px 0;
   font-family: var(--font-mono), monospace;
   font-size: 12px;
-  color: var(--ink-soft);
+  color: var(--text-secondary);
 }
 
 /* cta band — pinned constant vermillion + light text in BOTH themes (does NOT
    invert). The primary button is a constant dark chip with white text in both
-   themes (previously var(--ink), which flipped to near-white in dark mode and
+   themes (previously var(--text-primary), which flipped to near-white in dark mode and
    hid the white label). */
 .sift-landing .sl-cta {
   background: #e0492a;
@@ -1484,13 +1518,13 @@ html:has(.sift-landing) {
     right: 0;
     flex-direction: column;
     gap: 0;
-    background: var(--paper);
-    border-bottom: 1px solid var(--ink);
+    background: var(--surface-base);
+    border-bottom: 1px solid var(--text-primary);
     padding: 8px 28px 18px;
   }
   .sift-landing .sl-nav-links.sl-open a {
     padding: 14px 0;
-    border-bottom: 1px solid var(--line);
+    border-bottom: 1px solid var(--border);
     width: 100%;
   }
   .sift-landing .sl-add-grid {
@@ -1500,7 +1534,7 @@ html:has(.sift-landing) {
     border-right: 0 !important;
   }
   .sift-landing .sl-add:nth-child(3) {
-    border-bottom: 1px solid var(--ink);
+    border-bottom: 1px solid var(--text-primary);
   }
   .sift-landing .sl-frame {
     grid-template-columns: 1fr;

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -17,11 +17,11 @@ function NewsLoading() {
   return (
     <div
       className="min-h-screen font-body"
-      style={{ background: "var(--bg)", color: "var(--text)" }}
+      style={{ background: "var(--surface-base)", color: "var(--text-primary)" }}
     >
       <header
         className="sticky top-0 z-50 border-b border-(--border)"
-        style={{ background: "var(--nav-bg)", backdropFilter: "blur(20px)", WebkitBackdropFilter: "blur(20px)" }}
+        style={{ background: "var(--surface-overlay)", backdropFilter: "blur(20px)", WebkitBackdropFilter: "blur(20px)" }}
       >
         <div className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-10 py-3.5 h-14" />
       </header>
@@ -30,13 +30,13 @@ function NewsLoading() {
           {[0, 1, 2, 3, 4].map((i) => (
             <div
               key={i}
-              className={`bg-(--card-bg) rounded-[14px] overflow-hidden border border-(--border) ${i === 0 ? "col-span-full" : ""}`}
+              className={`bg-(--surface-raised) rounded-[14px] overflow-hidden border border-(--border) ${i === 0 ? "col-span-full" : ""}`}
             >
-              <div className={`bg-(--skeleton) animate-shimmer ${i === 0 ? "h-[200px]" : "h-[140px]"}`} />
+              <div className={`bg-(--surface-sunken) animate-shimmer ${i === 0 ? "h-[200px]" : "h-[140px]"}`} />
               <div className="p-5 space-y-3">
-                <div className="h-3 w-[30%] bg-(--skeleton) rounded-md animate-shimmer" />
-                <div className="h-4 w-[90%] bg-(--skeleton) rounded-md animate-shimmer" />
-                <div className="h-4 w-[70%] bg-(--skeleton) rounded-md animate-shimmer" />
+                <div className="h-3 w-[30%] bg-(--surface-sunken) rounded-md animate-shimmer" />
+                <div className="h-4 w-[90%] bg-(--surface-sunken) rounded-md animate-shimmer" />
+                <div className="h-4 w-[70%] bg-(--surface-sunken) rounded-md animate-shimmer" />
               </div>
             </div>
           ))}

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -6,7 +6,7 @@ import { COPY } from "@/lib/copy";
 import { timeAgo } from "@/lib/utils";
 import CardImage from "./CardImage";
 import BackgroundPrimer from "./primer/BackgroundPrimer";
-import OutletBadge from "./outlet/OutletBadge";
+import { OutletChip } from "./primitives";
 import EntityLinksList from "./glossary/EntityLinksList";
 import type { ArticleCardProps } from "@/lib/types";
 
@@ -54,7 +54,7 @@ export default function ArticleCard({
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       className={`
-        bg-(--card-bg) rounded-[14px] overflow-hidden
+        bg-(--surface-raised) rounded-[14px] overflow-hidden
         border border-(--border) ${index === 0 ? "animate-fade-slide-in" : ""}
         ${featured && hasImage ? "col-span-full grid grid-cols-1 md:grid-cols-2" : ""}
       `}
@@ -119,7 +119,7 @@ export default function ArticleCard({
               bookmarkAnimating ? "animate-bookmark-pop" : "transition-all duration-200"
             }`}
             style={{
-              color: isBookmarked ? "#f59e0b" : "var(--text-muted)",
+              color: isBookmarked ? "#f59e0b" : "var(--text-tertiary)",
               transform: !bookmarkAnimating && isBookmarked ? "scale(1.15)" : !bookmarkAnimating ? "scale(1)" : undefined,
             }}
           >
@@ -153,7 +153,7 @@ export default function ArticleCard({
               href={article.sourceUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-(--text) no-underline hover:underline"
+              className="text-(--text-primary) no-underline hover:underline"
               style={{
                 // Stretch link to cover entire card
                 position: "static",
@@ -169,7 +169,7 @@ export default function ArticleCard({
               {article.title}
             </a>
           ) : (
-            <span className="text-(--text)">{article.title}</span>
+            <span className="text-(--text-primary)">{article.title}</span>
           )}
         </h3>
 
@@ -219,8 +219,8 @@ export default function ArticleCard({
         <EntityLinksList links={article.entityLinks} />
 
         {/* Meta */}
-        <div className="flex items-center gap-3 mt-auto pt-2 text-xs text-(--text-muted) font-medium flex-wrap">
-          <OutletBadge outlet={article.outlet} fallback={article.sourceName} />
+        <div className="flex items-center gap-3 mt-auto pt-2 text-xs text-(--text-tertiary) font-medium flex-wrap">
+          <OutletChip outlet={article.outlet} fallback={article.sourceName} />
           <span className="opacity-30">&middot;</span>
           <span>{timeAgo(article.publishedDate)}</span>
           <span className="opacity-30">&middot;</span>

--- a/components/CardImage.tsx
+++ b/components/CardImage.tsx
@@ -43,7 +43,7 @@ export default function CardImage({ src, alt, featured, category }: CardImagePro
 
       {/* Shimmer placeholder while loading */}
       {status === "loading" && (
-        <div className="absolute inset-0 bg-(--skeleton) animate-shimmer" />
+        <div className="absolute inset-0 bg-(--surface-sunken) animate-shimmer" />
       )}
 
       {/* Vignette overlay */}

--- a/components/CompareView.tsx
+++ b/components/CompareView.tsx
@@ -101,10 +101,10 @@ export default function CompareView({
               {COPY.compare.emptyTitle}
             </span>
           </div>
-          <h2 className="font-heading text-[22px] font-bold text-(--text) tracking-tight">
+          <h2 className="font-heading text-[22px] font-bold text-(--text-primary) tracking-tight">
             {topic}
           </h2>
-          <div className="flex items-center gap-3 mt-1.5 text-xs text-(--text-muted)">
+          <div className="flex items-center gap-3 mt-1.5 text-xs text-(--text-tertiary)">
             <span>{sourcesChecked.length} sources checked</span>
             <span className="opacity-30">&middot;</span>
             <span>{(durationMs / 1000).toFixed(1)}s</span>
@@ -128,7 +128,7 @@ export default function CompareView({
             key={source}
             className="px-2.5 py-1 rounded-full text-[11px] font-medium"
             style={{
-              background: "var(--card-bg)",
+              background: "var(--surface-raised)",
               border: "1px solid var(--border)",
               color: "var(--text-secondary)",
             }}
@@ -142,11 +142,11 @@ export default function CompareView({
       <div
         className="rounded-[14px] p-6 mb-6"
         style={{
-          background: "var(--card-bg)",
+          background: "var(--surface-raised)",
           border: "1px solid var(--border)",
         }}
       >
-        <h3 className="text-xs font-bold uppercase tracking-widest text-(--text-muted) mb-3">
+        <h3 className="text-xs font-bold uppercase tracking-widest text-(--text-tertiary) mb-3">
           Summary
         </h3>
         <p className="text-[15px] leading-relaxed text-(--text-secondary)">
@@ -156,7 +156,7 @@ export default function CompareView({
 
       {/* Claims */}
       <div className="space-y-3 mb-8">
-        <h3 className="text-xs font-bold uppercase tracking-widest text-(--text-muted) mb-1">
+        <h3 className="text-xs font-bold uppercase tracking-widest text-(--text-tertiary) mb-1">
           Key Claims
         </h3>
         {claims.map((claim, i) => {
@@ -170,7 +170,7 @@ export default function CompareView({
               key={i}
               className="rounded-[12px] p-4 transition-all duration-200"
               style={{
-                background: "var(--card-bg)",
+                background: "var(--surface-raised)",
                 border: "1px solid var(--border)",
                 cursor: hasDetails ? "pointer" : "default",
               }}
@@ -188,12 +188,12 @@ export default function CompareView({
                 >
                   {style.dot} {style.label}
                 </span>
-                <p className="text-sm text-(--text) leading-relaxed flex-1">
+                <p className="text-sm text-(--text-primary) leading-relaxed flex-1">
                   {claim.claim}
                 </p>
                 {hasDetails && (
                   <span
-                    className="text-xs text-(--text-muted) shrink-0 mt-0.5 transition-transform duration-200"
+                    className="text-xs text-(--text-tertiary) shrink-0 mt-0.5 transition-transform duration-200"
                     style={{ transform: isExpanded ? "rotate(90deg)" : "rotate(0deg)" }}
                   >
                     ▸
@@ -231,7 +231,7 @@ export default function CompareView({
 
               {/* Non-disputed source list */}
               {!isDisputed && claim.sources && claim.sources.length > 0 && (
-                <div className="mt-2 ml-[calc(--spacing(2)+(--spacing(0))+1px)] text-[11px] text-(--text-muted)">
+                <div className="mt-2 ml-[calc(--spacing(2)+(--spacing(0))+1px)] text-[11px] text-(--text-tertiary)">
                   {claim.sources.join(", ")}
                 </div>
               )}
@@ -244,11 +244,11 @@ export default function CompareView({
       <div
         className="rounded-[14px] p-5"
         style={{
-          background: "var(--card-bg)",
+          background: "var(--surface-raised)",
           border: "1px solid var(--border)",
         }}
       >
-        <h3 className="text-xs font-bold uppercase tracking-widest text-(--text-muted) mb-3">
+        <h3 className="text-xs font-bold uppercase tracking-widest text-(--text-tertiary) mb-3">
           {COPY.compare.another}
         </h3>
         <form onSubmit={handleSubmit} className="flex items-center gap-2">
@@ -261,9 +261,9 @@ export default function CompareView({
             maxLength={200}
             className="flex-1 px-4 py-2 rounded-full text-sm font-body transition-all duration-200 outline-hidden"
             style={{
-              background: "var(--bg)",
+              background: "var(--surface-base)",
               border: "1px solid var(--border)",
-              color: "var(--text)",
+              color: "var(--text-primary)",
             }}
           />
           <button
@@ -273,7 +273,7 @@ export default function CompareView({
             className="flex items-center justify-center w-9 h-9 rounded-full text-sm cursor-pointer transition-all duration-200 shrink-0"
             style={{
               background: inputValue.trim().length >= 3 && selectedSources.length >= MIN_SOURCES ? "var(--accent)" : "transparent",
-              color: inputValue.trim().length >= 3 && selectedSources.length >= MIN_SOURCES ? "#fff" : "var(--text-muted)",
+              color: inputValue.trim().length >= 3 && selectedSources.length >= MIN_SOURCES ? "#fff" : "var(--text-tertiary)",
               border: `1px solid ${inputValue.trim().length >= 3 && selectedSources.length >= MIN_SOURCES ? "var(--accent)" : "var(--border)"}`,
             }}
           >
@@ -286,7 +286,7 @@ export default function CompareView({
           <button
             type="button"
             onClick={() => setSourcesExpanded(!sourcesExpanded)}
-            className="text-xs text-(--text-muted) cursor-pointer bg-transparent border-none p-0 transition-colors duration-200"
+            className="text-xs text-(--text-tertiary) cursor-pointer bg-transparent border-none p-0 transition-colors duration-200"
             style={{ color: sourcesExpanded ? "var(--accent)" : undefined }}
           >
             Comparing: {selectedLabels} {sourcesExpanded ? "▴" : "▾"}
@@ -307,7 +307,7 @@ export default function CompareView({
                     className="px-2.5 py-1 rounded-full text-[11px] font-medium cursor-pointer transition-all duration-200 border"
                     style={{
                       background: isSelected ? "var(--accent)" : "transparent",
-                      color: isSelected ? "#fff" : disabled ? "var(--text-muted)" : "var(--text-secondary)",
+                      color: isSelected ? "#fff" : disabled ? "var(--text-tertiary)" : "var(--text-secondary)",
                       borderColor: isSelected ? "var(--accent)" : "var(--border)",
                       opacity: disabled ? 0.4 : 1,
                       cursor: disabled ? "not-allowed" : "pointer",
@@ -317,7 +317,7 @@ export default function CompareView({
                   </button>
                 );
               })}
-              <span className="text-[10px] text-(--text-muted) self-center ml-1">
+              <span className="text-[10px] text-(--text-tertiary) self-center ml-1">
                 {selectedSources.length}/{MAX_SOURCES} selected
               </span>
             </div>

--- a/components/CrossSpectrumCompare.tsx
+++ b/components/CrossSpectrumCompare.tsx
@@ -52,7 +52,7 @@ export default function CrossSpectrumCompare({
   return (
     <div className="mt-1">
       <div className="flex items-center gap-3 mb-3">
-        <p className="text-kicker font-bold uppercase text-(--text-muted) shrink-0">
+        <p className="text-kicker font-bold uppercase text-(--text-tertiary) shrink-0">
           {COPY.stories.crossSpectrumHeader}
         </p>
         <span
@@ -86,7 +86,7 @@ function CrossSpectrumColumn({ bucket, framings }: CrossSpectrumColumnProps) {
           Same register as the outer "Across the spectrum" eyebrow but
           tighter, so the column hierarchy reads at a glance. */}
       <div className="flex items-center gap-2 mb-2.5">
-        <span className="text-outlet font-semibold uppercase text-(--text) shrink-0">
+        <span className="text-outlet font-semibold uppercase text-(--text-primary) shrink-0">
           {label}
         </span>
         <span

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -18,7 +18,7 @@ export default function EmptyState({ title, body, action }: EmptyStateProps) {
       <p className="font-heading text-lg font-bold text-(--text-secondary) mb-2">
         {title}
       </p>
-      <p className="text-sm text-(--text-muted) max-w-[360px] mx-auto leading-relaxed mb-5">
+      <p className="text-sm text-(--text-tertiary) max-w-[360px] mx-auto leading-relaxed mb-5">
         {body}
       </p>
       {action && (

--- a/components/ErrorState.tsx
+++ b/components/ErrorState.tsx
@@ -5,7 +5,7 @@ import type { ErrorStateProps } from "@/lib/types";
 
 export default function ErrorState({ message, onRetry }: ErrorStateProps) {
   return (
-    <div className="text-center py-16 px-5 text-(--text-muted)">
+    <div className="text-center py-16 px-5 text-(--text-tertiary)">
       <div className="text-5xl mb-4 opacity-30">⚠</div>
       <p className="text-base font-semibold text-(--text-secondary) mb-2">
         {COPY.error.title}

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -303,15 +303,15 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     <div
       className="min-h-screen font-body"
       style={{
-        background: "var(--bg)",
-        color: "var(--text)",
+        background: "var(--surface-base)",
+        color: "var(--text-primary)",
       }}
     >
       {/* ── Header ──────────────────────────────────── */}
       <header
         className="sticky top-0 z-50 border-b border-(--border)"
         style={{
-          background: "var(--nav-bg)",
+          background: "var(--surface-overlay)",
           backdropFilter: "blur(20px) saturate(180%)",
           WebkitBackdropFilter: "blur(20px) saturate(180%)",
         }}
@@ -419,8 +419,8 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
             {/* Scroll fade indicators for mobile. --nav-bg is rgba(...,0.92) so a
                 gradient from that color is barely visible over the pills. Use the
                 solid --bg color so the fade is unmistakable. */}
-            <div className="absolute left-0 top-0 bottom-0 w-8 z-10 pointer-events-none bg-linear-to-r from-(--bg) to-transparent md:hidden" />
-            <div className="absolute right-0 top-0 bottom-0 w-8 z-10 pointer-events-none bg-linear-to-l from-(--bg) to-transparent md:hidden" />
+            <div className="absolute left-0 top-0 bottom-0 w-8 z-10 pointer-events-none bg-linear-to-r from-(--surface-base) to-transparent md:hidden" />
+            <div className="absolute right-0 top-0 bottom-0 w-8 z-10 pointer-events-none bg-linear-to-l from-(--surface-base) to-transparent md:hidden" />
           <div ref={pillContainerRef} className="px-4 sm:px-6 lg:px-10 pb-3 flex gap-1.5 overflow-x-auto relative scrollbar-none" style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}>
             {CATEGORIES.map((cat) => {
               const active = activeCategory === cat.id && !activeCustomTopic;
@@ -431,8 +431,8 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
                   onClick={() => switchCategory(cat.id)}
                   className="flex items-center gap-1.5 px-4 py-1.5 rounded-full text-[13px] whitespace-nowrap cursor-pointer transition-all duration-200 font-body"
                   style={{
-                    background: active ? "var(--pill-active)" : "transparent",
-                    color: active ? "var(--pill-text)" : "var(--text-muted)",
+                    background: active ? "var(--accent)" : "transparent",
+                    color: active ? "var(--text-on-accent)" : "var(--text-tertiary)",
                     border: "1px solid transparent",
                     fontWeight: active ? 700 : 500,
                   }}
@@ -455,7 +455,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
                   className="flex items-center gap-1.5 px-4 py-1.5 rounded-full text-[13px] whitespace-nowrap cursor-pointer transition-all duration-200 font-body group relative"
                   style={{
                     background: active ? color.hex : "transparent",
-                    color: active ? "#fff" : "var(--text-muted)",
+                    color: active ? "#fff" : "var(--text-tertiary)",
                     border: active ? `1px solid ${color.hex}` : `1px solid rgba(${color.rgb}, 0.25)`,
                     fontWeight: active ? 700 : 500,
                   }}
@@ -481,7 +481,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
                       setPendingRemoval({ topic, timer });
                     }}
                     className="text-[10px] opacity-0 group-hover:opacity-60 transition-opacity duration-150 ml-0.5 cursor-pointer"
-                    style={{ color: active ? "#fff" : "var(--text-muted)" }}
+                    style={{ color: active ? "#fff" : "var(--text-tertiary)" }}
                   >
                     &times;
                   </span>
@@ -497,7 +497,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
                 style={{
                   background: "transparent",
                   border: "1px dashed var(--border)",
-                  color: "var(--text-muted)",
+                  color: "var(--text-tertiary)",
                 }}
                 aria-label="Add custom topic"
               >
@@ -564,9 +564,9 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
                   autoFocus
                   className="w-full px-4 py-2 pr-12 rounded-full text-sm font-body transition-all duration-200 outline-hidden"
                   style={{
-                    background: "var(--card-bg)",
+                    background: "var(--surface-raised)",
                     border: "1px solid var(--border)",
-                    color: "var(--text)",
+                    color: "var(--text-primary)",
                   }}
                 />
                 <button
@@ -576,7 +576,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
                   className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center w-8 h-8 rounded-full text-sm cursor-pointer transition-all duration-200"
                   style={{
                     background: compareInputValue.trim().length >= 3 ? "var(--accent)" : "transparent",
-                    color: compareInputValue.trim().length >= 3 ? "#fff" : "var(--text-muted)",
+                    color: compareInputValue.trim().length >= 3 ? "#fff" : "var(--text-tertiary)",
                   }}
                 >
                   &rarr;
@@ -587,7 +587,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
               <button
                 type="button"
                 onClick={() => setSourcesExpanded(!sourcesExpanded)}
-                className="text-xs text-(--text-muted) cursor-pointer bg-transparent border-none p-0 transition-colors duration-200"
+                className="text-xs text-(--text-tertiary) cursor-pointer bg-transparent border-none p-0 transition-colors duration-200"
                 style={{ color: sourcesExpanded ? "var(--accent)" : undefined }}
               >
                 Comparing: {selectedLabels} {sourcesExpanded ? "▴" : "▾"}
@@ -608,7 +608,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
                         className="px-2.5 py-1 rounded-full text-[11px] font-medium cursor-pointer transition-all duration-200 border"
                         style={{
                           background: isSelected ? "var(--accent)" : "transparent",
-                          color: isSelected ? "#fff" : disabled ? "var(--text-muted)" : "var(--text-secondary)",
+                          color: isSelected ? "#fff" : disabled ? "var(--text-tertiary)" : "var(--text-secondary)",
                           borderColor: isSelected ? "var(--accent)" : "var(--border)",
                           opacity: disabled ? 0.4 : 1,
                           cursor: disabled ? "not-allowed" : "pointer",
@@ -618,7 +618,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
                       </button>
                     );
                   })}
-                  <span className="text-[10px] text-(--text-muted) self-center ml-1">
+                  <span className="text-[10px] text-(--text-tertiary) self-center ml-1">
                     {selectedSources.length}/5
                   </span>
                 </div>
@@ -652,7 +652,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
                   {COPY.compare.loading}
                 </p>
                 {compareSlow && (
-                  <p className="text-sm mt-3 text-(--text-muted) animate-fade-slide-in">
+                  <p className="text-sm mt-3 text-(--text-tertiary) animate-fade-slide-in">
                     {COPY.compare.slow}
                   </p>
                 )}
@@ -702,7 +702,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
             {/* Section header */}
             <div className="flex justify-between items-baseline mb-7">
               <div>
-                <h2 className="font-heading text-[22px] font-bold text-(--text) tracking-tight">
+                <h2 className="font-heading text-[22px] font-bold text-(--text-primary) tracking-tight">
                   {searchMode
                     ? (topicQuery ? COPY.search.resultsFor(topicQuery) : COPY.articles.searchTopics)
                     : showBookmarks
@@ -712,18 +712,18 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
                         : activeCatLabel}
                 </h2>
                 {activeCustomTopic && (
-                  <p className="text-xs mt-1 text-(--text-muted)">
+                  <p className="text-xs mt-1 text-(--text-tertiary)">
                     {activeCustomTopic.description}
                   </p>
                 )}
                 {lastUpdated && !showBookmarks && !searchMode && !customTopicMode && (
-                  <p className="text-xs mt-1" style={{ color: refreshed ? "var(--accent)" : "var(--text-muted)" }}>
+                  <p className="text-xs mt-1" style={{ color: refreshed ? "var(--accent)" : "var(--text-tertiary)" }}>
                     {refreshed ? COPY.articles.updated : `Updated ${timeAgo(lastUpdated.toISOString())}`}
                   </p>
                 )}
               </div>
               {hasData && (
-                <span className="text-xs text-(--text-muted) font-medium">
+                <span className="text-xs text-(--text-tertiary) font-medium">
                   {feedItems.length} item{feedItems.length !== 1 ? "s" : ""}
                 </span>
               )}
@@ -739,7 +739,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
                   ))}
                 </div>
                 {((searchMode || customTopicMode) ? topicSlow : slow) && (
-                  <p className="text-center mt-6 text-sm text-(--text-muted) animate-fade-slide-in">
+                  <p className="text-center mt-6 text-sm text-(--text-tertiary) animate-fade-slide-in">
                     {(searchMode || customTopicMode)
                       ? COPY.loading.slowTopic
                       : COPY.loading.slow}
@@ -834,7 +834,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
 
             {/* Loading toast for refresh */}
             {loading && hasData && (
-              <div role="status" className="fixed bottom-8 left-1/2 -translate-x-1/2 bg-(--card-bg) border border-(--border) rounded-full px-6 py-2.5 text-sm font-semibold text-(--text-secondary) flex items-center gap-2.5 shadow-lg z-50 animate-fade-slide-in">
+              <div role="status" className="fixed bottom-8 left-1/2 -translate-x-1/2 bg-(--surface-raised) border border-(--border) rounded-full px-6 py-2.5 text-sm font-semibold text-(--text-secondary) flex items-center gap-2.5 shadow-lg z-50 animate-fade-slide-in">
                 <span className="animate-sift-refresh inline-block text-(--accent)">◆</span>
                 {COPY.loading.refresh}
               </div>
@@ -842,7 +842,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
 
             {/* Undo toast for topic removal */}
             {pendingRemoval && (
-              <div className="fixed bottom-8 left-1/2 -translate-x-1/2 bg-(--card-bg) border border-(--border) rounded-full px-6 py-2.5 text-sm font-semibold text-(--text-secondary) flex items-center gap-3 shadow-lg z-50 animate-fade-slide-in">
+              <div className="fixed bottom-8 left-1/2 -translate-x-1/2 bg-(--surface-raised) border border-(--border) rounded-full px-6 py-2.5 text-sm font-semibold text-(--text-secondary) flex items-center gap-3 shadow-lg z-50 animate-fade-slide-in">
                 <span>Removed &ldquo;{pendingRemoval.topic.shortLabel}&rdquo;</span>
                 <button
                   onClick={() => {
@@ -876,13 +876,13 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
       )}
 
       {/* ── Footer ──────────────────────────────────── */}
-      <footer className="border-t border-(--border) py-6 px-6 text-center text-xs text-(--text-muted) max-w-[1200px] mx-auto">
+      <footer className="border-t border-(--border) py-6 px-6 text-center text-xs text-(--text-tertiary) max-w-[1200px] mx-auto">
         <SiftLogo variant="full" size={18} />
         <span className="mx-2">&mdash;</span>{COPY.footer.main}
         <div className="mt-2 flex items-center justify-center gap-3">
-          <a href="/privacy" className="text-(--text-muted) no-underline hover:text-(--text-secondary) transition-colors">Privacy</a>
+          <a href="/privacy" className="text-(--text-tertiary) no-underline hover:text-(--text-secondary) transition-colors">Privacy</a>
           <span className="opacity-30">&middot;</span>
-          <a href="/terms" className="text-(--text-muted) no-underline hover:text-(--text-secondary) transition-colors">Terms</a>
+          <a href="/terms" className="text-(--text-tertiary) no-underline hover:text-(--text-secondary) transition-colors">Terms</a>
         </div>
       </footer>
     </div>

--- a/components/SkeletonCard.tsx
+++ b/components/SkeletonCard.tsx
@@ -19,15 +19,15 @@ export default function SkeletonCard({ featured, hasImage = true }: ExtendedSkel
   return (
     <div
       className={`
-        bg-(--card-bg) rounded-[14px] overflow-hidden border border-(--border)
+        bg-(--surface-raised) rounded-[14px] overflow-hidden border border-(--border)
         ${featured && hasImage ? "col-span-full grid grid-cols-1 md:grid-cols-2" : ""}
       `}
-      style={!hasImage ? { borderTop: "3px solid var(--skeleton)" } : undefined}
+      style={!hasImage ? { borderTop: "3px solid var(--surface-sunken)" } : undefined}
     >
       {hasImage && (
         <div
           className={`
-            bg-(--skeleton) animate-shimmer
+            bg-(--surface-sunken) animate-shimmer
             ${featured ? "min-h-[280px]" : "h-[140px]"}
           `}
         />
@@ -36,7 +36,7 @@ export default function SkeletonCard({ featured, hasImage = true }: ExtendedSkel
         {BARS.map((bar, i) => (
           <div
             key={i}
-            className={`${bar.h} ${bar.w} bg-(--skeleton) rounded-md animate-shimmer ${
+            className={`${bar.h} ${bar.w} bg-(--surface-sunken) rounded-md animate-shimmer ${
               i < BARS.length - 1 ? (i === 2 || i === 4 ? "mb-4" : "mb-2.5") : ""
             }`}
             style={{ animationDelay: `${i * 0.1}s` }}

--- a/components/StoryCard.tsx
+++ b/components/StoryCard.tsx
@@ -97,7 +97,7 @@ export default function StoryCard({
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       className={`
-        bg-(--card-bg) rounded-[14px] overflow-hidden
+        bg-(--surface-raised) rounded-[14px] overflow-hidden
         border border-(--border)
         ${featured && hasImage ? "col-span-full grid grid-cols-1 md:grid-cols-2" : ""}
       `}
@@ -170,7 +170,7 @@ export default function StoryCard({
 
         {/* Headline */}
         <h3
-          className={`font-heading font-bold text-(--text) ${
+          className={`font-heading font-bold text-(--text-primary) ${
             featured ? "text-headline-lg" : "text-headline"
           }`}
         >
@@ -198,7 +198,7 @@ export default function StoryCard({
                 key={tag}
                 className="px-2 py-0.5 rounded-full text-[10px] font-medium"
                 style={{
-                  background: "var(--bg)",
+                  background: "var(--surface-base)",
                   color: "var(--text-secondary)",
                   border: "1px solid var(--border)",
                 }}
@@ -207,7 +207,7 @@ export default function StoryCard({
               </span>
             ))}
             {entityTags.length > 6 && (
-              <span className="text-[10px] text-(--text-muted) self-center">
+              <span className="text-[10px] text-(--text-tertiary) self-center">
                 +{entityTags.length - 6}
               </span>
             )}
@@ -230,7 +230,7 @@ export default function StoryCard({
         {isMultiSource && !renderCrossSpectrum && (
           <div className="mt-1">
             <div className="flex items-center gap-3 mb-3">
-              <p className="text-kicker font-bold uppercase text-(--text-muted) shrink-0">
+              <p className="text-kicker font-bold uppercase text-(--text-tertiary) shrink-0">
                 {COPY.stories.framing(uniqueSourceCount)}
               </p>
               <span
@@ -269,7 +269,7 @@ export default function StoryCard({
           ).size;
           if (uniqueSourcesInArticles < 2) return null;
           return (
-            <p className="text-body text-(--text-muted) italic">
+            <p className="text-body text-(--text-tertiary) italic">
               {COPY.stories.analyzingFallback}
             </p>
           );
@@ -300,7 +300,7 @@ export default function StoryCard({
           <div style={{ overflow: "hidden", minHeight: 0 }}>
             {expanded && (
               <div className="mt-3 pt-4 border-t border-(--border)">
-                <p className="text-meta text-(--text-muted) mb-3">
+                <p className="text-meta text-(--text-tertiary) mb-3">
                   {COPY.stories.expandedMeta(timeAgo(story.publishedDate), story.articles.length)}
                 </p>
                 <div
@@ -334,7 +334,7 @@ export default function StoryCard({
                           className="story-row__source shrink-0 min-w-[88px]"
                         />
                         <span
-                          className="text-body text-(--text) flex-1"
+                          className="text-body text-(--text-primary) flex-1"
                           style={{
                             display: "-webkit-box",
                             WebkitLineClamp: 2,
@@ -344,7 +344,7 @@ export default function StoryCard({
                         >
                           {article.title}
                         </span>
-                        <span className="text-meta text-(--text-muted) shrink-0">
+                        <span className="text-meta text-(--text-tertiary) shrink-0">
                           {timeAgo(article.publishedDate)}
                         </span>
                         {onCompare && (
@@ -370,7 +370,7 @@ export default function StoryCard({
         </div>
 
         {/* Meta row */}
-        <div className="flex items-center gap-3 mt-auto pt-2 text-xs text-(--text-muted) font-medium">
+        <div className="flex items-center gap-3 mt-auto pt-2 text-xs text-(--text-tertiary) font-medium">
           <span>{timeAgo(story.publishedDate)}</span>
           <span className="opacity-30">&middot;</span>
           <span>{story.articleCount} article{story.articleCount !== 1 ? "s" : ""}</span>

--- a/components/TopicModal.tsx
+++ b/components/TopicModal.tsx
@@ -127,16 +127,16 @@ export default function TopicModal({ onClose, onAdd, existingTopics, colorIndex 
       <div
         ref={dialogRef}
         className="w-full max-w-[460px] rounded-2xl border border-(--border) overflow-hidden animate-fade-slide-in"
-        style={{ background: "var(--card-bg)" }}
+        style={{ background: "var(--surface-raised)" }}
       >
         {/* Header */}
         <div className="px-6 pt-6 pb-4 flex items-center justify-between">
-          <h2 id="topic-modal-title" className="font-heading text-lg font-bold text-(--text)">
+          <h2 id="topic-modal-title" className="font-heading text-lg font-bold text-(--text-primary)">
             {step === "preview" ? COPY.topics.previewTitle : COPY.topics.modalTitle}
           </h2>
           <button
             onClick={onClose}
-            className="bg-transparent border-none text-(--text-muted) text-xl cursor-pointer p-1 transition-colors duration-200"
+            className="bg-transparent border-none text-(--text-tertiary) text-xl cursor-pointer p-1 transition-colors duration-200"
             aria-label="Close"
           >
             &times;
@@ -160,9 +160,9 @@ export default function TopicModal({ onClose, onAdd, existingTopics, colorIndex 
                 disabled={step === "generating"}
                 className="w-full px-4 py-3 rounded-xl text-sm font-body transition-all duration-200 outline-hidden"
                 style={{
-                  background: "var(--bg)",
+                  background: "var(--surface-base)",
                   border: "1px solid var(--border)",
-                  color: "var(--text)",
+                  color: "var(--text-primary)",
                   opacity: step === "generating" ? 0.6 : 1,
                 }}
               />
@@ -174,7 +174,7 @@ export default function TopicModal({ onClose, onAdd, existingTopics, colorIndex 
                   <span className="animate-sift-refresh inline-block text-sm" style={{ color: color.hex }}>
                     &#x25C6;
                   </span>
-                  <span className="text-xs text-(--text-muted)">
+                  <span className="text-xs text-(--text-tertiary)">
                     {COPY.topics.generating}
                   </span>
                 </div>
@@ -186,7 +186,7 @@ export default function TopicModal({ onClose, onAdd, existingTopics, colorIndex 
                   className="mt-3 w-full py-2.5 rounded-xl text-sm font-semibold cursor-pointer transition-all duration-200 border-none"
                   style={{
                     background: inputValue.trim().length >= 2 ? color.hex : "var(--border)",
-                    color: inputValue.trim().length >= 2 ? "#fff" : "var(--text-muted)",
+                    color: inputValue.trim().length >= 2 ? "#fff" : "var(--text-tertiary)",
                     cursor: inputValue.trim().length >= 2 ? "pointer" : "not-allowed",
                   }}
                 >
@@ -208,14 +208,14 @@ export default function TopicModal({ onClose, onAdd, existingTopics, colorIndex 
                   {preview.icon}
                 </span>
                 <div>
-                  <p className="font-bold text-(--text)">{preview.shortLabel}</p>
-                  <p className="text-xs text-(--text-muted)">{preview.description}</p>
+                  <p className="font-bold text-(--text-primary)">{preview.shortLabel}</p>
+                  <p className="text-xs text-(--text-tertiary)">{preview.description}</p>
                 </div>
               </div>
 
               {/* Search queries */}
               <div>
-                <p className="text-[10px] font-bold uppercase tracking-widest text-(--text-muted) mb-2">
+                <p className="text-[10px] font-bold uppercase tracking-widest text-(--text-tertiary) mb-2">
                   {COPY.topics.previewQueries}
                 </p>
                 <div className="flex flex-wrap gap-1.5">

--- a/components/TopicSearch.tsx
+++ b/components/TopicSearch.tsx
@@ -57,9 +57,9 @@ export default function TopicSearch({
             maxLength={200}
             className="w-full px-4 py-2 pr-12 rounded-full text-sm font-body transition-all duration-200 outline-hidden"
             style={{
-              background: "var(--card-bg)",
+              background: "var(--surface-raised)",
               border: "1px solid var(--border)",
-              color: "var(--text)",
+              color: "var(--text-primary)",
             }}
           />
           <button
@@ -71,7 +71,7 @@ export default function TopicSearch({
               background:
                 inputValue.trim().length >= 2 ? "var(--accent)" : "transparent",
               color:
-                inputValue.trim().length >= 2 ? "#fff" : "var(--text-muted)",
+                inputValue.trim().length >= 2 ? "#fff" : "var(--text-tertiary)",
               opacity: loading ? 0.5 : 1,
               cursor: loading ? "wait" : "pointer",
             }}
@@ -86,7 +86,7 @@ export default function TopicSearch({
       </form>
 
       {matchQuality && (
-        <div className="flex items-center gap-3 mt-2 ml-11 text-xs text-(--text-muted) animate-fade-slide-in">
+        <div className="flex items-center gap-3 mt-2 ml-11 text-xs text-(--text-tertiary) animate-fade-slide-in">
           {resultCount > 0 ? (
             <span
               className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full font-semibold uppercase tracking-wide"
@@ -107,12 +107,12 @@ export default function TopicSearch({
               {matchQuality === "strong" ? "●" : "○"} {matchQuality} match
             </span>
           ) : (
-            <span className="text-(--text-muted)">
+            <span className="text-(--text-tertiary)">
               {COPY.search.noResults}
             </span>
           )}
           {fallbackUsed && (
-            <span className="text-(--text-muted) italic">
+            <span className="text-(--text-tertiary) italic">
               {resultCount === 0
                 ? COPY.search.fallbackSearching
                 : COPY.search.fallbackUsed}

--- a/components/glossary/EntityChipTooltip.tsx
+++ b/components/glossary/EntityChipTooltip.tsx
@@ -34,9 +34,9 @@ export default function EntityChipTooltip({ context }: EntityChipTooltipProps) {
       role="tooltip"
       // The presentational layer. Hidden by default, revealed when the
       // wrapping <li class="group"> is hovered or contains focus.
-      className="invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 transition-opacity duration-150 pointer-events-none absolute bottom-[calc(100%+6px)] left-0 z-20 w-[300px] max-w-[calc(100vw-2rem)] bg-(--card-bg) border border-(--border) rounded-md shadow-lg p-3 text-left"
+      className="invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 transition-opacity duration-150 pointer-events-none absolute bottom-[calc(100%+6px)] left-0 z-20 w-[300px] max-w-[calc(100vw-2rem)] bg-(--surface-raised) border border-(--border) rounded-md shadow-lg p-3 text-left"
     >
-      <p className="text-kicker font-bold uppercase text-(--text-muted) mb-2 leading-tight">
+      <p className="text-kicker font-bold uppercase text-(--text-tertiary) mb-2 leading-tight">
         {COPY.glossary.tooltip.politicianTopIndustries}
       </p>
       {topIndustries.length === 0 ? (
@@ -54,7 +54,7 @@ export default function EntityChipTooltip({ context }: EntityChipTooltipProps) {
                 {entry.industry}
               </span>
               {entry.amount_usd != null && (
-                <span className="font-mono text-[11px] tabular-nums text-(--text-muted)">
+                <span className="font-mono text-[11px] tabular-nums text-(--text-tertiary)">
                   {formatUsdCompact(entry.amount_usd)}
                 </span>
               )}
@@ -62,7 +62,7 @@ export default function EntityChipTooltip({ context }: EntityChipTooltipProps) {
           ))}
         </ul>
       )}
-      <p className="text-outlet uppercase tracking-wider text-(--text-muted) mt-2 pt-2 border-t border-(--border-subtle)">
+      <p className="text-outlet uppercase tracking-wider text-(--text-tertiary) mt-2 pt-2 border-t border-(--border-subtle)">
         {COPY.glossary.tooltip.openDossierHint}
       </p>
     </span>

--- a/components/glossary/EntityLinksList.tsx
+++ b/components/glossary/EntityLinksList.tsx
@@ -41,7 +41,7 @@ export default function EntityLinksList({ links }: EntityLinksListProps) {
     >
       <p
         id="entity-list-eyebrow"
-        className="text-kicker font-bold uppercase text-(--text-muted)"
+        className="text-kicker font-bold uppercase text-(--text-tertiary)"
       >
         {COPY.glossary.eyebrow}
       </p>
@@ -67,12 +67,12 @@ export default function EntityLinksList({ links }: EntityLinksListProps) {
                 // 22-24px the chip had originally. Side padding bumped from
                 // px-2 to px-2.5 for the same reason. Visual weight stays
                 // small enough to read as a "chip" not a "button."
-                className="inline-flex items-center gap-1.5 px-2.5 py-1.5 sm:py-0.5 rounded-full text-[12px] leading-none no-underline transition-colors duration-200 relative z-2 border border-(--border) text-(--text-secondary) bg-(--card-bg) hover:border-(--accent) hover:text-(--accent)"
+                className="inline-flex items-center gap-1.5 px-2.5 py-1.5 sm:py-0.5 rounded-full text-[12px] leading-none no-underline transition-colors duration-200 relative z-2 border border-(--border) text-(--text-secondary) bg-(--surface-raised) hover:border-(--accent) hover:text-(--accent)"
               >
                 {glyph && (
                   <span
                     aria-hidden
-                    className="font-mono text-[10px] text-(--text-muted)"
+                    className="font-mono text-[10px] text-(--text-tertiary)"
                   >
                     {glyph}
                   </span>

--- a/components/outlet/OutletBadge.tsx
+++ b/components/outlet/OutletBadge.tsx
@@ -54,7 +54,7 @@ export default function OutletBadge({
     if (isRail) {
       return (
         <span
-          className={`text-outlet font-semibold uppercase text-(--text) ${className ?? ""}`}
+          className={`text-outlet font-semibold uppercase text-(--text-primary) ${className ?? ""}`}
         >
           {fallback}
         </span>
@@ -79,7 +79,7 @@ export default function OutletBadge({
           href={`/outlet/${outlet.slug}`}
           onClick={(e) => e.stopPropagation()}
           aria-label={`Outlet dossier for ${outlet.name}`}
-          className="text-outlet font-semibold uppercase text-(--text) no-underline hover:underline relative z-2"
+          className="text-outlet font-semibold uppercase text-(--text-primary) no-underline hover:underline relative z-2"
         >
           {outlet.name}
         </a>
@@ -98,7 +98,7 @@ export default function OutletBadge({
         href={`/outlet/${outlet.slug}`}
         onClick={(e) => e.stopPropagation()}
         aria-label={`Outlet dossier for ${outlet.name}`}
-        className="font-bold text-(--text-secondary) no-underline hover:underline hover:text-(--text) relative z-2"
+        className="font-bold text-(--text-secondary) no-underline hover:underline hover:text-(--text-primary) relative z-2"
       >
         {outlet.name}
       </a>
@@ -109,7 +109,7 @@ export default function OutletBadge({
           rel={outlet.allSidesUrl ? "noopener noreferrer" : undefined}
           onClick={(e) => e.stopPropagation()}
           aria-label={`AllSides bias rating: ${allSides}${outlet.allSidesUrl ? " (opens AllSides in a new tab)" : ""}`}
-          className="font-mono text-[10px] uppercase tracking-wider text-(--text-muted) no-underline hover:text-(--text-secondary) hover:underline relative z-2 whitespace-nowrap"
+          className="font-mono text-[10px] uppercase tracking-wider text-(--text-tertiary) no-underline hover:text-(--text-secondary) hover:underline relative z-2 whitespace-nowrap"
         >
           {allSides}
         </a>

--- a/components/primer/BackgroundPrimer.tsx
+++ b/components/primer/BackgroundPrimer.tsx
@@ -88,11 +88,11 @@ export default function BackgroundPrimer({
           type="button"
           onClick={handleExpand}
           aria-expanded={false}
-          className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-bold tracking-[0.04em] uppercase border border-(--border) bg-transparent text-(--text-secondary) hover:text-(--text) hover:border-(--text-muted) transition-colors duration-200 cursor-pointer"
+          className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-bold tracking-[0.04em] uppercase border border-(--border) bg-transparent text-(--text-secondary) hover:text-(--text-primary) hover:border-(--text-tertiary) transition-colors duration-200 cursor-pointer"
         >
           <span aria-hidden>◆</span>
           <span>{COPY.primer.eyebrow}</span>
-          <span aria-hidden className="text-(--text-muted)">▾</span>
+          <span aria-hidden className="text-(--text-tertiary)">▾</span>
         </button>
       )}
 
@@ -108,7 +108,7 @@ export default function BackgroundPrimer({
         >
           {/* Eyebrow + collapse */}
           <div className="flex items-center justify-between gap-3 mb-2.5">
-            <p className="text-kicker font-bold uppercase text-(--text-muted)">
+            <p className="text-kicker font-bold uppercase text-(--text-tertiary)">
               <span aria-hidden className="mr-1.5">◆</span>
               {COPY.primer.eyebrow}
             </p>
@@ -119,7 +119,7 @@ export default function BackgroundPrimer({
                 setExpanded(false);
               }}
               aria-expanded={true}
-              className="text-meta uppercase tracking-wider text-(--text-secondary) hover:text-(--text) cursor-pointer transition-colors duration-200 bg-transparent border-none p-0"
+              className="text-meta uppercase tracking-wider text-(--text-secondary) hover:text-(--text-primary) cursor-pointer transition-colors duration-200 bg-transparent border-none p-0"
             >
               {COPY.primer.hide} <span aria-hidden>▴</span>
             </button>
@@ -171,7 +171,7 @@ export default function BackgroundPrimer({
 function PrimerTermLabel({ term }: { term: ContextPrimerTerm }) {
   if (!term.link) {
     return (
-      <dt className="inline font-semibold text-(--text)">{term.term}</dt>
+      <dt className="inline font-semibold text-(--text-primary)">{term.term}</dt>
     );
   }
   // Reuse the shared dossier-routing helper so primer-term links + chip
@@ -187,7 +187,7 @@ function PrimerTermLabel({ term }: { term: ContextPrimerTerm }) {
         href={href}
         onClick={(e) => e.stopPropagation()}
         aria-label={`Open dossier for ${term.term}`}
-        className="font-semibold text-(--text) no-underline border-b border-dotted border-(--accent) hover:text-(--accent) hover:border-solid transition-colors"
+        className="font-semibold text-(--text-primary) no-underline border-b border-dotted border-(--accent) hover:text-(--accent) hover:border-solid transition-colors"
       >
         {term.term}
       </Link>

--- a/components/primitives/FactualChip.tsx
+++ b/components/primitives/FactualChip.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { formatMbfcLabel } from "@/lib/outlet";
+import type { OutletMbfcRating } from "@/lib/types";
+
+/**
+ * MBFC factual-reporting tier as a NEUTRAL fill-level meter + cited label.
+ *
+ * Per sign-off (SIFT_THEME_MIGRATION.md §3): the factual tier is encoded
+ * tonally/neutrally — a fill-level meter in neutral ink, NOT green-good /
+ * red-bad — to stay consistent with Sift's symmetric-citation ethos. Cites +
+ * links MBFC and shows the last-verified date.
+ */
+const LEVEL: Record<OutletMbfcRating, number> = {
+  "very-high": 6,
+  high: 5,
+  "mostly-factual": 4,
+  mixed: 3,
+  low: 2,
+  "very-low": 1,
+};
+
+interface FactualChipProps {
+  rating: OutletMbfcRating | null | undefined;
+  url?: string | null;
+  lastChecked?: string | null;
+  className?: string;
+}
+
+export default function FactualChip({
+  rating,
+  url,
+  lastChecked,
+  className = "",
+}: FactualChipProps) {
+  const label = formatMbfcLabel(rating);
+  if (!rating || !label) return null;
+  const level = LEVEL[rating];
+
+  const body = (
+    <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-wider text-[var(--text-tertiary)]">
+      MBFC: {label}
+      <span aria-hidden className="inline-flex items-center gap-[2px] align-middle">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <span
+            key={i}
+            className="inline-block w-[3px] h-[9px] rounded-[1px]"
+            style={{
+              background:
+                i <= level ? "var(--text-secondary)" : "var(--border-strong)",
+            }}
+          />
+        ))}
+      </span>
+    </span>
+  );
+
+  if (!url) return <span className={className}>{body}</span>;
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(e) => e.stopPropagation()}
+      aria-label={`MBFC factual reporting: ${label}${lastChecked ? `, verified ${lastChecked}` : ""} (opens MBFC in a new tab)`}
+      className={`no-underline hover:text-[var(--text-secondary)] relative z-[2] ${className}`}
+    >
+      {body}
+    </a>
+  );
+}

--- a/components/primitives/LeanGlyph.tsx
+++ b/components/primitives/LeanGlyph.tsx
@@ -1,0 +1,51 @@
+import { formatAllSidesLabel } from "@/lib/outlet";
+import type { OutletAllSidesRating } from "@/lib/types";
+
+/**
+ * AllSides political lean as a 5-tick position indicator in NEUTRAL ink.
+ *
+ * Brand-critical rule (SIFT_THEME_MIGRATION.md §3): lean is NEVER hue-coded —
+ * Left and Right render identically. Differentiate by POSITION (which tick is
+ * filled), not color. "mixed" has no single position, so no tick is filled.
+ */
+const POSITION: Record<OutletAllSidesRating, number | null> = {
+  left: 0,
+  "lean-left": 1,
+  center: 2,
+  "lean-right": 3,
+  right: 4,
+  mixed: null,
+};
+
+interface LeanGlyphProps {
+  rating: OutletAllSidesRating | null | undefined;
+  className?: string;
+}
+
+export default function LeanGlyph({ rating, className = "" }: LeanGlyphProps) {
+  if (!rating) return null;
+  const label = formatAllSidesLabel(rating);
+  const pos = POSITION[rating];
+
+  return (
+    <span
+      className={`inline-flex items-center gap-[3px] align-middle ${className}`}
+      role="img"
+      aria-label={`AllSides lean: ${label}`}
+    >
+      {[0, 1, 2, 3, 4].map((i) => (
+        <span
+          key={i}
+          aria-hidden
+          className="inline-block w-[3px] h-[10px] rounded-[1px]"
+          // Neutral ink only: filled tick = secondary text, empty = strong
+          // border. No red/blue, ever.
+          style={{
+            background:
+              i === pos ? "var(--text-secondary)" : "var(--border-strong)",
+          }}
+        />
+      ))}
+    </span>
+  );
+}

--- a/components/primitives/OutletChip.tsx
+++ b/components/primitives/OutletChip.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { formatAllSidesLabel } from "@/lib/outlet";
+import type { OutletProfile } from "@/lib/types";
+import LeanGlyph from "./LeanGlyph";
+import FactualChip from "./FactualChip";
+
+/**
+ * One neutral, sourced outlet rating treatment shared by the reader, the
+ * comparison view, and every dossier (§3). Outlet name links to the Sift
+ * dossier; the AllSides lean (neutral LeanGlyph + label) links to AllSides;
+ * the MBFC factual tier (FactualChip) links to MBFC. Nothing is hue-coded by
+ * political lean. Falls back to plain neutral text when no curated outlet
+ * matches (graceful degradation).
+ */
+interface OutletChipProps {
+  outlet?: OutletProfile | null;
+  /** Plain source-name used when no curated outlet matches. */
+  fallback: string;
+  /** Show the last-verified date captions (dossier context). Default: false. */
+  showVerified?: boolean;
+  className?: string;
+}
+
+export default function OutletChip({
+  outlet,
+  fallback,
+  showVerified = false,
+  className = "",
+}: OutletChipProps) {
+  if (!outlet) {
+    return (
+      <span className={`font-bold text-[var(--text-secondary)] ${className}`}>
+        {fallback}
+      </span>
+    );
+  }
+
+  const allSides = formatAllSidesLabel(outlet.allSidesRating);
+
+  return (
+    <span className={`inline-flex items-center gap-2 flex-wrap ${className}`}>
+      <a
+        href={`/outlet/${outlet.slug}`}
+        onClick={(e) => e.stopPropagation()}
+        aria-label={`Outlet dossier for ${outlet.name}`}
+        className="font-bold text-[var(--text-secondary)] no-underline hover:text-[var(--text-primary)] hover:underline relative z-[2]"
+      >
+        {outlet.name}
+      </a>
+
+      {outlet.allSidesRating && allSides && (
+        <a
+          href={outlet.allSidesUrl ?? `/outlet/${outlet.slug}`}
+          target={outlet.allSidesUrl ? "_blank" : undefined}
+          rel={outlet.allSidesUrl ? "noopener noreferrer" : undefined}
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`AllSides bias rating: ${allSides}${outlet.allSidesLastChecked ? `, verified ${outlet.allSidesLastChecked}` : ""}${outlet.allSidesUrl ? " (opens AllSides in a new tab)" : ""}`}
+          className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-wider text-[var(--text-tertiary)] no-underline hover:text-[var(--text-secondary)] relative z-[2] whitespace-nowrap"
+        >
+          <LeanGlyph rating={outlet.allSidesRating} />
+          {allSides}
+        </a>
+      )}
+
+      <FactualChip
+        rating={outlet.mbfcFactual}
+        url={outlet.mbfcUrl}
+        lastChecked={outlet.mbfcLastChecked}
+      />
+
+      {showVerified && (outlet.allSidesLastChecked || outlet.mbfcLastChecked) && (
+        <span className="font-mono text-[9.5px] uppercase tracking-wider text-[var(--text-tertiary)] w-full">
+          Ratings cited from AllSides &amp; MBFC
+          {outlet.mbfcLastChecked
+            ? ` · verified ${outlet.mbfcLastChecked}`
+            : outlet.allSidesLastChecked
+              ? ` · verified ${outlet.allSidesLastChecked}`
+              : ""}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/components/primitives/PartyTag.tsx
+++ b/components/primitives/PartyTag.tsx
@@ -1,0 +1,30 @@
+/**
+ * Party tag (R / D / I) in NEUTRAL ink — never red/blue (§3). Differentiated
+ * by letter, not color. Same treatment for every party, symmetrically.
+ */
+const PARTY_LABEL: Record<string, string> = {
+  R: "Republican",
+  D: "Democrat",
+  I: "Independent",
+};
+
+interface PartyTagProps {
+  party: string | null | undefined;
+  className?: string;
+}
+
+export default function PartyTag({ party, className = "" }: PartyTagProps) {
+  if (!party) return null;
+  const code = party.trim().charAt(0).toUpperCase();
+  const full = PARTY_LABEL[code] ?? party;
+
+  return (
+    <span
+      className={`inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-[3px] border border-[var(--border)] bg-[var(--surface-sunken)] font-mono text-[10px] font-medium text-[var(--text-secondary)] ${className}`}
+      title={full}
+      aria-label={full}
+    >
+      {code}
+    </span>
+  );
+}

--- a/components/primitives/index.ts
+++ b/components/primitives/index.ts
@@ -1,0 +1,7 @@
+// Neutral, sourced rating primitives (SIFT_THEME_MIGRATION.md §3). Shared by
+// the reader, the comparison view, and every dossier so lean/factual/party
+// render one way everywhere — neutral ink, cited, never hue-coded by politics.
+export { default as OutletChip } from "./OutletChip";
+export { default as LeanGlyph } from "./LeanGlyph";
+export { default as FactualChip } from "./FactualChip";
+export { default as PartyTag } from "./PartyTag";


### PR DESCRIPTION
Tracks the Phase 2 theme migration (SIFT_THEME_MIGRATION.md). **Draft — sub-phased; pause for review after each.**

## Review log
- **2a — homepage visual review PASSED** ✅ (light + dark) — confirmed by the owner before 2b began.
- **2b — implemented (this push), pending visual review.**

## 2a — tokens + primitives (merged into this branch)
- Global editorial semantic token layer (both themes) promoted from the homepage reskin's `.sift-landing` scope into `:root`/`[data-theme]`. Homepage repointed with zero visual change (value-identical) — **verified visually, passed**.
- §3 neutral primitives: `LeanGlyph` (5-tick position, no color), `FactualChip` (neutral fill-level + MBFC cite), `PartyTag` (neutral letter), `OutletChip`. Neutrality test asserts position-not-color + a partisan-color guard.

## 2b — `/news` reader (this push)
- Migrated the reader surfaces (NewsAggregator, ArticleCard, StoryCard, CompareView, CrossSpectrumCompare, TopicSearch, TopicModal, SkeletonCard, Empty/ErrorState, BackgroundPrimer, EntityLinks, OutletBadge, CardImage, auth) onto the editorial tokens — both themes. Warm dark (`#15120C`, not pure black) preserved for long reading.
- `OutletChip` wired into the article-card footer (neutral lean glyph + AllSides cite + MBFC factual tier); compact `OutletBadge` rail kept in StoryCard / cross-spectrum compare. **No partisan color** on lean/party/factual.

### Please verify on the preview (2b pause)
- `/news` **light** mode
- `/news` **dark** mode
- article cards
- story cards (expanded)
- source/outlet chips (lean glyph + factual neutral, cited)
- compare / search affordances
- loading / error / empty states

## Known transitional state (on-branch only)
Dossiers, civic index, methodology, colophon, legal still run the legacy stone/indigo bg (`--bg`/`--text`) with editorial accents/borders on top — migrated in **2c–2d**; stone/indigo **deleted in 2d**. (`OutletBadge` is shared with the outlet dossier, so its text already reads editorial there — transitional until 2c.)

## Verify (CI parity)
- `tsc --noEmit` ✓ · `npm test --ci --coverage` **329/329** ✓ · `npm run build` ✓

## Next
2c civic + dossiers → 2d methodology/colophon/legal + delete stone/indigo → 2e QA (AA contrast both themes + neutrality audit). Pausing after 2b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Tailwind v4 compatibility pass (post-2b)

The v3→v4 migration (#142) introduced a `/news` spacing regression: the app's universal reset `* { margin:0; padding:0 }` was **unlayered**, and under v4's native cascade layers an unlayered declaration overrides every layered utility regardless of specificity — silently killing every `p-*` / `m-*` / `mt-auto` / `space-y-*` / `mx-auto` utility (collapsed card padding, page gutters, container centering). The homepage was unaffected because it's hand-written `.sl-*` CSS rather than Tailwind spacing utilities, which is why only `/news` (and the centered dossier/legal columns) looked off.

**Fix — `app/globals.css` only:**
- Moved the universal reset into `@layer base` — still zeroes UA defaults, but now loses to `@layer utilities`, restoring v3 behavior.
- Added the documented v4 button-cursor compat rule (`@layer base`) for third-party buttons (e.g. Clerk) lacking an explicit `cursor-pointer`.
- No editorial-token or reader-migration changes.

**Verified:** `tsc` · `build` (22 routes) · 329 tests. Compiled CSS confirms the reset is in `@layer base` and `.p-5`/`.pt-2`/`.mt-auto`/`.space-y-3` in `@layer utilities` (layer order `…base, utilities` → utilities win). `/news` light + dark visually rechecked; transitional surfaces (`/civic`, dossiers, `/methodology`, `/privacy`) smoke-checked as transitional-but-acceptable.
