### PR TITLE
fix: derive outlet-count copy from live outlet data

### DIFF
--- a/__tests__/SourceColophon.test.tsx
+++ b/__tests__/SourceColophon.test.tsx
@@ -21,6 +21,8 @@ describe("SourceColophon", () => {
     // Section eyebrow + exclusions list always render.
     expect(screen.getByText(S.eyebrow)).toBeInTheDocument();
     expect(screen.getByText(S.exclusionsLabel)).toBeInTheDocument();
+    // Heading carries the LIVE count of the outlets passed in (issue #153).
+    expect(screen.getByText("3 curated outlets.")).toBeInTheDocument();
   });
 
   it("does not bake in a hardcoded source list — only renders provided outlets", () => {
@@ -42,6 +44,8 @@ describe("SourceColophon", () => {
     expect(screen.getByText(S.eyebrow)).toBeInTheDocument();
     expect(screen.getByText(S.exclusionsLabel)).toBeInTheDocument();
     expect(screen.getByText(S.methodologyCta)).toBeInTheDocument();
+    // ...the heading falls back to count-free copy (never "0 outlets")...
+    expect(screen.getByText("Curated outlets.")).toBeInTheDocument();
     // ...and the live outlet list is omitted entirely (no stale names).
     expect(container.querySelector("ul.sl-outlets")).toBeNull();
   });

--- a/__tests__/copy.test.ts
+++ b/__tests__/copy.test.ts
@@ -73,7 +73,7 @@ describe("COPY strings", () => {
     });
 
     it("has footer text", () => {
-      expect(COPY.footer.main).toBeTruthy();
+      expect(COPY.footer.main()).toBeTruthy();
     });
 
     it("has error strings", () => {
@@ -107,6 +107,70 @@ describe("COPY strings", () => {
     it("has bookmark strings", () => {
       expect(COPY.bookmarks.title).toBeTruthy();
       expect(COPY.bookmarks.emptyTitle).toBeTruthy();
+    });
+  });
+
+  describe("dynamic outlet-count copy (issue #153)", () => {
+    const R = COPY.landingReskin;
+
+    it("renders the live count as 'N curated outlets'", () => {
+      expect(R.hero.foot(77)).toContain("77 curated outlets");
+      expect(R.strip(77)[0]).toBe("77 curated outlets");
+      expect(R.sources.titleIt(77)).toBe("77 curated outlets.");
+      expect(R.cta.body(77)).toContain("77 curated outlets");
+      expect(R.hero.lede(77)).toContain("77 outlets");
+      expect(COPY.methodology.sections.includes.body(77)).toContain(
+        "77 curated outlets",
+      );
+    });
+
+    it("drops the number on a DB miss (n<=0) — never prints '0'", () => {
+      const fallbacks = [
+        R.hero.foot(0),
+        R.strip(0)[0],
+        R.sources.titleIt(0),
+        R.cta.body(0),
+        R.hero.lede(0),
+        R.footer.blurb(0),
+        COPY.footer.main(),
+        COPY.methodology.sections.includes.body(0),
+      ];
+      for (const s of fallbacks) {
+        expect(s).not.toMatch(/\b0\b/);
+        expect(s.toLowerCase()).toContain("outlets");
+      }
+    });
+
+    it("no surface hardcodes the stale '~50 outlets' or 'reads from'", () => {
+      const all = [
+        R.hero.lede(77),
+        R.hero.foot(77),
+        R.strip(77).join(" "),
+        R.sources.titleIt(77),
+        R.cta.body(77),
+        R.footer.blurb(77),
+        COPY.footer.main(77),
+        COPY.methodology.sections.includes.body(77),
+      ].join(" | ");
+      expect(all).not.toMatch(/~?50\s+(vetted\s+)?outlets/);
+      expect(all).not.toContain("reads from");
+    });
+
+    it("the /news footer and the landing footer share one builder", () => {
+      expect(COPY.footer.main(77)).toBe(R.footer.blurb(77));
+      // /news renders it count-free (hot path, no outlet fetch).
+      expect(COPY.footer.main()).toContain("curates outlets");
+    });
+
+    it("manifesto spectrum reflects live bucket counts", () => {
+      expect(
+        R.manifesto.spectrum({ left: 22, center: 24, right: 11, specialty: 20 }),
+      ).toEqual([
+        { label: "Left", count: 22 },
+        { label: "Center", count: 24 },
+        { label: "Right", count: 11 },
+        { label: "Specialty", count: 20 },
+      ]);
     });
   });
 });

--- a/__tests__/outletStats.test.ts
+++ b/__tests__/outletStats.test.ts
@@ -1,0 +1,38 @@
+import { computeOutletStats, EMPTY_OUTLET_STATS } from "@/lib/outletStats";
+
+describe("computeOutletStats", () => {
+  it("buckets ratings into L/C/R, folding lean-left / lean-right", () => {
+    expect(
+      computeOutletStats([
+        { allSidesRating: "left" },
+        { allSidesRating: "lean-left" },
+        { allSidesRating: "center" },
+        { allSidesRating: "right" },
+        { allSidesRating: "lean-right" },
+      ]),
+    ).toEqual({ total: 5, left: 2, center: 1, right: 2, specialty: 0 });
+  });
+
+  it("counts mixed / null / undefined / unknown / missing ratings as specialty", () => {
+    expect(
+      computeOutletStats([
+        { allSidesRating: "mixed" },
+        { allSidesRating: null },
+        { allSidesRating: undefined },
+        { allSidesRating: "not-a-real-rating" },
+        {}, // no allSidesRating key at all
+      ]),
+    ).toEqual({ total: 5, left: 0, center: 0, right: 0, specialty: 5 });
+  });
+
+  it("returns all-zero stats for an empty list (DB miss / empty table)", () => {
+    expect(computeOutletStats([])).toEqual(EMPTY_OUTLET_STATS);
+  });
+
+  it("total always equals the input length", () => {
+    const outlets = Array.from({ length: 12 }, () => ({
+      allSidesRating: "center" as const,
+    }));
+    expect(computeOutletStats(outlets).total).toBe(12);
+  });
+});

--- a/app/colophon/page.tsx
+++ b/app/colophon/page.tsx
@@ -2,12 +2,17 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import LandingMasthead from "@/components/landing/LandingMasthead";
 import SiftLogo from "@/components/SiftLogo";
+import { getOutletStats } from "@/lib/db";
 
 export const metadata: Metadata = {
   title: "Colophon",
   description:
     "How Sift is built. Stack, architecture, and credits for the AI-curated news aggregator.",
 };
+
+// ISR — the architecture note carries the live curated-outlet count, read from
+// outlet_profiles. Same 10-minute heartbeat as the landing + methodology.
+export const revalidate = 600;
 
 const STACK = [
   { name: "Next.js 15", role: "Frontend & App Router on Vercel" },
@@ -20,14 +25,21 @@ const STACK = [
   { name: "next/font", role: "Self-hosted Fraunces, Hanken Grotesk & DM Mono" },
 ];
 
-const ARCHITECTURE = [
+const ARCHITECTURE_STATIC = [
   "Articles load in under 50ms — AI processing happens in the background, not when you read.",
   "Works without an account — sign in only if you want bookmarks synced across devices.",
   "Graceful degradation: every feature works independently, so one slow service never blocks the page.",
-  "~50 vetted sources are ingested, deduplicated, and ranked every 30 minutes before you open the app.",
 ];
 
-export default function ColophonPage() {
+// The ingest principle carries the live curated-outlet count (issue #153);
+// count-free fallback on a DB miss.
+function ingestPrinciple(total: number): string {
+  return `${total > 0 ? `${total} curated outlets` : "Curated outlets"} are ingested, deduplicated, and ranked every 30 minutes before you open the app.`;
+}
+
+export default async function ColophonPage() {
+  const { total } = await getOutletStats();
+  const architecture = [...ARCHITECTURE_STATIC, ingestPrinciple(total)];
   return (
     <div className="min-h-screen bg-(--surface-base) text-(--text-primary)">
       <LandingMasthead />
@@ -119,7 +131,7 @@ export default function ColophonPage() {
             Principles
           </p>
           <ul className="space-y-4 max-w-[60ch]">
-            {ARCHITECTURE.map((point) => (
+            {architecture.map((point) => (
               <li
                 key={point}
                 className="font-body text-[15px] leading-relaxed text-(--text-secondary) flex items-baseline gap-3"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -43,7 +43,7 @@ export const metadata: Metadata = {
     template: "%s | Sift",
   },
   description:
-    "Sift reads from ~50 vetted outlets across the political spectrum and adds the footnotes — the civic context the news assumes, the framing across the spectrum, and the financial and political ties behind every story. Every claim links to a public record.",
+    "Sift curates outlets across the political spectrum and adds the footnotes — the civic context the news assumes, the framing across the spectrum, and the financial and political ties behind every story. Every claim links to a public record.",
   metadataBase: new URL("https://siftnews.kristenmartino.ai"),
   openGraph: {
     title: "Sift — The news, with footnotes.",

--- a/app/methodology/page.tsx
+++ b/app/methodology/page.tsx
@@ -83,7 +83,7 @@ export default async function MethodologyPage() {
             {m.sections.includes.kicker}
           </p>
           <p className="font-body text-[15px] text-(--text-secondary) leading-relaxed max-w-[60ch] mb-7">
-            {m.sections.includes.body}
+            {m.sections.includes.body(outlets.length)}
           </p>
           {outlets.length > 0 ? (
             <div className="space-y-7">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     absolute: "Sift — The news, with footnotes.",
   },
   description:
-    "Sift reads from ~50 vetted outlets across the political spectrum and adds the civic context, cross-spectrum framing, and money trail the news assumes you already know. Every claim links to a public record.",
+    "Sift curates outlets across the political spectrum and adds the civic context, cross-spectrum framing, and money trail the news assumes you already know. Every claim links to a public record.",
 };
 
 // ISR: re-render at most once every 10 minutes. This bounds staleness of the

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { COPY } from "@/lib/copy";
+import { computeOutletStats } from "@/lib/outletStats";
 import LandingHeader from "./landing/LandingHeader";
 import LeadStory from "./landing/LeadStory";
 import PrincipleStrip from "./landing/PrincipleStrip";
@@ -26,6 +27,10 @@ interface LandingPageProps {
 const HERO = COPY.landingReskin.hero;
 
 export default function LandingPage({ leadStory, outlets }: LandingPageProps) {
+  // Live spectrum stats from the server-fetched outlet list — drives every
+  // outlet-count surface on the landing (issue #153). Pure + already-fetched,
+  // so no extra round-trip; an empty list (DB miss) degrades to count-free copy.
+  const stats = computeOutletStats(outlets);
   const rootRef = useRef<HTMLDivElement>(null);
   // `sl-anim` gates the reveal/stagger starting states. It's added only after
   // mount, and only when motion is allowed — so SSR / no-JS / reduced-motion
@@ -91,7 +96,7 @@ export default function LandingPage({ leadStory, outlets }: LandingPageProps) {
                 </span>
                 .
               </h1>
-              <p className="sl-lede">{HERO.lede}</p>
+              <p className="sl-lede">{HERO.lede(stats.total)}</p>
               <div className="sl-hero-actions">
                 <Link href="/news" className="sl-btn sl-btn-solid">
                   {HERO.ctaPrimary}{" "}
@@ -105,7 +110,7 @@ export default function LandingPage({ leadStory, outlets }: LandingPageProps) {
               </div>
               <div className="sl-hero-foot">
                 <span className="sl-pip" aria-hidden />
-                {HERO.foot}
+                {HERO.foot(stats.total)}
               </div>
             </div>
 
@@ -113,15 +118,15 @@ export default function LandingPage({ leadStory, outlets }: LandingPageProps) {
           </div>
         </section>
 
-        <PrincipleStrip />
-        <Manifesto />
+        <PrincipleStrip count={stats.total} />
+        <Manifesto stats={stats} />
         <WhatSiftAdds />
         <ComparisonDemo />
         <SourceColophon outlets={outlets} />
-        <CtaBand />
+        <CtaBand count={stats.total} />
       </main>
 
-      <LandingFooter />
+      <LandingFooter count={stats.total} />
     </div>
   );
 }

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -877,7 +877,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
       {/* ── Footer ──────────────────────────────────── */}
       <footer className="border-t border-(--border) py-6 px-6 text-center text-xs text-(--text-tertiary) max-w-[1200px] mx-auto">
         <SiftLogo variant="full" size={18} />
-        <span className="mx-2">&mdash;</span>{COPY.footer.main}
+        <span className="mx-2">&mdash;</span>{COPY.footer.main()}
         <div className="mt-2 flex items-center justify-center gap-3">
           <a href="/privacy" className="text-(--text-tertiary) no-underline hover:text-(--text-secondary) transition-colors">Privacy</a>
           <span className="opacity-30">&middot;</span>

--- a/components/landing/CtaBand.tsx
+++ b/components/landing/CtaBand.tsx
@@ -4,7 +4,7 @@ import { COPY } from "@/lib/copy";
 const C = COPY.landingReskin.cta;
 
 /** Closing CTA band → /news. */
-export default function CtaBand() {
+export default function CtaBand({ count }: { count: number }) {
   return (
     <section className="sl-cta">
       <div className="sl-wrap sl-cta-inner">
@@ -12,7 +12,7 @@ export default function CtaBand() {
           {C.titleLead}
           <em>{C.titleEm}</em>
         </h2>
-        <p>{C.body}</p>
+        <p>{C.body(count)}</p>
         <div className="sl-hero-actions">
           <Link href="/news" className="sl-btn sl-btn-solid">
             {C.ctaPrimary}{" "}

--- a/components/landing/LandingFooter.tsx
+++ b/components/landing/LandingFooter.tsx
@@ -5,7 +5,7 @@ import SlDiamond from "./SlDiamond";
 const F = COPY.landingReskin.footer;
 
 /** Reskinned footer — real in-app routes + byline → kristenmartino.ai. */
-export default function LandingFooter() {
+export default function LandingFooter({ count }: { count: number }) {
   const year = new Date().getFullYear();
 
   return (
@@ -17,7 +17,7 @@ export default function LandingFooter() {
               <SlDiamond />
               Sift
             </a>
-            <p>{F.blurb}</p>
+            <p>{F.blurb(count)}</p>
           </div>
 
           <div className="sl-foot-cols">

--- a/components/landing/Manifesto.tsx
+++ b/components/landing/Manifesto.tsx
@@ -1,17 +1,20 @@
 import { COPY } from "@/lib/copy";
+import type { OutletStats } from "@/lib/outletStats";
 
 const M = COPY.landingReskin.manifesto;
 
 // Spectrum segment fills, in L/C/R/Specialty order. Presentation only — the
-// labels + counts live in COPY. Reverses visually with the manifesto band,
-// which flips with the theme.
+// labels + LIVE counts come from COPY.manifesto.spectrum(stats). Reverses
+// visually with the manifesto band, which flips with the theme.
 const SEG_COLORS = ["#8A8174", "#B3AA99", "#6B5F52", "#423D35"];
 
 /**
- * "Why Sift" manifesto band + the outlet-spectrum bar. Counts (22/24/11/20)
- * are the real curated totals from /methodology; static here is fine.
+ * "Why Sift" manifesto band + the live outlet-spectrum bar. Counts come from
+ * the curated outlet list (issue #153); on an empty list (DB miss) the bar is
+ * dropped and only the manifesto copy renders.
  */
-export default function Manifesto() {
+export default function Manifesto({ stats }: { stats: OutletStats }) {
+  const spectrum = M.spectrum(stats);
   return (
     <section className="sl-manifesto">
       <div className="sl-wrap sl-manifesto-grid">
@@ -24,26 +27,28 @@ export default function Manifesto() {
           <p>{M.body}</p>
         </div>
 
-        <div className="sl-spectrum" data-reveal>
-          <div className="sl-bar" aria-hidden="true">
-            {M.spectrum.map((s, i) => (
-              <div
-                key={s.label}
-                className="sl-seg"
-                style={{ flex: s.count, background: SEG_COLORS[i] }}
-                title={`${s.label}: ${s.count}`}
-              />
-            ))}
+        {stats.total > 0 && (
+          <div className="sl-spectrum" data-reveal>
+            <div className="sl-bar" aria-hidden="true">
+              {spectrum.map((s, i) => (
+                <div
+                  key={s.label}
+                  className="sl-seg"
+                  style={{ flex: s.count, background: SEG_COLORS[i] }}
+                  title={`${s.label}: ${s.count}`}
+                />
+              ))}
+            </div>
+            <div className="sl-leg">
+              {spectrum.map((s) => (
+                <span key={s.label}>
+                  {s.label} · {s.count}
+                </span>
+              ))}
+            </div>
+            <p className="sl-cap">{M.spectrumCaption}</p>
           </div>
-          <div className="sl-leg">
-            {M.spectrum.map((s) => (
-              <span key={s.label}>
-                {s.label} · {s.count}
-              </span>
-            ))}
-          </div>
-          <p className="sl-cap">{M.spectrumCaption}</p>
-        </div>
+        )}
       </div>
     </section>
   );

--- a/components/landing/PrincipleStrip.tsx
+++ b/components/landing/PrincipleStrip.tsx
@@ -1,14 +1,14 @@
 import { Fragment } from "react";
 import { COPY } from "@/lib/copy";
 
-const ITEMS = COPY.landingReskin.strip;
-
-/** The "~50 vetted outlets / Left → Center → Right / …" principle strip. */
-export default function PrincipleStrip() {
+/** The "{n} curated outlets / Left → Center → Right / …" principle strip. The
+ *  count comes from the live outlet list (issue #153); the rest is static. */
+export default function PrincipleStrip({ count }: { count: number }) {
+  const items = COPY.landingReskin.strip(count);
   return (
     <div className="sl-strip">
       <div className="sl-wrap sl-strip-inner">
-        {ITEMS.map((item, i) => (
+        {items.map((item, i) => (
           <Fragment key={item}>
             {i > 0 && (
               <span className="sl-sep" aria-hidden>

--- a/components/landing/SourceColophon.tsx
+++ b/components/landing/SourceColophon.tsx
@@ -28,7 +28,7 @@ export default function SourceColophon({
           <span className="sl-eyebrow">{S.eyebrow}</span>
           <h2>
             {S.titleLead}
-            <span className="sl-it">{S.titleIt}</span>
+            <span className="sl-it">{S.titleIt(outlets.length)}</span>
             {S.titleRest}
           </h2>
           <p>{S.body}</p>

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -8,6 +8,26 @@
 
 import type { StoryFraming } from "./types";
 
+// ── Outlet-count phrasing (issue #153) ──────────────────
+// One source of truth for how the LIVE curated-outlet count reads, so it can't
+// drift the way the old hardcoded "~50" did (28 copies, while the real set had
+// grown to ~77). The data (outlet_profiles) proves a CURATED set — not which
+// outlets are actively ingested — so the honest noun is "curated outlets".
+// `n <= 0` (DB miss / empty) drops the number for a graceful, still-truthful
+// fallback instead of printing "0".
+const curatedOutlets = (n: number): string =>
+  n > 0 ? `${n} curated outlets` : "curated outlets";
+
+// The shared brand blurb — rendered in BOTH the /news footer and the landing
+// footer. Pass the live count on the landing (the outlet list is already
+// fetched for the colophon, ISR-cached); call with no argument on /news (a hot,
+// per-request path that doesn't fetch the outlet list — render count-free
+// rather than add a DB read there).
+const siftBlurb = (n = 0): string =>
+  `Sift curates ${n > 0 ? `${n} ` : ""}outlets across the political spectrum, ` +
+  `surfaces the civic context the news assumes you already know, and shows you ` +
+  `who's behind every story. Every link goes to the original.`;
+
 export const COPY = {
   header: {
     tagline: "The news, with footnotes",
@@ -18,7 +38,9 @@ export const COPY = {
     dateline: "Curated civic context for the day's news",
   },
   footer: {
-    main: "Sift reads from ~50 vetted outlets across the political spectrum, surfaces the civic context the news assumes you already know, and shows you who's behind every story. Every link goes to the original.",
+    // Shared with landingReskin.footer.blurb via siftBlurb. The /news footer
+    // calls it with no count (count-free); the landing passes the live count.
+    main: siftBlurb,
   },
   error: {
     title: "We hit a snag pulling today's stories",
@@ -158,8 +180,8 @@ export const COPY = {
     sections: {
       includes: {
         kicker: "What Sift reads",
-        body:
-          "Around 50 outlets, hand-picked to balance the political spectrum (AllSides Left → Center → Right), span sector specialties (finance, tech, science, climate, health), and clear a factual-reporting bar. Each outlet has a dossier with ownership, funding model, and external rating links — click any name below.",
+        body: (n: number): string =>
+          `${n > 0 ? `${n} curated outlets` : "Curated outlets"}, hand-picked to balance the political spectrum (AllSides Left → Center → Right), span sector specialties (finance, tech, science, climate, health), and clear a factual-reporting bar. Each outlet has a dossier with ownership, funding model, and external rating links — click any name below.`,
         bucketLabels: {
           left: "Left",
           center: "Center",
@@ -369,18 +391,19 @@ export const COPY = {
       eyebrow: "Curated civic context for the news",
       headingLead: "The news, with ",
       headingAccent: "footnotes",
-      lede: "Sift reads ~50 vetted outlets across the political spectrum and adds the context the news assumes you already know — the background, the people and organizations involved, and how to read each source. Every link goes to the original.",
+      lede: (n: number): string =>
+        `Sift curates ${n > 0 ? `${n} ` : ""}outlets across the political spectrum and adds the context the news assumes you already know — the background, the people and organizations involved, and how to read each source. Every link goes to the original.`,
       ctaPrimary: "Open Sift",
       ctaSecondary: "See what Sift adds",
-      foot: "~50 vetted outlets · Left → Center → Right",
+      foot: (n: number): string => `${curatedOutlets(n)} · Left → Center → Right`,
     },
     card: {
       barLabel: "Today · Top story",
       badge: "civic context on",
       primerLabel: "What you should know first",
     },
-    strip: [
-      "~50 vetted outlets",
+    strip: (n: number): string[] => [
+      curatedOutlets(n),
       "Left → Center → Right",
       "Ratings cited, never computed",
       "Every link goes to the original",
@@ -390,11 +413,16 @@ export const COPY = {
       headingLead: "The news is written for people who ",
       headingEm: "already have the context.",
       body: "Most reporting assumes you know the players, the precedent, and where the source is coming from. Sift adds it back — so you can read across the spectrum and judge for yourself, with the footnotes in front of you.",
-      spectrum: [
-        { label: "Left", count: 22 },
-        { label: "Center", count: 24 },
-        { label: "Right", count: 11 },
-        { label: "Specialty", count: 20 },
+      spectrum: (s: {
+        left: number;
+        center: number;
+        right: number;
+        specialty: number;
+      }): { label: string; count: number }[] => [
+        { label: "Left", count: s.left },
+        { label: "Center", count: s.center },
+        { label: "Right", count: s.right },
+        { label: "Specialty", count: s.specialty },
       ],
       spectrumCaption:
         "Hand-picked to balance the spectrum and clear a factual-reporting bar. Outlets without a political-lean rating are peer-reviewed journals or sector specialists.",
@@ -458,8 +486,9 @@ export const COPY = {
     },
     sources: {
       eyebrow: "Curated & cited",
-      titleLead: "About ",
-      titleIt: "50 outlets.",
+      titleLead: "",
+      titleIt: (n: number): string =>
+        n > 0 ? `${n} curated outlets.` : "Curated outlets.",
       titleRest: " Every rating sourced.",
       body: "Hand-picked across Left, Center, and Right, each with a dossier: ownership, funding model, AllSides lean, and MBFC factual tier — cited verbatim with a link, reviewed quarterly, and applied symmetrically to every outlet.",
       methodologyCta: "Read the methodology",
@@ -471,18 +500,18 @@ export const COPY = {
         { term: "Sites without", desc: "mastheads, bylines, or corrections policies." },
         { term: "Crypto & supplement sites", desc: "dressed up as news." },
       ],
-      outletsLabel: "Outlets Sift reads",
+      outletsLabel: "Curated outlets",
     },
     cta: {
       titleLead: "Read today's news — ",
       titleEm: "with the footnotes.",
-      body: "~50 vetted outlets, the civic context the news assumes you already know, and a link to the original on every story.",
+      body: (n: number): string =>
+        `${n > 0 ? `${n} curated outlets` : "Curated outlets across the spectrum"}, the civic context the news assumes you already know, and a link to the original on every story.`,
       ctaPrimary: "Open Sift",
       ctaSecondary: "How it works",
     },
     footer: {
-      blurb:
-        "Sift reads from ~50 vetted outlets across the political spectrum, surfaces the civic context the news assumes you already know, and shows you who's behind every story. Every link goes to the original.",
+      blurb: siftBlurb,
       cols: [
         {
           heading: "Read",

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -7,6 +7,11 @@ import {
   parseDbPoliticianProfile,
   type DbPoliticianProfileRow,
 } from "./politician";
+import {
+  computeOutletStats,
+  EMPTY_OUTLET_STATS,
+  type OutletStats,
+} from "./outletStats";
 import type {
   BillListItem,
   BillProfile,
@@ -549,6 +554,21 @@ export async function getAllOutletProfiles(): Promise<OutletProfile[]> {
     const msg = String(err);
     if (msg.includes("does not exist")) return [];
     throw err;
+  }
+}
+
+/**
+ * Spectrum stats for the curated outlet set — the single server-side source
+ * for outlet-count copy (issue #153), read from the same `outlet_profiles`
+ * table as the public outlet list. Fully graceful: any DB/table miss degrades
+ * to all-zero stats so callers fall back to count-free, still-truthful copy
+ * rather than rendering "0".
+ */
+export async function getOutletStats(): Promise<OutletStats> {
+  try {
+    return computeOutletStats(await getAllOutletProfiles());
+  } catch {
+    return { ...EMPTY_OUTLET_STATS };
   }
 }
 

--- a/lib/outletStats.ts
+++ b/lib/outletStats.ts
@@ -1,0 +1,63 @@
+// Outlet-count + spectrum stats derived from the live curated outlet list
+// (issue #153). One place computes "how many outlets, split how across the
+// spectrum" so the landing, methodology, colophon, and footers can all stop
+// hardcoding "~50" — a number that had drifted to ~77 in 28 places.
+//
+// `computeOutletStats` is PURE (only depends on the pure `bucketize`), so it is
+// safe to import into client components — the landing already receives the
+// outlet list as a server prop, so it derives its count on the client without a
+// second fetch. The server-side entry point that reads `outlet_profiles` lives
+// in `lib/db.ts` (`getOutletStats`) to keep this module free of the pg pool.
+
+import { bucketize } from "./crossSpectrum";
+import type { OutletAllSidesRating } from "./types";
+
+export interface OutletStats {
+  /** Total curated outlets (outlet_profiles rows). */
+  total: number;
+  left: number;
+  center: number;
+  right: number;
+  /**
+   * Outlets AllSides doesn't place on the L/C/R axis (mixed or no rating) —
+   * peer-reviewed journals + sector specialists. Mirrors the methodology
+   * page's "unrated or specialty" bucket and the manifesto's "Specialty".
+   */
+  specialty: number;
+}
+
+export const EMPTY_OUTLET_STATS: OutletStats = {
+  total: 0,
+  left: 0,
+  center: 0,
+  right: 0,
+  specialty: 0,
+};
+
+/**
+ * Bucket a curated outlet list into spectrum counts. Accepts anything with an
+ * `allSidesRating` (OutletProfile or the landing's lighter SourceColophonOutlet)
+ * — unknown/missing ratings fall through `bucketize` to `specialty`. Pure.
+ */
+export function computeOutletStats(
+  outlets: ReadonlyArray<{ allSidesRating?: string | null }>,
+): OutletStats {
+  const stats: OutletStats = { ...EMPTY_OUTLET_STATS, total: outlets.length };
+  for (const outlet of outlets) {
+    const rating = (outlet.allSidesRating ?? null) as OutletAllSidesRating | null;
+    switch (bucketize(rating)) {
+      case "left":
+        stats.left += 1;
+        break;
+      case "center":
+        stats.center += 1;
+        break;
+      case "right":
+        stats.right += 1;
+        break;
+      default:
+        stats.specialty += 1;
+    }
+  }
+  return stats;
+}


### PR DESCRIPTION
## What

"~50 outlets" was hardcoded in **28 places** while the curated set had grown to **~77** (#153). This replaces it with a single **live count** derived from `outlet_profiles` — the same source as the public outlet list — so it can't drift again.

## How

- **`lib/outletStats.ts`** (new, pure): `computeOutletStats(outlets) → {total, left, center, right, specialty}` via the existing `bucketize`. Client-safe (no `pg` import), so the landing computes it from already-fetched data.
- **`lib/db.ts`**: `getOutletStats()` wraps it over `getAllOutletProfiles()` — the one server-side helper, **graceful** (any DB/table miss → all-zero stats).
- **`lib/copy.ts`**: centralized phrasing (`curatedOutlets`, `siftBlurb`); every count-bearing string became a function of the count. **One shared builder backs both the `/news` footer and the landing footer.**
- **No new fetches where data already flows:** the landing derives the count from the `outlets` list `app/page.tsx` already passes to `LandingPage`; `/methodology` reuses its fetched list; `/colophon` is now async (ISR @ 600s) via `getOutletStats()`.

## Truthfulness (per the issue)

`outlet_profiles` has no active/ingested field — it proves a **curated** set, not a read one. So copy now says **"curated outlets"**, not "reads from N sources". `n <= 0` (DB miss) **drops the number** rather than printing "0".

## Scope

- Metadata (homepage + root layout) reworded **count-free** — kills the stale number without adding a DB read to the root layout's metadata.
- **Not** touched (tracked separately): outlet-data dedupe + Yahoo exclusion → **sift-api#91**; source expansion → **#151**; topic/hybrid search → **#149**.

## Verification

- `npx tsc --noEmit` clean
- `npm test -- --ci --coverage` — **350 passed** (+9; `outletStats.ts` & `SourceColophon.tsx` 100%)
- `npm run build` green — `/colophon` now ISR @ 10m

Closes #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)