### PR TITLE
Relicense: all rights reserved

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,11 @@
-MIT License
+Copyright (c) 2026 Kristen Martino. All rights reserved.
 
-Copyright (c) 2026 Kristen Martino
+This software and its source code are proprietary and confidential.
+No license, express or implied, is granted to use, copy, modify, merge,
+publish, distribute, sublicense, or sell any part of this software.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Viewing and forking via GitHub are permitted solely as provided by the
+GitHub Terms of Service and grant no additional rights.
+Portions of this repository were previously distributed under the MIT
+License. That grant remains in effect only for copies obtained before
+this notice; it does not extend to any subsequent version.

--- a/LICENSE
+++ b/LICENSE
@@ -6,6 +6,7 @@ publish, distribute, sublicense, or sell any part of this software.
 
 Viewing and forking via GitHub are permitted solely as provided by the
 GitHub Terms of Service and grant no additional rights.
+
 Portions of this repository were previously distributed under the MIT
 License. That grant remains in effect only for copies obtained before
 this notice; it does not extend to any subsequent version.


### PR DESCRIPTION
Replaces the MIT License with a proprietary all-rights-reserved notice, per the IP-posture review. The prior MIT grant remains valid only for copies obtained before this commit.