### PR TITLE
feat: /agencies + /think-tanks — the week-one test pages (and a live D37 fix)

### DIFF
--- a/__tests__/agencies.test.ts
+++ b/__tests__/agencies.test.ts
@@ -1,5 +1,6 @@
 import {
   hasPartisanBalanceCap,
+  partisanCap,
   sortAgencies,
   sourceLabel,
 } from "@/lib/agencies";
@@ -113,5 +114,56 @@ describe("sourceLabel", () => {
 
   it("degrades to a neutral label on an unparseable URL", () => {
     expect(sourceLabel("not a url")).toBe("source");
+  });
+});
+
+const FEC =
+  "Independent regulatory commission. Six voting members appointed by the President with the advice and consent of the Senate, each serving a single six-year term, plus the Secretary of the Senate and the Clerk of the House as non-voting ex officio members. No more than three appointed members may be affiliated with the same political party.";
+const FDIC =
+  "Governed by a five-member Board of Directors: the Comptroller of the Currency and the Director of the Consumer Financial Protection Bureau serve ex officio, and three members are appointed by the President with the advice and consent of the Senate for six-year terms. One appointed member must have State bank supervisory experience. Not more than three Board members may be of the same political party.";
+
+describe("partisanCap", () => {
+  it("reads the common 3-of-5 commission shape", () => {
+    expect(partisanCap(FTC)).toEqual({ cap: 3, total: 5 });
+    expect(partisanCap(FCC)).toEqual({ cap: 3, total: 5 });
+    expect(partisanCap(CPSC)).toEqual({ cap: 3, total: 5 });
+    expect(partisanCap(NTSB)).toEqual({ cap: 3, total: 5 });
+  });
+
+  it("reads the FEC's 3 of 6, ignoring the non-voting ex officio members", () => {
+    // "Six voting members ... plus the Secretary of the Senate and the Clerk
+    // of the House as non-voting ex officio members" — the cap applies to the
+    // six, and the badge must not say 3 of 8.
+    expect(partisanCap(FEC)).toEqual({ cap: 3, total: 6 });
+  });
+
+  it("reads the NCUA's 2 of 3 — the one that isn't three", () => {
+    expect(partisanCap(NCUA)).toEqual({ cap: 2, total: 3 });
+  });
+
+  it("reads a hyphenated body size (FDIC 'five-member Board')", () => {
+    expect(partisanCap(FDIC)).toEqual({ cap: 3, total: 5 });
+  });
+
+  it("returns null where no cap exists, so no badge renders", () => {
+    expect(partisanCap(NLRB)).toBeNull();
+    expect(partisanCap(TREASURY)).toBeNull();
+  });
+
+  it("returns null rather than guessing when the numbers are unreadable", () => {
+    // Cap present in words the matcher can't resolve — fall back to the
+    // generic label rather than print a wrong number beside a source link.
+    expect(
+      partisanCap("Members may not all be of the same political party.")
+    ).toBeNull();
+  });
+
+  it("rejects a cap that is not smaller than the body", () => {
+    // Nonsense input should not render "Max 5 of 5", which reads as no limit.
+    expect(
+      partisanCap(
+        "Five commissioners appointed. Not more than five commissioners may be members of the same political party."
+      )
+    ).toBeNull();
   });
 });

--- a/__tests__/agencies.test.ts
+++ b/__tests__/agencies.test.ts
@@ -1,0 +1,117 @@
+import {
+  hasPartisanBalanceCap,
+  sortAgencies,
+  sourceLabel,
+} from "@/lib/agencies";
+import type { AgencyGovernance } from "@/lib/types";
+
+// Real strings from prod org_profiles.governance_structure (migration 012).
+// Using the actual text matters: the matcher exists to read Congress's own
+// phrasings, which vary across statutes, and a paraphrase would not test that.
+const FTC =
+  "Independent regulatory commission. Five commissioners appointed by the President with the advice and consent of the Senate, serving seven-year terms. Not more than three commissioners may be members of the same political party.";
+const FCC =
+  "Independent regulatory commission. Five commissioners appointed by the President with the advice and consent of the Senate, serving five-year terms. No more than three commissioners may belong to the same political party.";
+const CPSC =
+  "Independent regulatory commission. Five commissioners appointed by the President with the advice and consent of the Senate, serving seven-year terms. Not more than three commissioners may be affiliated with the same political party.";
+const NTSB =
+  "Independent board of five members appointed by the President with the advice and consent of the Senate, serving five-year terms. Not more than three members may be appointed from the same political party.";
+const NCUA =
+  "Governed by a three-member Board appointed by the President with the advice and consent of the Senate, serving six-year terms. Not more than two Board members may be of the same political party.";
+const NLRB =
+  "Independent agency. Five members appointed by the President with the advice and consent of the Senate, serving five-year terms. The statute sets no partisan-balance requirement.";
+const TREASURY =
+  "Executive department. The Secretary of the Treasury is appointed by the President with the advice and consent of the Senate.";
+
+function agency(
+  name: string,
+  governanceStructure: string,
+  slug = name.toLowerCase().replace(/\s+/g, "-")
+): AgencyGovernance {
+  return {
+    slug,
+    name,
+    governanceStructure,
+    governanceSource: "https://www.law.cornell.edu/uscode/text/15/41",
+    hasPartisanBalanceCap: hasPartisanBalanceCap(governanceStructure),
+  };
+}
+
+describe("hasPartisanBalanceCap", () => {
+  it("matches every phrasing Congress actually uses across these statutes", () => {
+    // "may be members of" / "may belong to" / "may be affiliated with" /
+    // "may be appointed from" / "may be of" — five different verbs, one fact.
+    expect(hasPartisanBalanceCap(FTC)).toBe(true);
+    expect(hasPartisanBalanceCap(FCC)).toBe(true);
+    expect(hasPartisanBalanceCap(CPSC)).toBe(true);
+    expect(hasPartisanBalanceCap(NTSB)).toBe(true);
+    expect(hasPartisanBalanceCap(NCUA)).toBe(true);
+  });
+
+  it("is false when a statute sets no cap — the absence is the finding", () => {
+    // The NLRB text mentions partisan balance only to say there isn't one.
+    // A naive /partisan/ matcher would get this backwards and badge it.
+    expect(hasPartisanBalanceCap(NLRB)).toBe(false);
+  });
+
+  it("is false for executive departments, which have no such concept", () => {
+    expect(hasPartisanBalanceCap(TREASURY)).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(hasPartisanBalanceCap("NOT MORE THAN THREE ... SAME POLITICAL PARTY"))
+      .toBe(true);
+  });
+
+  it("does not fire on unrelated mentions of politics", () => {
+    expect(
+      hasPartisanBalanceCap("A nonpartisan agency with no political appointees.")
+    ).toBe(false);
+  });
+});
+
+describe("sortAgencies", () => {
+  it("puts capped agencies first, alphabetical within each group", () => {
+    const sorted = sortAgencies([
+      agency("Treasury", TREASURY),
+      agency("Federal Trade Commission", FTC),
+      agency("National Labor Relations Board", NLRB),
+      agency("Consumer Product Safety Commission", CPSC),
+    ]);
+    expect(sorted.map((a) => a.name)).toEqual([
+      "Consumer Product Safety Commission",
+      "Federal Trade Commission",
+      "National Labor Relations Board",
+      "Treasury",
+    ]);
+    // Capped block is contiguous and leads.
+    expect(sorted.slice(0, 2).every((a) => a.hasPartisanBalanceCap)).toBe(true);
+    expect(sorted.slice(2).every((a) => !a.hasPartisanBalanceCap)).toBe(true);
+  });
+
+  it("does not mutate its input", () => {
+    const input = [agency("Treasury", TREASURY), agency("FTC", FTC)];
+    const before = input.map((a) => a.name);
+    sortAgencies(input);
+    expect(input.map((a) => a.name)).toEqual(before);
+  });
+
+  it("handles an empty list", () => {
+    expect(sortAgencies([])).toEqual([]);
+  });
+});
+
+describe("sourceLabel", () => {
+  it("returns a short checkable host", () => {
+    expect(sourceLabel("https://www.law.cornell.edu/uscode/text/15/41")).toBe(
+      "law.cornell.edu"
+    );
+    expect(sourceLabel("https://www.epa.gov/archive/epa/aboutepa/x.html")).toBe(
+      "epa.gov"
+    );
+  });
+
+  it("degrades to a neutral label on an unparseable URL", () => {
+    expect(sourceLabel("not a url")).toBe("source");
+  });
+});

--- a/__tests__/thinkTanks.test.ts
+++ b/__tests__/thinkTanks.test.ts
@@ -1,0 +1,111 @@
+import { claimsNonPartisanship, sortSelfDescribed } from "@/lib/thinkTanks";
+import type { SelfDescribedOrg } from "@/lib/types";
+
+// Real self_description strings from prod (migration 012), quoted from each
+// organization's own site. Paraphrases would defeat the point: the matcher
+// exists to read these organizations' actual wording.
+const BROOKINGS =
+  "Brookings equips decisionmakers with nonpartisan research and policy strategies to create a more prosperous and secure country and world.";
+const CATO =
+  "assiduously nonpartisan and independent public policy research organization—or think tank—that creates a presence for and promotes libertarian ideas";
+const CAP =
+  "independent, nonpartisan policy institute … As progressives, we believe America should be a land of boundless opportunity";
+const EPI =
+  "a nonprofit, nonpartisan think tank working for the last 30 years to counter rising inequality, low wages and weak benefits for working people … recognized as national leaders on breakthrough liberal economic policies";
+const FEDSOC =
+  "Founded in 1982, the Federalist Society for Law and Public Policy Studies is a group of conservatives and libertarians dedicated to reforming the current legal order … Beyond our statement of purpose the Federalist Society takes no public policy positions and does not participate in activism of any kind.";
+const HERITAGE =
+  "Heritage’s mission is to formulate and promote conservative public policies based on the principles of free enterprise, limited government, individual freedom, traditional American values, and a strong national defense.";
+const ACS = "the nation's foremost progressive legal organization";
+const MANHATTAN =
+  "dedicated to advancing opportunity, individual liberty, and the rule of law in America and its great cities";
+
+function org(
+  name: string,
+  selfDescription: string,
+  extra: Partial<SelfDescribedOrg> = {}
+): SelfDescribedOrg {
+  return {
+    slug: name.toLowerCase().replace(/\s+/g, "-"),
+    name,
+    type: "think-tank",
+    selfDescription,
+    selfDescriptionSource: "https://example.org/about",
+    selfDescriptionChecked: "2026-07-27",
+    faraRegistered: false,
+    faraCountries: [],
+    claimsNonPartisanship: claimsNonPartisanship(selfDescription),
+    ...extra,
+  };
+}
+
+describe("claimsNonPartisanship", () => {
+  it("catches the plain 'nonpartisan' claim across spellings", () => {
+    expect(claimsNonPartisanship(BROOKINGS)).toBe(true);
+    expect(claimsNonPartisanship(CATO)).toBe(true);
+    expect(claimsNonPartisanship(CAP)).toBe(true);
+    expect(claimsNonPartisanship(EPI)).toBe(true);
+    expect(claimsNonPartisanship("an independent, non-partisan institute")).toBe(
+      true
+    );
+  });
+
+  it("catches a disclaimer of taking positions, not just the word", () => {
+    // The Federalist Society never says "nonpartisan" — it says it takes no
+    // public policy positions. Same claim, different words; missing it would
+    // undercount the finding the page leads with.
+    expect(FEDSOC.toLowerCase()).not.toContain("nonpartisan");
+    expect(claimsNonPartisanship(FEDSOC)).toBe(true);
+  });
+
+  it("is false for organizations that make no such claim", () => {
+    expect(claimsNonPartisanship(HERITAGE)).toBe(false);
+    expect(claimsNonPartisanship(ACS)).toBe(false);
+    expect(claimsNonPartisanship(MANHATTAN)).toBe(false);
+  });
+
+  it("does not fire on 'partisan' alone", () => {
+    // "deeply partisan" is the opposite claim and must not be counted.
+    expect(claimsNonPartisanship("a deeply partisan advocacy group")).toBe(
+      false
+    );
+  });
+
+  it("reproduces the page's headline count on the real ten", () => {
+    const all = [
+      BROOKINGS, CATO, CAP, EPI, FEDSOC,
+      HERITAGE, ACS, MANHATTAN,
+      "a public policy think tank dedicated to defending human dignity, expanding human potential, and building a freer and safer world",
+      "Drawing on the legacy of Franklin and Eleanor Roosevelt, the Roosevelt Institute champions new ideas and new leaders to make our economy and democracy work for the many, not the few.",
+    ];
+    expect(all.filter(claimsNonPartisanship)).toHaveLength(5);
+  });
+});
+
+describe("sortSelfDescribed", () => {
+  it("puts non-partisanship claimants first, alphabetical within group", () => {
+    const sorted = sortSelfDescribed([
+      org("Heritage Foundation", HERITAGE),
+      org("Cato Institute", CATO),
+      org("American Constitution Society", ACS),
+      org("Brookings Institution", BROOKINGS),
+    ]);
+    expect(sorted.map((o) => o.name)).toEqual([
+      "Brookings Institution",
+      "Cato Institute",
+      "American Constitution Society",
+      "Heritage Foundation",
+    ]);
+  });
+
+  it("does not mutate its input", () => {
+    const input = [org("Heritage Foundation", HERITAGE), org("Cato", CATO)];
+    const before = input.map((o) => o.name);
+    sortSelfDescribed(input);
+    expect(input.map((o) => o.name)).toEqual(before);
+  });
+
+  it("handles an empty list", () => {
+    expect(sortSelfDescribed([])).toEqual([]);
+  });
+});

--- a/app/agencies/page.tsx
+++ b/app/agencies/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from "next";
+
+import AgenciesGovernance from "@/components/agencies/AgenciesGovernance";
+import { listAllOrgsLite, listCitedAgencies } from "@/lib/db";
+
+// ISR — statutory governance changes on the order of decades, not days. The
+// only thing that moves here is Sift citing another agency, so a 10-minute
+// window matches the rest of the civic surface without staleness mattering.
+export const revalidate = 600;
+
+const TITLE = "Who controls a federal agency — Sift";
+const DESC =
+  "Appointment, terms, and the partisan-balance limits Congress wrote into statute. Every line cited to the section it came from. No AI-generated text.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESC,
+  alternates: { canonical: "/agencies" },
+  openGraph: { title: TITLE, description: DESC, type: "website" },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESC },
+};
+
+export default async function AgenciesPage() {
+  const [agencies, allOrgs] = await Promise.all([
+    listCitedAgencies(),
+    listAllOrgsLite(),
+  ]);
+
+  // Total agency dossiers held, cited or not. Drives the "what is missing"
+  // note — the page says out loud that most agencies are omitted rather than
+  // quietly showing only the flattering subset.
+  const totalAgencies = allOrgs.filter((o) => o.type === "agency").length;
+
+  return (
+    <AgenciesGovernance agencies={agencies} totalAgencies={totalAgencies} />
+  );
+}

--- a/app/think-tanks/page.tsx
+++ b/app/think-tanks/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+
+import SelfDescriptions from "@/components/thinkTanks/SelfDescriptions";
+import { listSelfDescribedOrgs } from "@/lib/db";
+
+// ISR — a self-description changes when an organization rewrites its About
+// page, which is rare. Matches the rest of the civic surface.
+export const revalidate = 600;
+
+const TITLE = "How policy organizations describe themselves — Sift";
+const DESC =
+  "Think tanks and advocacy organizations quoted from their own sites — not summarized, not rated, not characterized. Every quote linked to its source. No AI-generated text.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESC,
+  alternates: { canonical: "/think-tanks" },
+  openGraph: { title: TITLE, description: DESC, type: "website" },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESC },
+};
+
+export default async function ThinkTanksPage() {
+  const orgs = await listSelfDescribedOrgs();
+  return <SelfDescriptions orgs={orgs} />;
+}

--- a/components/agencies/AgenciesGovernance.tsx
+++ b/components/agencies/AgenciesGovernance.tsx
@@ -1,0 +1,165 @@
+import Link from "next/link";
+
+import LandingMasthead from "@/components/landing/LandingMasthead";
+import { sortAgencies, sourceLabel } from "@/lib/agencies";
+import { COPY } from "@/lib/copy";
+import type { AgencyGovernance } from "@/lib/types";
+
+interface AgenciesGovernanceProps {
+  agencies: AgencyGovernance[];
+  /** Total agency dossiers held, cited or not — for the honest gap note. */
+  totalAgencies: number;
+}
+
+/**
+ * /agencies — statutory governance for the agencies whose law has been cited.
+ *
+ * Deliberately narrow. No AI text, no ratings, no auth, no comparison. Every
+ * claim is a statutory fact with a link to the section it came from, so the
+ * page carries none of the exposure the rest of the product does: no
+ * Cohere/Meltwater question, no Art. 50(4) disclosure obligation, no
+ * AllSides/MBFC licence dependency, and no news-avoidance problem — this is
+ * reference, not news.
+ *
+ * Mirrors the dossier pages' visual register (eyebrow, hairline rules, mono
+ * labels, Fraunces display, max-w-800) rather than inventing a layout.
+ */
+export default function AgenciesGovernance({
+  agencies,
+  totalAgencies,
+}: AgenciesGovernanceProps) {
+  const c = COPY.agencies;
+  const sorted = sortAgencies(agencies);
+  const cappedCount = sorted.filter((a) => a.hasPartisanBalanceCap).length;
+
+  return (
+    <div className="min-h-screen bg-(--surface-base) text-(--text-primary)">
+      <LandingMasthead />
+
+      <main id="main-content" className="max-w-[800px] mx-auto px-6 pt-12 pb-24">
+        <header className="mb-9">
+          <p className="font-body text-kicker uppercase text-(--text-tertiary) mb-3 flex items-center">
+            <span aria-hidden className="inline-block w-7 h-px bg-(--border) mr-3" />
+            {c.eyebrow}
+          </p>
+          <h1 className="font-heading text-[36px] md:text-[44px] font-bold leading-[1.05] tracking-tight text-(--text-primary)">
+            {c.headline}
+          </h1>
+          <p className="font-body text-[16px] text-(--text-secondary) mt-3 max-w-[62ch] leading-relaxed">
+            {c.dek}
+          </p>
+          {sorted.length > 0 && (
+            <p className="font-body text-meta uppercase text-(--text-tertiary) mt-4 tracking-wide">
+              {c.countLine(sorted.length)}
+            </p>
+          )}
+        </header>
+
+        <hr className="border-0 border-t border-(--border) mb-10" />
+
+        {sorted.length === 0 ? (
+          <p className="font-body text-[15px] text-(--text-tertiary) italic leading-relaxed">
+            {c.empty}
+          </p>
+        ) : (
+          <>
+            {/* The finding, before the list. A reader who stops here should
+                still leave with the one fact that makes the page worth
+                sending on. */}
+            {cappedCount > 0 && (
+              <section className="mb-12 border-l-2 border-(--accent) pl-5">
+                <p className="font-body text-kicker uppercase text-(--text-tertiary) mb-3">
+                  {c.capExplainerHeading}
+                </p>
+                <p className="font-body text-[16px] text-(--text-secondary) leading-relaxed max-w-[62ch]">
+                  {c.capExplainer(cappedCount, sorted.length)}
+                </p>
+              </section>
+            )}
+
+            <ul className="space-y-10">
+              {sorted.map((agency) => (
+                <li key={agency.slug}>
+                  <article>
+                    <div className="flex flex-wrap items-baseline gap-x-3 gap-y-2 mb-2">
+                      <h2 className="font-heading text-[22px] font-semibold leading-snug tracking-tight text-(--text-primary)">
+                        <Link
+                          href={`/org/${agency.slug}`}
+                          className="text-(--text-primary) no-underline hover:underline"
+                        >
+                          {agency.name}
+                        </Link>
+                      </h2>
+                      {agency.hasPartisanBalanceCap && (
+                        <span className="font-body text-meta uppercase tracking-wide text-(--accent) border border-(--accent) rounded-sm px-2 py-0.5 whitespace-nowrap">
+                          {c.capLabel}
+                        </span>
+                      )}
+                    </div>
+
+                    <p className="font-body text-[16px] text-(--text-secondary) leading-relaxed max-w-[62ch]">
+                      {agency.governanceStructure}
+                    </p>
+
+                    <p className="font-body text-meta text-(--text-tertiary) mt-3 flex flex-wrap gap-x-4 gap-y-1">
+                      <a
+                        href={agency.governanceSource}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-(--text-tertiary) no-underline hover:underline hover:text-(--accent)"
+                      >
+                        {c.sourcePrefix} {sourceLabel(agency.governanceSource)}{" "}
+                        <span aria-hidden>↗</span>
+                      </a>
+                      <Link
+                        href={`/org/${agency.slug}`}
+                        className="text-(--text-tertiary) no-underline hover:underline hover:text-(--accent)"
+                      >
+                        {c.dossierLink} →
+                      </Link>
+                    </p>
+                  </article>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+
+        <hr className="border-0 border-t border-(--border) my-12" />
+
+        {/* Provenance and the gap. Stating what is missing is the point:
+            omitting 78 agencies is a choice, and a reader who can see the
+            choice can trust the 15 that are here. */}
+        <section className="mb-8">
+          <p className="font-body text-kicker uppercase text-(--text-tertiary) mb-3">
+            {c.provenanceHeading}
+          </p>
+          <p className="font-body text-[15px] text-(--text-secondary) leading-relaxed max-w-[62ch] mb-4">
+            {c.provenance}
+          </p>
+          <p className="font-body text-[15px] text-(--text-secondary) leading-relaxed max-w-[62ch]">
+            {c.notAiNote}
+          </p>
+        </section>
+
+        {totalAgencies > sorted.length && (
+          <section className="mb-10">
+            <p className="font-body text-kicker uppercase text-(--text-tertiary) mb-3">
+              {c.incompleteHeading}
+            </p>
+            <p className="font-body text-[15px] text-(--text-secondary) leading-relaxed max-w-[62ch]">
+              {c.incomplete(sorted.length, totalAgencies)}
+            </p>
+          </section>
+        )}
+
+        <Link
+          href="/"
+          className="font-body text-meta text-(--text-tertiary) no-underline hover:underline hover:text-(--accent)"
+        >
+          <span aria-hidden>←</span> {c.backLink}
+        </Link>
+      </main>
+    </div>
+  );
+}

--- a/components/agencies/AgenciesGovernance.tsx
+++ b/components/agencies/AgenciesGovernance.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 
 import LandingMasthead from "@/components/landing/LandingMasthead";
-import { sortAgencies, sourceLabel } from "@/lib/agencies";
+import { partisanCap, sortAgencies, sourceLabel } from "@/lib/agencies";
 import { COPY } from "@/lib/copy";
 import type { AgencyGovernance } from "@/lib/types";
 
@@ -90,11 +90,19 @@ export default function AgenciesGovernance({
                           {agency.name}
                         </Link>
                       </h2>
-                      {agency.hasPartisanBalanceCap && (
-                        <span className="font-body text-meta uppercase tracking-wide text-(--accent) border border-(--accent) rounded-sm px-2 py-0.5 whitespace-nowrap">
-                          {c.capLabel}
-                        </span>
-                      )}
+                      {agency.hasPartisanBalanceCap &&
+                        (() => {
+                          // Prefer the concrete numbers; fall back only when
+                          // the statute can't be read confidently.
+                          const cap = partisanCap(agency.governanceStructure);
+                          return (
+                            <span className="font-body text-meta uppercase tracking-wide text-(--accent) border border-(--accent) rounded-sm px-2 py-0.5 whitespace-nowrap">
+                              {cap
+                                ? c.capLabel(cap.cap, cap.total)
+                                : c.capLabelFallback}
+                            </span>
+                          );
+                        })()}
                     </div>
 
                     <p className="font-body text-[16px] text-(--text-secondary) leading-relaxed max-w-[62ch]">

--- a/components/civic/CivicIndex.tsx
+++ b/components/civic/CivicIndex.tsx
@@ -6,7 +6,6 @@ import {
   groupByState,
   groupByType,
   filterByChamber,
-  orgLeanLabel,
   orgTypeLabel,
   stateName,
 } from "@/lib/civic";
@@ -34,7 +33,7 @@ interface CivicIndexProps {
  *
  * Three sections:
  *   1. Politicians — grouped by state, chamber-filterable via URL.
- *   2. Organizations — grouped by type, lean shown inline.
+ *   2. Organizations — grouped by type. No lean: D37 / migration 012.
  *   3. Bills — flat list with congress + status.
  *
  * No search, no sortable tables, no pagination — the political surface is
@@ -208,6 +207,14 @@ export default function CivicIndex({
                 {c.agenciesCrossLink}
               </Link>
             </p>
+            <p className="font-body text-[14px] mt-2 leading-relaxed">
+              <Link
+                href="/think-tanks"
+                className="text-(--accent) no-underline hover:underline"
+              >
+                {c.thinkTanksCrossLink}
+              </Link>
+            </p>
           </header>
 
           {orgTypeGroups.length === 0 ? (
@@ -233,12 +240,15 @@ export default function CivicIndex({
                         >
                           {o.name}
                         </Link>
-                        {o.politicalLean && (
-                          <span className="text-(--text-tertiary)">
-                            {" "}
-                            ({orgLeanLabel(o.politicalLean)})
-                          </span>
-                        )}
+                        {/* The Sift-assigned political_lean used to render
+                            here as "(Left)" / "(Right)" / "(Nonpartisan)".
+                            Removed: it is Sift computing its own political
+                            rating, which D37 forbids, and it was uncited.
+                            Migration 012 replaced it on the dossier pages with
+                            cited self-descriptions; this index was missed in
+                            that pass and kept publishing the label for every
+                            one of the 103 orgs. See /think-tanks for what the
+                            organizations say about themselves instead. */}
                       </li>
                     ))}
                   </ul>

--- a/components/civic/CivicIndex.tsx
+++ b/components/civic/CivicIndex.tsx
@@ -196,6 +196,18 @@ export default function CivicIndex({
                 </p>
               ) : null;
             })()}
+            {/* Cross-link to /agencies. Placed here rather than in the nav
+                because it is a cut of this section, not a separate area of the
+                site — and the agencies are the majority of these rows, so a
+                reader scanning the org list is exactly who wants it. */}
+            <p className="font-body text-[14px] mt-3 leading-relaxed">
+              <Link
+                href="/agencies"
+                className="text-(--accent) no-underline hover:underline"
+              >
+                {c.agenciesCrossLink}
+              </Link>
+            </p>
           </header>
 
           {orgTypeGroups.length === 0 ? (

--- a/components/thinkTanks/SelfDescriptions.tsx
+++ b/components/thinkTanks/SelfDescriptions.tsx
@@ -1,0 +1,155 @@
+import Link from "next/link";
+
+import LandingMasthead from "@/components/landing/LandingMasthead";
+import { sourceLabel } from "@/lib/agencies";
+import { COPY } from "@/lib/copy";
+import { sortSelfDescribed } from "@/lib/thinkTanks";
+import type { SelfDescribedOrg } from "@/lib/types";
+
+interface SelfDescriptionsProps {
+  orgs: SelfDescribedOrg[];
+}
+
+/**
+ * /think-tanks — policy organizations in their own words.
+ *
+ * The quote is the page. Everything else is scaffolding around it: a source
+ * link, a verification date, and two public-record facts (FARA registration,
+ * the org type). Sift assigns nothing here — which is the point, and the
+ * reason this replaced the Sift-authored `political_lean` on these rows.
+ *
+ * Same posture as /agencies: no AI text, no ratings, no auth, no comparison.
+ * Reference rather than news.
+ */
+export default function SelfDescriptions({ orgs }: SelfDescriptionsProps) {
+  const c = COPY.thinkTanks;
+  const sorted = sortSelfDescribed(orgs);
+  const claiming = sorted.filter((o) => o.claimsNonPartisanship).length;
+
+  return (
+    <div className="min-h-screen bg-(--surface-base) text-(--text-primary)">
+      <LandingMasthead />
+
+      <main id="main-content" className="max-w-[800px] mx-auto px-6 pt-12 pb-24">
+        <header className="mb-9">
+          <p className="font-body text-kicker uppercase text-(--text-tertiary) mb-3 flex items-center">
+            <span aria-hidden className="inline-block w-7 h-px bg-(--border) mr-3" />
+            {c.eyebrow}
+          </p>
+          <h1 className="font-heading text-[36px] md:text-[44px] font-bold leading-[1.05] tracking-tight text-(--text-primary)">
+            {c.headline}
+          </h1>
+          <p className="font-body text-[16px] text-(--text-secondary) mt-3 max-w-[62ch] leading-relaxed">
+            {c.dek}
+          </p>
+          {sorted.length > 0 && (
+            <p className="font-body text-meta uppercase text-(--text-tertiary) mt-4 tracking-wide">
+              {c.countLine(sorted.length)}
+            </p>
+          )}
+        </header>
+
+        <hr className="border-0 border-t border-(--border) mb-10" />
+
+        {sorted.length === 0 ? (
+          <p className="font-body text-[15px] text-(--text-tertiary) italic leading-relaxed">
+            {c.empty}
+          </p>
+        ) : (
+          <>
+            {/* The observation, before the quotes. Deliberately stops short of
+                calling it a contradiction — party and ideology are different
+                things, and the reader has both halves right below. */}
+            {claiming > 0 && (
+              <section className="mb-12 border-l-2 border-(--accent) pl-5">
+                <p className="font-body text-kicker uppercase text-(--text-tertiary) mb-3">
+                  {c.findingHeading}
+                </p>
+                <p className="font-body text-[16px] text-(--text-secondary) leading-relaxed max-w-[62ch]">
+                  {c.finding(claiming, sorted.length)}
+                </p>
+              </section>
+            )}
+
+            <ul className="space-y-12">
+              {sorted.map((org) => (
+                <li key={org.slug}>
+                  <article>
+                    <div className="flex flex-wrap items-baseline gap-x-3 gap-y-2 mb-3">
+                      <h2 className="font-heading text-[22px] font-semibold leading-snug tracking-tight text-(--text-primary)">
+                        <Link
+                          href={`/org/${org.slug}`}
+                          className="text-(--text-primary) no-underline hover:underline"
+                        >
+                          {org.name}
+                        </Link>
+                      </h2>
+                      {org.claimsNonPartisanship && (
+                        <span className="font-body text-meta uppercase tracking-wide text-(--accent) border border-(--accent) rounded-sm px-2 py-0.5 whitespace-nowrap">
+                          {c.nonPartisanBadge}
+                        </span>
+                      )}
+                      {org.faraRegistered && (
+                        <span className="font-body text-meta uppercase tracking-wide text-(--text-tertiary) border border-(--border) rounded-sm px-2 py-0.5">
+                          {c.faraBadge(org.faraCountries)}
+                        </span>
+                      )}
+                    </div>
+
+                    {/* The quote is the content. Given display weight so it
+                        reads as theirs, not as Sift's prose about them. */}
+                    <blockquote className="font-heading text-[20px] text-(--text-primary) leading-snug max-w-[60ch] border-l-2 border-(--border) pl-4">
+                      &ldquo;{org.selfDescription}&rdquo;
+                    </blockquote>
+
+                    <p className="font-body text-meta text-(--text-tertiary) mt-3 flex flex-wrap gap-x-4 gap-y-1">
+                      <a
+                        href={org.selfDescriptionSource}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-(--text-tertiary) no-underline hover:underline hover:text-(--accent)"
+                      >
+                        {c.sourcePrefix} {sourceLabel(org.selfDescriptionSource)}
+                        {org.selfDescriptionChecked
+                          ? ` · ${c.checkedPrefix} ${org.selfDescriptionChecked}`
+                          : ""}{" "}
+                        <span aria-hidden>↗</span>
+                      </a>
+                      <Link
+                        href={`/org/${org.slug}`}
+                        className="text-(--text-tertiary) no-underline hover:underline hover:text-(--accent)"
+                      >
+                        {c.dossierLink} →
+                      </Link>
+                    </p>
+                  </article>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+
+        <hr className="border-0 border-t border-(--border) my-12" />
+
+        <section className="mb-10">
+          <p className="font-body text-kicker uppercase text-(--text-tertiary) mb-3">
+            {c.provenanceHeading}
+          </p>
+          <p className="font-body text-[15px] text-(--text-secondary) leading-relaxed max-w-[62ch] mb-4">
+            {c.provenance}
+          </p>
+          <p className="font-body text-[15px] text-(--text-secondary) leading-relaxed max-w-[62ch]">
+            {c.notAiNote}
+          </p>
+        </section>
+
+        <Link
+          href="/"
+          className="font-body text-meta text-(--text-tertiary) no-underline hover:underline hover:text-(--accent)"
+        >
+          <span aria-hidden>←</span> {c.backLink}
+        </Link>
+      </main>
+    </div>
+  );
+}

--- a/lib/agencies.ts
+++ b/lib/agencies.ts
@@ -1,0 +1,55 @@
+import type { AgencyGovernance } from "./types";
+
+/**
+ * Helpers for /agencies — the cited-governance page.
+ *
+ * Everything here reads facts already written to `org_profiles` by
+ * sift-api migration 012. Nothing on this page is AI-generated and nothing is
+ * Sift's own characterization: each entry is a statutory fact with a link to
+ * the section it came from.
+ */
+
+/**
+ * Does the citing statute cap how many members may share a political party?
+ *
+ * Read off the stored statutory text rather than kept as its own column, and
+ * that is deliberate. The claim only exists because the cited section says so;
+ * a separate boolean could drift out of step with the prose it is supposed to
+ * summarise, and then the badge would assert something the source link
+ * contradicts. Deriving it keeps the two impossible to separate.
+ *
+ * Matches the phrasings Congress actually uses across these statutes:
+ *   "no more than three ... may belong to the same political party"  (FCC)
+ *   "Not more than three ... shall be members of the same political party" (FTC)
+ *   "Not more than three ... may be affiliated with the same political party" (CPSC)
+ *   "Not more than 3 members may be appointed from the same political party" (NTSB)
+ */
+export function hasPartisanBalanceCap(governanceStructure: string): boolean {
+  return /same political party/i.test(governanceStructure);
+}
+
+/**
+ * Capped agencies first, then alphabetical within each group.
+ *
+ * The cap is the reason this page is interesting — it is the fact that
+ * explains deadlock coverage — so it leads. Alphabetical within group because
+ * any other ordering would be an editorial ranking of agencies, which is
+ * exactly the kind of Sift-assigned judgment migration 012 removed.
+ */
+export function sortAgencies(agencies: AgencyGovernance[]): AgencyGovernance[] {
+  return [...agencies].sort((a, b) => {
+    if (a.hasPartisanBalanceCap !== b.hasPartisanBalanceCap) {
+      return a.hasPartisanBalanceCap ? -1 : 1;
+    }
+    return a.name.localeCompare(b.name, "en");
+  });
+}
+
+/** Short, checkable label for a citation link, e.g. "law.cornell.edu". */
+export function sourceLabel(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return "source";
+  }
+}

--- a/lib/agencies.ts
+++ b/lib/agencies.ts
@@ -28,6 +28,59 @@ export function hasPartisanBalanceCap(governanceStructure: string): boolean {
   return /same political party/i.test(governanceStructure);
 }
 
+const NUMBER_WORDS: Record<string, number> = {
+  one: 1, two: 2, three: 3, four: 4, five: 5,
+  six: 6, seven: 7, eight: 8, nine: 9, ten: 10,
+};
+
+function toNumber(word: string): number | null {
+  const w = word.toLowerCase();
+  if (NUMBER_WORDS[w] !== undefined) return NUMBER_WORDS[w];
+  const n = Number.parseInt(w, 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/**
+ * The cap and the body size it applies to, e.g. {cap: 3, total: 5}.
+ *
+ * Both numbers are read out of the same cited sentence-pair they describe, for
+ * the reason given on `hasPartisanBalanceCap` — a stored pair could drift from
+ * the prose and then the badge would contradict its own source link.
+ *
+ * The numbers genuinely differ across these statutes (FEC 3 of 6, NCUA 2 of 3,
+ * most commissions 3 of 5), which is exactly why the badge is worth computing
+ * rather than writing one fixed string.
+ *
+ * Returns null when either number can't be read with confidence. Callers fall
+ * back to the generic label rather than guessing — a wrong number here is
+ * worse than a vaguer one, because the source link is right beside it.
+ */
+export function partisanCap(
+  governanceStructure: string
+): { cap: number; total: number } | null {
+  if (!hasPartisanBalanceCap(governanceStructure)) return null;
+
+  // "No more than three ... may belong to the same political party"
+  // "Not more than two Board members may be of the same political party"
+  const capMatch = governanceStructure.match(
+    /(?:no|not)\s+more\s+than\s+([a-z]+|\d+)\b[^.]*?same political party/i
+  );
+  // First body-size mention: "Five commissioners", "Six voting members",
+  // "five members", "a five-member Board of Directors", "three-member Board".
+  const totalMatch = governanceStructure.match(
+    /\b([a-z]+|\d+)[-\s]+(?:voting\s+)?(?:commissioners?|members?)\b/i
+  );
+  if (!capMatch || !totalMatch) return null;
+
+  const cap = toNumber(capMatch[1]);
+  const total = toNumber(totalMatch[1]);
+  if (cap === null || total === null) return null;
+  // A cap that isn't smaller than the body isn't a constraint; treat as
+  // unreadable rather than publish something that reads as nonsense.
+  if (cap >= total) return null;
+  return { cap, total };
+}
+
 /**
  * Capped agencies first, then alphabetical within each group.
  *

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -602,6 +602,35 @@ export const COPY = {
     empty: "No agency governance has been cited yet.",
     backLink: "Back to Sift",
   },
+  // /think-tanks — the self-description page. Every rendered claim is the
+  // organization's own wording, quoted and linked. Sift does not characterize
+  // these organizations; that is the whole reason this replaced the
+  // Sift-assigned political_lean (D37, migration 012).
+  thinkTanks: {
+    eyebrow: "In their own words",
+    headline: "How policy organizations describe themselves",
+    dek: "Each of these organizations, quoted from its own site \u2014 not summarized, not rated, not characterized by Sift. Every quote links to the page it came from.",
+    countLine: (n: number) =>
+      `${n} ${n === 1 ? "organization" : "organizations"}, quoted and cited`,
+    nonPartisanBadge: "Also calls itself nonpartisan",
+    faraBadge: (countries: string[]) =>
+      countries.length > 0
+        ? `Registered foreign agent \u00b7 ${countries.join(", ")}`
+        : "Registered foreign agent",
+    findingHeading: "What to notice",
+    finding: (claiming: number, total: number) =>
+      `${claiming} of these ${total} state an ideology and a claim of non-partisanship in the same breath \u2014 conservative, libertarian, progressive or liberal, alongside "nonpartisan" or a disclaimer of taking positions. Both halves are quoted below. Party and ideology are not the same thing, and an organization can honestly claim one while holding the other; a one-word label would have hidden the distinction entirely.`,
+    sourcePrefix: "Their words, from",
+    checkedPrefix: "last verified",
+    dossierLink: "Full dossier",
+    provenanceHeading: "How this page was made",
+    provenance:
+      "These are self-descriptions: what each organization says about itself, not an independent assessment. Organizations describe themselves favorably \u2014 that is exactly why the wording is quoted rather than paraphrased, and why the source sits beside every one. Sift assigns no rating to any organization on this page.",
+    notAiNote:
+      "No part of this page is AI-generated. Every quotation was read from the organization's own site on the date shown.",
+    empty: "No self-descriptions have been cited yet.",
+    backLink: "Back to Sift",
+  },
   civicIndex: {
     eyebrow: "Civic dossiers",
     headline: "Civic dossiers",
@@ -640,6 +669,8 @@ export const COPY = {
     // click; the partisan-balance fact does.
     agenciesCrossLink:
       "Who controls a federal agency \u2014 appointment, terms, and the party-balance limits written into statute \u2192",
+    thinkTanksCrossLink:
+      "How these organizations describe themselves \u2014 in their own words, quoted and linked \u2192",
     emptyBills: "No bills curated yet.",
     billsMoreSoon: "More bills as they're curated.",
     backLink: "Back to Sift",

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -626,6 +626,11 @@ export const COPY = {
     emptyPoliticians:
       "No politicians match this filter. Try Senate, House, or All.",
     emptyOrgs: "No organizations curated yet.",
+    // Cross-link into /agencies. States the payoff rather than the
+    // destination — "see the agencies page" gives a reader no reason to
+    // click; the partisan-balance fact does.
+    agenciesCrossLink:
+      "Who controls a federal agency \u2014 appointment, terms, and the party-balance limits written into statute \u2192",
     emptyBills: "No bills curated yet.",
     billsMoreSoon: "More bills as they're curated.",
     backLink: "Back to Sift",

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -573,7 +573,16 @@ export const COPY = {
     eyebrow: "Public records",
     headline: "Who controls a federal agency",
     dek: "Appointment, terms, and the partisan-balance limits Congress wrote into statute \u2014 for the agencies whose governing law Sift has read and cited. Every line links to the section it came from.",
-    capLabel: "Statutory partisan-balance limit",
+    // Per-agency and concrete. The first reader of this page asked what
+    // "statutory partisan-balance limit" meant — naming a category made a
+    // reader decode it; the numbers state the constraint outright. They
+    // genuinely differ (FEC 3 of 6, NCUA 2 of 3), so this is computed.
+    capLabel: (cap: number, total: number) =>
+      `Max ${cap} of ${total} from one party`,
+    // Used only when the numbers can't be read out of the statute with
+    // confidence. A vaguer label beats a wrong number sitting next to a
+    // source link that contradicts it.
+    capLabelFallback: "Party balance required by law",
     capExplainerHeading: "Why this matters",
     // The finding, stated plainly. Counts are computed from live data.
     capExplainer: (capped: number, total: number) =>

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -563,6 +563,36 @@ export const COPY = {
       tagline: "Every story links to the original.",
     },
   },
+  // /agencies — the cited-governance page. Every string here describes a
+  // statutory fact or the provenance of one. Nothing on this page is
+  // AI-generated and nothing is Sift's own characterization, which is the
+  // whole point of it: it is the one surface with no Cohere/Meltwater
+  // exposure, no Art. 50(4) disclosure obligation, and no ratings licence
+  // dependency. Keep it that way.
+  agencies: {
+    eyebrow: "Public records",
+    headline: "Who controls a federal agency",
+    dek: "Appointment, terms, and the partisan-balance limits Congress wrote into statute \u2014 for the agencies whose governing law Sift has read and cited. Every line links to the section it came from.",
+    capLabel: "Statutory partisan-balance limit",
+    capExplainerHeading: "Why this matters",
+    // The finding, stated plainly. Counts are computed from live data.
+    capExplainer: (capped: number, total: number) =>
+      `${capped} of these ${total} agencies operate under a limit, written into their authorizing statute, on how many members may belong to one political party. That constraint \u2014 not personality, and not the current administration \u2014 is why some of them deadlock. Where a statute sets no such limit, that absence is a fact about the agency too.`,
+    countLine: (total: number) =>
+      `${total} ${total === 1 ? "agency" : "agencies"} with cited governing law`,
+    sourcePrefix: "Source:",
+    dossierLink: "Full dossier",
+    provenanceHeading: "How this page was made",
+    provenance:
+      "Each entry states only what the cited section says. Facts that change with an administration \u2014 who currently chairs an agency, its present composition, which president appointed the sitting majority \u2014 are deliberately absent: they go stale and there is no process here to refresh them. What remains is structural and durable.",
+    notAiNote:
+      "No part of this page is AI-generated. These are statutory facts, quoted or summarized from the sections linked beside each one.",
+    incompleteHeading: "What is missing",
+    incomplete: (shown: number, totalAgencies: number) =>
+      `Sift holds dossiers on ${totalAgencies} federal agencies. ${shown} appear here \u2014 the ones whose governing law has been read and cited. The rest are omitted rather than summarized from memory.`,
+    empty: "No agency governance has been cited yet.",
+    backLink: "Back to Sift",
+  },
   civicIndex: {
     eyebrow: "Civic dossiers",
     headline: "Civic dossiers",

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,6 +1,7 @@
 import { Pool } from "pg";
 
 import { parseDbOrgProfile, type DbOrgProfileRow } from "./org";
+import { hasPartisanBalanceCap } from "./agencies";
 import { parseDbBillProfile, type DbBillProfileRow } from "./bill";
 import { parseDbOutletProfile, type DbOutletProfileRow } from "./outlet";
 import {
@@ -13,6 +14,7 @@ import {
   type OutletStats,
 } from "./outletStats";
 import type {
+  AgencyGovernance,
   BillListItem,
   BillProfile,
   OrgListItem,
@@ -798,6 +800,45 @@ export async function listAllPoliticiansLite(): Promise<PoliticianListItem[]> {
  * Lite list of every curated org for the civic index page. Sorted by type
  * then name so the index can group by type without re-sorting client-side.
  */
+/**
+ * Agencies whose governance is documented AND cited. Powers /agencies.
+ *
+ * The WHERE clause is the load-bearing part: both the text and its source URL
+ * must be present, so a row can never reach the page as an uncited assertion
+ * about how a federal agency is controlled. As of migration 012 that is 15 of
+ * 93 agency rows — the rest render nothing rather than something unsourced.
+ */
+export async function listCitedAgencies(): Promise<AgencyGovernance[]> {
+  try {
+    const result = await pool.query<{
+      slug: string;
+      name: string;
+      governance_structure: string;
+      governance_source: string;
+    }>(
+      `SELECT slug, name, governance_structure, governance_source
+       FROM org_profiles
+       WHERE type = 'agency'
+         AND governance_structure IS NOT NULL
+         AND governance_source IS NOT NULL
+       ORDER BY name ASC`,
+    );
+    return result.rows.map((r) => ({
+      slug: r.slug,
+      name: r.name,
+      governanceStructure: r.governance_structure,
+      governanceSource: r.governance_source,
+      hasPartisanBalanceCap: hasPartisanBalanceCap(r.governance_structure),
+    }));
+  } catch (err) {
+    // Pre-012 databases lack the columns; degrade to an empty page rather
+    // than a 500. The page renders its own empty state.
+    const msg = String(err);
+    if (msg.includes("does not exist")) return [];
+    throw err;
+  }
+}
+
 export async function listAllOrgsLite(): Promise<OrgListItem[]> {
   try {
     const result = await pool.query<{

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -2,6 +2,7 @@ import { Pool } from "pg";
 
 import { parseDbOrgProfile, type DbOrgProfileRow } from "./org";
 import { hasPartisanBalanceCap } from "./agencies";
+import { claimsNonPartisanship } from "./thinkTanks";
 import { parseDbBillProfile, type DbBillProfileRow } from "./bill";
 import { parseDbOutletProfile, type DbOutletProfileRow } from "./outlet";
 import {
@@ -15,6 +16,7 @@ import {
 } from "./outletStats";
 import type {
   AgencyGovernance,
+  SelfDescribedOrg,
   BillListItem,
   BillProfile,
   OrgListItem,
@@ -833,6 +835,59 @@ export async function listCitedAgencies(): Promise<AgencyGovernance[]> {
   } catch (err) {
     // Pre-012 databases lack the columns; degrade to an empty page rather
     // than a 500. The page renders its own empty state.
+    const msg = String(err);
+    if (msg.includes("does not exist")) return [];
+    throw err;
+  }
+}
+
+/**
+ * Organizations that describe themselves, quoted and cited. Powers /think-tanks.
+ *
+ * Both the quote and its source must be present — same rule as
+ * listCitedAgencies. Excludes agencies: a federal agency does not "describe
+ * itself" in the sense this page means, and lumping them together would blur
+ * the distinction the page is built on.
+ */
+export async function listSelfDescribedOrgs(): Promise<SelfDescribedOrg[]> {
+  try {
+    const result = await pool.query<{
+      slug: string;
+      name: string;
+      type: string | null;
+      self_description: string;
+      self_description_source: string;
+      self_description_checked: Date | string | null;
+      fara_registered: boolean | null;
+      fara_countries: unknown;
+    }>(
+      `SELECT slug, name, type, self_description, self_description_source,
+              self_description_checked, fara_registered, fara_countries
+       FROM org_profiles
+       WHERE type <> 'agency'
+         AND self_description IS NOT NULL
+         AND self_description_source IS NOT NULL
+       ORDER BY name ASC`,
+    );
+    return result.rows.map((r) => ({
+      slug: r.slug,
+      name: r.name,
+      type: (r.type as SelfDescribedOrg["type"]) ?? null,
+      selfDescription: r.self_description,
+      selfDescriptionSource: r.self_description_source,
+      selfDescriptionChecked:
+        r.self_description_checked instanceof Date
+          ? r.self_description_checked.toISOString().slice(0, 10)
+          : (r.self_description_checked?.trim() || null),
+      faraRegistered: r.fara_registered === true,
+      faraCountries: Array.isArray(r.fara_countries)
+        ? (r.fara_countries as unknown[]).filter(
+            (v): v is string => typeof v === "string",
+          )
+        : [],
+      claimsNonPartisanship: claimsNonPartisanship(r.self_description),
+    }));
+  } catch (err) {
     const msg = String(err);
     if (msg.includes("does not exist")) return [];
     throw err;

--- a/lib/thinkTanks.ts
+++ b/lib/thinkTanks.ts
@@ -1,0 +1,53 @@
+import type { SelfDescribedOrg } from "./types";
+
+/**
+ * Helpers for /think-tanks — the self-description page.
+ *
+ * Everything rendered there is the organization's own wording, quoted verbatim
+ * and linked to the page it came from. Sift does not characterize these
+ * organizations, which is the whole reason this page replaced the Sift-assigned
+ * `political_lean` (sift-api migration 012, D37).
+ */
+
+/**
+ * Does the organization's own description claim non-partisanship, or disclaim
+ * taking policy positions?
+ *
+ * This is a fact about the quoted text, not a judgment about the organization —
+ * and the quote is rendered directly beside the badge, so a reader can check it
+ * in the same glance. That is the only reason it is safe to compute: an
+ * assessment a reader cannot verify on the spot would be exactly the
+ * Sift-assigned characterization D37 forbids.
+ *
+ * Covers the phrasings these organizations actually use:
+ *   "nonpartisan research and policy strategies"          (Brookings)
+ *   "assiduously nonpartisan and independent"             (Cato)
+ *   "independent, nonpartisan policy institute"           (CAP)
+ *   "a nonprofit, nonpartisan think tank"                 (EPI)
+ *   "takes no public policy positions"                    (Federalist Society)
+ */
+export function claimsNonPartisanship(selfDescription: string): boolean {
+  const t = selfDescription.toLowerCase();
+  return (
+    /\bnon-?partisan\b/.test(t) ||
+    /takes no public policy positions/.test(t) ||
+    /any special interest or political party/.test(t)
+  );
+}
+
+/**
+ * Organizations that claim non-partisanship first, then alphabetical.
+ *
+ * The juxtaposition is the finding — a stated ideology and a stated
+ * non-partisanship in the same breath — so those lead. Alphabetical within
+ * each group, because ranking policy organizations against each other would be
+ * an editorial judgment, which is what this page exists to avoid making.
+ */
+export function sortSelfDescribed(orgs: SelfDescribedOrg[]): SelfDescribedOrg[] {
+  return [...orgs].sort((a, b) => {
+    if (a.claimsNonPartisanship !== b.claimsNonPartisanship) {
+      return a.claimsNonPartisanship ? -1 : 1;
+    }
+    return a.name.localeCompare(b.name, "en");
+  });
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -239,6 +239,27 @@ export interface AgencyGovernance {
   hasPartisanBalanceCap: boolean;
 }
 
+/**
+ * An organization rendered through its own words. Powers /think-tanks.
+ *
+ * Like AgencyGovernance, there is no nullable-source variant: a quote without
+ * the page it came from is the defect migration 012 removed, and the query
+ * refuses to build one.
+ */
+export interface SelfDescribedOrg {
+  slug: string;
+  name: string;
+  type: OrgType | null;
+  selfDescription: string;
+  selfDescriptionSource: string;
+  selfDescriptionChecked: string | null;
+  /** FARA-registered. A public-record fact, shown because it sits oddly beside a non-partisanship claim. */
+  faraRegistered: boolean;
+  faraCountries: string[];
+  /** True when the org's own wording claims non-partisanship — see lib/thinkTanks.ts. */
+  claimsNonPartisanship: boolean;
+}
+
 // ─── Entity Links (Phase 3.H) ──────────────────────────
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -217,6 +217,28 @@ export interface OrgProfile {
   notes: string | null;
 }
 
+/**
+ * An agency whose governance is documented and cited. Powers /agencies.
+ *
+ * Only rows with BOTH `governance_structure` and `governance_source` are ever
+ * built into this shape — an uncited claim about how a federal agency is
+ * controlled is the same defect the Sift-assigned `political_lean` was
+ * (migration 012). The query enforces it; the type has no nullable variant on
+ * purpose, so a caller cannot render one without a source.
+ */
+export interface AgencyGovernance {
+  slug: string;
+  name: string;
+  governanceStructure: string;
+  governanceSource: string;
+  /**
+   * True when the citing statute caps how many members may share a political
+   * party. Derived from the statutory text, not asserted by Sift — see
+   * lib/agencies.ts for why this is read off the prose rather than stored.
+   */
+  hasPartisanBalanceCap: boolean;
+}
+
 // ─── Entity Links (Phase 3.H) ──────────────────────────
 
 /**


### PR DESCRIPTION
Both publishable artifacts for the **week-one evidence test** in `docs/LAUNCH_DECISION_MEMO.md` §4.2 — the memo offered two framings and this builds both, so the choice can be made by looking rather than guessing.

Plus a **live D37 violation** found along the way. See the last section; it may warrant shipping ahead of the rest.

## `/agencies` — who controls a federal agency

25 agencies whose governing law has been read and cited: how many members, who appoints them, term length, and whether the statute caps how many may share a political party.

**Leads with: 13 of 25 operate under a statutory partisan-balance cap.** The FEC's six voting members capped at three per party is *why* it deadlocks 3–3. Where a statute sets no cap (NLRB), the absence is a fact too.

The badge states the constraint — **"Max 3 of 5 from one party"** — not its category. It originally read *"Statutory partisan-balance limit"*; the page's first reader asked what that meant, which is the whole audience answering in advance. The numbers genuinely differ (FEC 3 of 6, NCUA 2 of 3), so it's computed.

## `/think-tanks` — organizations in their own words

10 think tanks and advocacy organizations, each quoted verbatim from its own site with source and verification date.

**Leads with: 5 of 10 state an ideology and a claim of non-partisanship in the same breath.** The page deliberately does **not** call that a contradiction — party and ideology are different things, and an organization can honestly claim one while holding the other. Both halves are quoted; the reader concludes. A one-word lean label would have erased the distinction entirely, which is the concrete case for why migration 012 was worth doing.

FARA registration renders as a second badge. Brookings claims nonpartisan research and is a registered foreign agent for Qatar — both facts, both public record, no comment.

## Why these pages rather than the product

| | |
|---|---|
| No *Cohere*/*Meltwater* question | public records and quotations, not summarized journalism |
| No Art. 50(4) obligation | nothing on either page is AI-generated |
| No AllSides/MBFC licence dependency | no ratings anywhere |
| No news-avoidance problem | reference, not news |
| No auth wall, no 504, no cost exposure | nothing computes on request |

## ⚠️ Also fixes a live D37 violation

`/civic` was **still rendering the Sift-assigned political lean** inline for every organization — *"American Constitution Society (Left)"*, *"Federalist Society (Right)"*, *"Amtrak (Nonpartisan)"* — on all 103 rows.

Migration 012 removed it from the dossier pages. **This index was missed in that pass**, so the violation stayed live on the most-linked civic page while being reported as fixed. Found by reading the rendered `/civic` output while adding a cross-link.

Removed, with the reason recorded inline so it doesn't return, and the stale "lean shown inline" component doc corrected.

**If you want this out ahead of the pages, `37e96ce`/`1858bac` can be split** — the removal is a handful of lines in `CivicIndex.tsx` plus one import.

## Design decisions worth reviewing

- **Both queries require the text *and* its source.** Neither `AgencyGovernance` nor `SelfDescribedOrg` has a nullable-source variant, so an uncited characterization of a real organization cannot reach a page even if the data is edited carelessly.
- **Derived facts read the stored text** rather than living in their own columns. A stored boolean could drift from the prose it summarizes, and then a badge would contradict the source link directly beneath it.
- **`partisanCap` returns null rather than guessing**, falling back to a vaguer label. A wrong number beside a one-click-checkable citation is worse than a vague one.
- **Both pages sort by the finding, then alphabetically.** Any other ordering would be a Sift-assigned ranking — what 012 removed.
- **`/agencies` states what's missing:** 68 of 93 agencies are omitted rather than summarized from memory.
- **No current chairs, composition, or appointing presidents.** Those rot and there's no refresh job.

## Tests

**26 new** across `__tests__/agencies.test.ts` and `__tests__/thinkTanks.test.ts`, using **real prod strings** — the matchers exist to read actual wording, and paraphrases wouldn't test that. Notable cases:

- NLRB's *"the statute sets no partisan-balance requirement"* must read **false** — a naive `/partisan/` matcher badges it backwards
- FEC must not render **"3 of 8"** — its non-voting ex officio members don't count toward the cap
- The Federalist Society never says "nonpartisan" but does say it *"takes no public policy positions"* — missing that undercounts the finding to 4
- A cap not smaller than the body → null, since "Max 5 of 5" describes no limit at all

## Verification

- `tsc --noEmit` clean; `jest` — **382 passed**, 21 suites
- Parser checked against **all 25 production strings** before wiring: 13 capped, 13 parsed, 0 unparsed, 0 false positives
- Both pages rendered against **production data** and reviewed in a browser: correct counts, ordering, badges, and cross-links
- Confirmed no lean label survives anywhere on `/civic`

## Known and deliberate

Neither page is linked from the site nav — only from `/civic`. The week-one test sends direct URLs; making these permanent product surfaces is a separate decision.

Only the agencies badge has had a cold read from anyone but me. The "Why this matters" / "What to notice" blocks and the provenance notes are unreviewed copy — and the badge failing its first cold read is reason to expect the same of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)