### PR TITLE
perf(feed): add 30-day recency floor to category feed queries

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -59,6 +59,14 @@ export interface DbArticle {
   reading_levels: unknown;
 }
 
+// The category feed queries (here and the standalone query in
+// getStoriesWithArticles) carry a 30-day recency floor. The EXP() decay in
+// ORDER BY already zeroes out older rows (score × ~1e-13 at 30 days), so
+// they can never rank — but without the floor Postgres still fetches and
+// sorts every feed-quality row in the category (29k for business, 73k for
+// sports as of 2026-07; sift-api#16). Written as an OR rather than
+// COALESCE(published_date, created_at) so both branches stay servable by
+// idx_articles_feed (category, published_date DESC).
 export async function getArticlesByCategory(
   category: string,
   limit = 30
@@ -70,6 +78,8 @@ export async function getArticlesByCategory(
      WHERE category = $1 AND from_search = false
        AND summary IS NOT NULL AND summary != ''
        AND LOWER(summary) NOT LIKE 'unable to provide%'
+       AND (published_date > NOW() - INTERVAL '30 days'
+            OR (published_date IS NULL AND created_at > NOW() - INTERVAL '30 days'))
      ORDER BY
        COALESCE(importance_score, 3)::float *
        EXP(-LEAST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))) / 86400.0, 700))
@@ -185,6 +195,8 @@ export async function getStoriesWithArticles(
          AND (story_id IS NULL OR story_id <> ALL($2::text[]))
          AND summary IS NOT NULL AND summary != ''
          AND LOWER(summary) NOT LIKE 'unable to provide%'
+         AND (published_date > NOW() - INTERVAL '30 days'
+              OR (published_date IS NULL AND created_at > NOW() - INTERVAL '30 days'))
        ORDER BY
          COALESCE(importance_score, 3)::float *
          EXP(-LEAST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))) / 86400.0, 700))
@@ -203,6 +215,8 @@ export async function getStoriesWithArticles(
        WHERE category = $1 AND from_search = false
          AND summary IS NOT NULL AND summary != ''
          AND LOWER(summary) NOT LIKE 'unable to provide%'
+         AND (published_date > NOW() - INTERVAL '30 days'
+              OR (published_date IS NULL AND created_at > NOW() - INTERVAL '30 days'))
        ORDER BY
          COALESCE(importance_score, 3)::float *
          EXP(-LEAST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))) / 86400.0, 700))


### PR DESCRIPTION
## Problem

The `feed-perf` tripwire in [sift-api#16](https://github.com/kristenmartino/sift-api/issues/16) fired: `business/standalone` hit **2374 ms** (warn threshold 2000 ms) in a diagnostic run.

Root cause: the standalone/articles feed queries order by `importance × EXP(-age_days)` — a computed score no index can serve — so Postgres fetched **every** feed-quality row in the category (29,571 for business, 73,112 for sports), scored, sorted, and kept 50. The decay makes anything older than ~30 days score ~10⁻¹³ (mathematically unable to rank), yet the scan covered rows back to 2020. The cost is dominated by cold heap reads on Neon (~16,700 pages ≈ 130 MB for business) and grows daily with ingestion.

## Fix

Add a 30-day recency floor to `getArticlesByCategory` and the standalone query (including its no-`story_id` fallback):

```sql
AND (published_date > NOW() - INTERVAL '30 days'
     OR (published_date IS NULL AND created_at > NOW() - INTERVAL '30 days'))
```

OR-form rather than `COALESCE(published_date, created_at)` so both branches stay servable by the existing `idx_articles_feed (category, published_date DESC)` partial index via BitmapOr — 612 recent articles have NULL `published_date` and keep their `created_at` fallback semantics. No schema change, no new index.

## Verification (against prod Neon)

- **Result parity**: business top-50 IDs identical before/after (the floor only excludes rows the decay already made unrankable). Every live category has ≥ 950 in-window candidates vs LIMIT 50.
- **Plans**: BitmapOr with both branches as index conditions on `idx_articles_feed`; the former seq scans on politics/sports/entertainment are gone.
- **Timings** (`scripts/explain_feed_queries.py`, all 30 shapes): worst query now **140 ms** (sports/standalone); business/standalone **2374 ms → 30 ms**.
- `__tests__/api.test.ts` 18/18 pass; `tsc --noEmit` clean.

Companion PR mirrors the SQL into the sift-api diagnostic (byte-identical requirement) and triggers the `feed-perf` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)