### PR TITLE
fix(news): treat empty-array web search response as clean no-result

### DIFF
--- a/app/api/news/topic/route.ts
+++ b/app/api/news/topic/route.ts
@@ -439,6 +439,7 @@ If you truly cannot find any articles, respond with an empty array: []`,
     source_url: string;
     source_name: string;
   }> | null = null;
+  let sawEmptyArray = false;
 
   for (const text of textBlocks) {
     try {
@@ -450,9 +451,16 @@ If you truly cannot find any articles, respond with an empty array: []`,
       const arrayMatch = jsonStr.match(/\[[\s\S]*\]/);
       if (arrayMatch) {
         const candidate = JSON.parse(arrayMatch[0]);
-        if (Array.isArray(candidate) && candidate.length > 0 && candidate[0].title) {
-          parsed = candidate;
-          break;
+        if (Array.isArray(candidate)) {
+          if (candidate.length === 0) {
+            // Valid "no relevant articles found" response, not a parse failure
+            sawEmptyArray = true;
+            continue;
+          }
+          if (candidate[0].title) {
+            parsed = candidate;
+            break;
+          }
         }
       }
     } catch {
@@ -461,6 +469,7 @@ If you truly cannot find any articles, respond with an empty array: []`,
   }
 
   if (!parsed) {
+    if (sawEmptyArray) return [];
     console.error("Failed to parse Claude web search response. Text blocks:", JSON.stringify(textBlocks.map(t => t.substring(0, 500))));
     console.error("All content block types:", response.content.map(b => b.type));
     return [];


### PR DESCRIPTION
## Problem

The topic-search `web_search` fallback in `app/api/news/topic/route.ts` logged

> `Failed to parse Claude web search response. Text blocks: ["[]"]`

at **error** level every time Claude correctly returned an empty array (no relevant news found). `[]` is valid JSON for zero results — the prompt explicitly instructs the model to return it — but the parse loop required `candidate.length > 0`, so a legitimate empty array fell through to the malformed-response branch and polluted Vercel error-level runtime logs on every no-result fallback.

## Fix

- Track a valid-but-empty parse in a `sawEmptyArray` flag inside the parse loop.
- When no articles were parsed but a valid `[]` was seen, return a clean empty result with no logging.
- The `console.error` diagnostics now fire only when no text block contained any parseable JSON array — the genuinely malformed case.
- Non-empty arrays still require `title` on the first item, as before.

## Verification

- `npx tsc --noEmit` passes.
- Not exercised end-to-end: the fallback path requires a live paid Anthropic `web_search` call that returns zero articles, so there's no cheap deterministic way to drive it locally.

## Notes

- This route's fallback is grandfathered per D35 and migrating to sift-api (sift-api#79) — the same empty-array handling should carry over there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)