### PR TITLE
docs: accuracy fixes + interim cost guard for topic-search fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ CLERK_SECRET_KEY=sk_test_xxx
 # ── AI / topic-search read-path fallback (grandfathered — see DECISIONS D35) ──
 ANTHROPIC_API_KEY=sk-ant-xxx
 VOYAGE_API_KEY=pa-xxx
+# Interim daily cost guard for the topic-search fallback (sift-api#79). Inert
+# unless AI_COST_GUARD_ENABLED=true; shares sift-api's ai_usage_daily ledger.
+AI_COST_GUARD_ENABLED=false
+DAILY_AI_COST_LIMIT_USD=10
 
 # ── Backend proxy (multi-source compare) ──────────────
 SIFT_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@
 ```
 Browser --> Vercel (Next.js) --reads--> Neon Postgres (pgvector)
                 |
-                +----- refresh /30min --> Railway (FastAPI + LangGraph) --writes--> Neon Postgres
-                +----- /api/compare ---> Railway
+                +----- /api/compare ---> Railway (FastAPI + LangGraph)
+
+Railway runs its own 30-min asyncio scheduler --> pipeline --writes--> Neon Postgres
+(no Vercel cron is configured; /api/cron/refresh is a manual/backstop trigger)
 ```
 
 - **sift** (this repo): Next.js 15 frontend on Vercel — reads from Postgres, serves UI. *(One grandfathered exception being migrated out: the topic-search AI fallback still runs AI + writes here — see [`docs/DECISIONS.md`](docs/DECISIONS.md) D35.)*
@@ -22,7 +24,7 @@ Browser --> Vercel (Next.js) --reads--> Neon Postgres (pgvector)
 ## Foundation (the reader surface)
 
 - **10 categories**: Top, Technology, Business, Science, Energy, World, Health, Politics, Sports, Entertainment.
-- **AI summaries**: every article summarized by Claude Haiku 4.5 in the background pipeline — user requests never touch Claude.
+- **AI summaries**: every article summarized by Claude Haiku 4.5 in the background pipeline — the browse path never touches Claude (live compare + topic-search fallback do call Claude; see "AI split by SLA" below).
 - **Topic search**: vector similarity (Voyage AI embeddings + pgvector), SSE streaming, Claude web-search fallback for niche queries.
 - **Multi-source comparison**: LangGraph workflow — fan-out search across outlets, extract claims, compare framings. Described, not labeled.
 - **Bookmarks**: localStorage + Clerk server sync.
@@ -103,6 +105,8 @@ sift/
 | `DATABASE_URL` | Yes | Neon Postgres pooled connection string |
 | `ANTHROPIC_API_KEY` | Yes | Claude API key (topic search fallback) |
 | `VOYAGE_API_KEY` | Yes | Voyage AI key (topic search embeddings) |
+| `AI_COST_GUARD_ENABLED` | No | Enable the interim daily cost ceiling on the topic-search fallback (default: `false`) |
+| `DAILY_AI_COST_LIMIT_USD` | No | Daily AI spend ceiling, USD, shared with sift-api's `ai_usage_daily` ledger (default: `10`) |
 | `SIFT_API_URL` | Yes | Railway sift-api URL |
 | `SIFT_API_KEY` | Yes | Shared secret for pipeline trigger |
 | `CRON_SECRET` | Yes | Cron endpoint auth |
@@ -121,7 +125,7 @@ npm run test:coverage
 
 ## Deployment
 
-Auto-deploys to Vercel on push to `main`. CI runs on every PR via GitHub Actions (`tsc --noEmit`).
+Auto-deploys to Vercel on push to `main`. CI runs on every PR via GitHub Actions: `npm audit`, `tsc --noEmit`, a production `next build` against a throwaway pgvector Postgres, and Jest with coverage.
 
 ## Tech stack
 

--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -6,6 +6,8 @@ import {
   getOutletProfilesMap,
   resolveOutletForSourceName,
   getArticleEntityLinks,
+  getTodayAiSpendUsd,
+  recordAiUsage,
 } from "@/lib/db";
 import { parseContextPrimer, attachPrimerTermLinks } from "@/lib/primer";
 import { parseEntityLinks } from "@/lib/entityLinks";
@@ -47,6 +49,13 @@ function cleanImageUrl(raw: string | null): string | null {
 const SIMILARITY_THRESHOLD = 0.35;
 const MIN_STRONG_RESULTS = 3;
 const MAX_RESULTS = 10;
+
+// Interim cost guard for the paid web-search fallback (sift-api#79). Mirrors
+// sift-api's env contract: inert unless AI_COST_GUARD_ENABLED=true, so enabling
+// it is an explicit opt-in and never silently changes live behavior. Reads/writes
+// the SAME ai_usage_daily ledger the backend guard uses → the ceiling is global.
+const AI_COST_GUARD_ENABLED = process.env.AI_COST_GUARD_ENABLED === "true";
+const DAILY_AI_COST_LIMIT_USD = Number(process.env.DAILY_AI_COST_LIMIT_USD ?? "10");
 
 function getVoyageApiKey(): string {
   const key = process.env.VOYAGE_API_KEY;
@@ -278,8 +287,12 @@ export async function GET(request: NextRequest) {
         totalArticles = articles.length;
         resultCountVector = articles.length;
 
-        // 5. If < 3 results, run Claude web_search fallback
-        if (articles.length < MIN_STRONG_RESULTS) {
+        // 5. If < 3 results, run Claude web_search fallback — unless the daily
+        // AI budget is exhausted (interim cost guard, sift-api#79). The vector
+        // results above still stream regardless of the budget decision.
+        const fallbackBudgetOk =
+          !AI_COST_GUARD_ENABLED || (await isUnderDailyAiBudget());
+        if (articles.length < MIN_STRONG_RESULTS && fallbackBudgetOk) {
           fallbackUsed = true;
           controller.enqueue(sseEvent("fallback-start", {}));
 
@@ -388,6 +401,28 @@ async function embedQuery(text: string): Promise<number[]> {
   return data.data[0].embedding;
 }
 
+// ─── Interim daily-budget check ─────────────────────────
+
+// Is the shared daily AI ledger still under the ceiling? Fails OPEN (returns
+// true) on any read error so a ledger hiccup never breaks search — only a
+// confirmed over-budget read skips the paid fallback. The durable #79 version
+// runs server-side in sift-api and can fail closed like the compare path.
+async function isUnderDailyAiBudget(): Promise<boolean> {
+  try {
+    const spent = await getTodayAiSpendUsd();
+    if (spent >= DAILY_AI_COST_LIMIT_USD) {
+      console.warn(
+        `Topic-search fallback skipped: daily AI spend $${spent.toFixed(2)} >= limit $${DAILY_AI_COST_LIMIT_USD}`
+      );
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.warn("AI budget check failed; allowing fallback:", err);
+    return true;
+  }
+}
+
 // ─── Claude Web Search Fallback ─────────────────────────
 
 async function webSearchFallback(query: string): Promise<Article[]> {
@@ -424,7 +459,18 @@ If you truly cannot find any articles, respond with an empty array: []`,
       },
     ],
   });
-  logUsage("news.topic.webSearchFallback", response, "claude-haiku-4-5");
+  const usage = logUsage("news.topic.webSearchFallback", response, "claude-haiku-4-5");
+  if (usage) {
+    // Interim: meter the fallback's Claude spend into the shared daily ledger
+    // (sift-api#79 moves this server-side). Voyage micro-costs are dwarfed by the
+    // $0.01/web_search and are deferred to #79. Fire-and-forget; never blocks.
+    recordAiUsage({
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      operation: "news.topic.webSearchFallback",
+      costUsd: usage.cost_usd,
+    }).catch((err) => console.warn("recordAiUsage failed:", err));
+  }
 
   // Extract JSON from response — Claude may return multiple text blocks
   const textBlocks = response.content

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -370,6 +370,42 @@ export async function insertArticle(article: {
   );
 }
 
+// ─── AI cost ledger (interim cost-guard for topic search, sift-api#79) ──
+// The topic-search route runs paid Claude/Voyage calls on the user path but,
+// unlike sift-api, those calls were never recorded in ai_usage_daily or checked
+// against the daily ceiling (init.sql flags this as a temporary D35 gap). Until
+// the fallback moves into sift-api (#79), the route meters its spend into the
+// SAME shared ledger the backend guard reads, so the daily ceiling stays global.
+
+/** Today's combined estimated AI spend (USD) across backend + frontend. */
+export async function getTodayAiSpendUsd(): Promise<number> {
+  const result = await pool.query<{ total: number | null }>(
+    `SELECT COALESCE(SUM(estimated_cost_usd), 0) AS total
+       FROM ai_usage_daily
+      WHERE usage_date = CURRENT_DATE`
+  );
+  return Number(result.rows[0]?.total ?? 0);
+}
+
+/** Add one paid call's estimated cost to today's ledger (idempotent upsert). */
+export async function recordAiUsage(entry: {
+  provider: string;
+  model: string;
+  operation: string;
+  costUsd: number;
+}): Promise<void> {
+  await pool.query(
+    `INSERT INTO ai_usage_daily
+        (usage_date, provider, model, operation, estimated_cost_usd, call_count)
+     VALUES (CURRENT_DATE, $1, $2, $3, $4, 1)
+     ON CONFLICT (usage_date, provider, model, operation) DO UPDATE SET
+        estimated_cost_usd = ai_usage_daily.estimated_cost_usd + EXCLUDED.estimated_cost_usd,
+        call_count = ai_usage_daily.call_count + 1,
+        updated_at = NOW()`,
+    [entry.provider, entry.model, entry.operation, entry.costUsd]
+  );
+}
+
 // ─── Custom Topics ────────────────────────────────────
 
 export interface DbCustomTopic {

--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
 const nextConfig = {
   images: {
     // Allow news article images from any HTTPS domain.
-    // Sift aggregates from 100+ RSS sources with diverse CDN domains,
+    // Sift aggregates from ~58 RSS sources with diverse CDN domains,
     // making a strict allowlist impractical. Images are only loaded from
     // URLs stored in the database via trusted RSS feed ingestion.
     remotePatterns: [{ protocol: "https", hostname: "**" }],
@@ -20,7 +20,7 @@ const nextConfig = {
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       // font-src: Google Fonts CDN
       "font-src 'self' https://fonts.gstatic.com data:",
-      // img-src: self + any HTTPS (news article images from 100+ sources)
+      // img-src: self + any HTTPS (news article images from ~58 sources)
       "img-src 'self' https: data:",
       // connect-src: API calls to self, Clerk, server-side proxied services,
       // and the Sentry ingest endpoint (only used when NEXT_PUBLIC_SENTRY_DSN is set)


### PR DESCRIPTION
## What
Documentation-accuracy fixes from a code audit, plus an interim cost guard for the topic-search paid fallback.

## Changes
**Docs (`README.md`, `next.config.js`)**
- Architecture diagram: the 30-min refresh is the **backend asyncio scheduler** (no Vercel cron is configured); `/api/cron/refresh` is a manual/backstop trigger
- Qualify "user requests never touch Claude" → **browse path** only (compare + topic-search fallback call Claude live)
- CI description: the real pipeline (`npm audit` + `tsc` + DB-backed `next build` + Jest), not just `tsc --noEmit`
- `next.config.js` comments: "100+ sources" → ~58
- Document `AI_COST_GUARD_ENABLED` / `DAILY_AI_COST_LIMIT_USD`

**Interim cost guard (`app/api/news/topic/route.ts`, `lib/db.ts`, `.env.example`)**
- The topic-search Claude `web_search` fallback was the one paid path on the user request not metered or budget-checked (D35 exception). It's now metered into the **same `ai_usage_daily` ledger** sift-api's `cost_guard` reads, and skipped when today's combined spend exceeds the daily ceiling.
- **Off by default** (`AI_COST_GUARD_ENABLED` opt-in) → no behavior change on the live site until enabled.
- `lib/db.ts`: `getTodayAiSpendUsd()` + `recordAiUsage()` (shared-ledger helpers).

## Interim caveats (by design)
- Per-search Voyage query-embed cost isn't metered; the budget check fails **open** on a ledger read error.
- Durable fix = move the fallback server-side (kristenmartino/sift-api#79); enable/verify tracked in #165.

## Verification
- `tsc --noEmit` → 0 errors; `jest __tests__/api.test.ts` → 18/18

🤖 Generated with [Claude Code](https://claude.com/claude-code)