### PR TITLE
feat(orgs): budgets render only with fiscal year + source; drop political_lean

### DIFF
--- a/__tests__/org.test.ts
+++ b/__tests__/org.test.ts
@@ -1,6 +1,5 @@
 import {
   formatBudgetUsd,
-  formatOrgLeanLabel,
   formatOrgTypeLabel,
   parseDbOrgProfile,
   type DbOrgProfileRow,
@@ -12,7 +11,8 @@ const fullRow: DbOrgProfileRow = {
   slug: "brookings-institution",
   name: "Brookings Institution",
   type: "think-tank",
-  political_lean: "center",
+  annual_budget_fy: "FY ending June 2025",
+  annual_budget_source: "https://projects.propublica.org/nonprofits/organizations/530196577",
   founded_year: 1916,
   annual_budget_usd: 120_000_000,
   major_funders: [
@@ -53,25 +53,6 @@ describe("formatOrgTypeLabel", () => {
   it("returns null for null/undefined", () => {
     expect(formatOrgTypeLabel(null)).toBeNull();
     expect(formatOrgTypeLabel(undefined)).toBeNull();
-  });
-});
-
-// ─── formatOrgLeanLabel ──────────────────────────────────
-
-describe("formatOrgLeanLabel", () => {
-  it("formats every valid lean (incl. nonpartisan)", () => {
-    expect(formatOrgLeanLabel("left")).toBe("Left");
-    expect(formatOrgLeanLabel("lean-left")).toBe("Lean Left");
-    expect(formatOrgLeanLabel("center")).toBe("Center");
-    expect(formatOrgLeanLabel("lean-right")).toBe("Lean Right");
-    expect(formatOrgLeanLabel("right")).toBe("Right");
-    expect(formatOrgLeanLabel("mixed")).toBe("Mixed");
-    expect(formatOrgLeanLabel("nonpartisan")).toBe("Nonpartisan");
-  });
-
-  it("returns null for null/undefined", () => {
-    expect(formatOrgLeanLabel(null)).toBeNull();
-    expect(formatOrgLeanLabel(undefined)).toBeNull();
   });
 });
 
@@ -123,7 +104,8 @@ describe("parseDbOrgProfile", () => {
         slug: "brookings-institution",
         name: "Brookings Institution",
         type: "think-tank",
-        politicalLean: "center",
+        annualBudgetFy: "FY ending June 2025",
+        annualBudgetSource: "https://projects.propublica.org/nonprofits/organizations/530196577",
         foundedYear: 1916,
         annualBudgetUsd: 120_000_000,
         majorFunders: [
@@ -185,12 +167,20 @@ describe("parseDbOrgProfile", () => {
       expect(profile?.type).toBeNull();
     });
 
-    it("nulls out unknown political_lean values", () => {
-      const profile = parseDbOrgProfile({
-        ...fullRow,
-        political_lean: "very-left",
-      });
-      expect(profile?.politicalLean).toBeNull();
+    it("drops a budget figure that has no fiscal year or source", () => {
+      // Migration 013: an unsourced number is exactly the fixture value this
+      // replaced. Parser nulls all three together rather than let a bare
+      // figure render.
+      const noFy = parseDbOrgProfile({ ...fullRow, annual_budget_fy: null });
+      expect(noFy?.annualBudgetUsd).toBeNull();
+      expect(noFy?.annualBudgetSource).toBeNull();
+
+      const noSrc = parseDbOrgProfile({ ...fullRow, annual_budget_source: null });
+      expect(noSrc?.annualBudgetUsd).toBeNull();
+      expect(noSrc?.annualBudgetFy).toBeNull();
+
+      const badSrc = parseDbOrgProfile({ ...fullRow, annual_budget_source: "a filing somewhere" });
+      expect(badSrc?.annualBudgetUsd).toBeNull();
     });
 
     it("normalizes empty-string optional fields to null", () => {

--- a/components/org/OrgDossier.tsx
+++ b/components/org/OrgDossier.tsx
@@ -4,7 +4,6 @@ import LandingMasthead from "@/components/landing/LandingMasthead";
 import { COPY } from "@/lib/copy";
 import {
   formatBudgetUsd,
-  formatOrgLeanLabel,
   formatOrgTypeLabel,
 } from "@/lib/org";
 import type { OrgProfile } from "@/lib/types";
@@ -28,7 +27,6 @@ interface OrgDossierProps {
 export default function OrgDossier({ org }: OrgDossierProps) {
   const c = COPY.orgDossier;
   const typeLabel = formatOrgTypeLabel(org.type);
-  const leanLabel = formatOrgLeanLabel(org.politicalLean);
   const budgetLabel = formatBudgetUsd(org.annualBudgetUsd);
 
   // Lede bits: "{type} · Founded {year} · Annual budget ~{budget}"
@@ -36,7 +34,8 @@ export default function OrgDossier({ org }: OrgDossierProps) {
   const ledeBits: string[] = [];
   if (typeLabel) ledeBits.push(typeLabel);
   if (org.foundedYear) ledeBits.push(c.foundedYearLabel(org.foundedYear));
-  if (budgetLabel) ledeBits.push(c.annualBudgetLabel(budgetLabel));
+  if (budgetLabel && org.annualBudgetFy)
+    ledeBits.push(c.annualBudgetLabel(budgetLabel, org.annualBudgetFy));
 
   // External links: stable order; forward-compat for unknown keys.
   const linkOrder: Array<keyof typeof c.externalLinkLabels> = [
@@ -85,6 +84,20 @@ export default function OrgDossier({ org }: OrgDossierProps) {
           {ledeBits.length > 0 && (
             <p className="font-body text-[16px] text-(--text-secondary) mt-3 max-w-[60ch] leading-relaxed">
               {ledeBits.join(" · ")}
+            </p>
+          )}
+          {/* The budget figure is only meaningful with the filing it came
+              from — lib/org.ts refuses to surface one without a source. */}
+          {org.annualBudgetUsd !== null && org.annualBudgetSource && (
+            <p className="font-body text-meta text-(--text-tertiary) mt-2">
+              <a
+                href={org.annualBudgetSource}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-(--text-tertiary) no-underline hover:underline hover:text-(--accent)"
+              >
+                {c.budgetSourceLabel} <span aria-hidden>↗</span>
+              </a>
             </p>
           )}
         </header>

--- a/lib/civic.ts
+++ b/lib/civic.ts
@@ -4,7 +4,6 @@
 
 import type {
   OrgListItem,
-  OrgPoliticalLean,
   OrgType,
   PoliticianChamber,
   PoliticianListItem,
@@ -89,20 +88,6 @@ export function orgTypeLabel(type: OrgType | null | undefined): string {
 }
 
 /** Pretty-printed lean label for sub-sorted listing inside type groups. */
-export const ORG_LEAN_LABELS: Record<OrgPoliticalLean, string> = {
-  "left": "Left",
-  "lean-left": "Lean left",
-  "center": "Center",
-  "lean-right": "Lean right",
-  "right": "Right",
-  "mixed": "Mixed",
-  "nonpartisan": "Nonpartisan",
-};
-
-export function orgLeanLabel(lean: OrgPoliticalLean | null | undefined): string {
-  if (!lean) return "—";
-  return ORG_LEAN_LABELS[lean] ?? "—";
-}
 
 /**
  * Group orgs by `type`, preserving incoming sort order within each group.

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -318,7 +318,12 @@ export const COPY = {
           : `This organization is registered with the U.S. Department of Justice under FARA on behalf of: ${countries.join(", ")}.`,
     // Single-line lede builder bits.
     foundedYearLabel: (year: number) => `Founded ${year}`,
-    annualBudgetLabel: (budget: string) => `Annual budget ~${budget}`,
+    // Was `Annual budget ~${budget}` against an unsourced fixture figure.
+    // "Annual budget" was never a checkable claim; total expenses from a named
+    // filing is. The tilde is gone too — the figure is now exact.
+    annualBudgetLabel: (budget: string, fy: string) =>
+      `Total expenses ${budget} · ${fy}`,
+    budgetSourceLabel: "Per the Form 990 on ProPublica Nonprofit Explorer",
     methodologyHint: "Funding data comes from IRS 990s and FARA. Read the methodology.",
   },
   billDossier: {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -707,8 +707,9 @@ export async function getOrgBySlug(slug: string): Promise<OrgProfile | null> {
 
   try {
     const result = await pool.query<DbOrgProfileRow>(
-      `SELECT slug, name, type, political_lean, founded_year,
-              annual_budget_usd, major_funders, fara_registered,
+      `SELECT slug, name, type, founded_year,
+              annual_budget_usd, annual_budget_fy, annual_budget_source,
+              major_funders, fara_registered,
               fara_countries, external_links, notes,
               self_description, self_description_source,
               self_description_checked, governance_structure,
@@ -900,9 +901,8 @@ export async function listAllOrgsLite(): Promise<OrgListItem[]> {
       slug: string;
       name: string;
       type: string | null;
-      political_lean: string | null;
     }>(
-      `SELECT slug, name, type, political_lean
+      `SELECT slug, name, type
        FROM org_profiles
        ORDER BY type ASC NULLS LAST, name ASC`,
     );
@@ -910,7 +910,6 @@ export async function listAllOrgsLite(): Promise<OrgListItem[]> {
       slug: r.slug,
       name: r.name,
       type: (r.type as OrgListItem["type"]) ?? null,
-      politicalLean: (r.political_lean as OrgListItem["politicalLean"]) ?? null,
     }));
   } catch (err) {
     const msg = String(err);

--- a/lib/org.ts
+++ b/lib/org.ts
@@ -6,7 +6,6 @@
 
 import type {
   OrgExternalLinks,
-  OrgPoliticalLean,
   OrgProfile,
   OrgType,
 } from "./types";
@@ -23,16 +22,6 @@ const ORG_TYPES: ReadonlySet<string> = new Set([
   "industry-group",
   "agency",
   "other",
-]);
-
-const ORG_LEAN_VALUES: ReadonlySet<string> = new Set([
-  "left",
-  "lean-left",
-  "center",
-  "lean-right",
-  "right",
-  "mixed",
-  "nonpartisan",
 ]);
 
 // ─── Display labels ───────────────────────────────────────────────────
@@ -57,24 +46,7 @@ export function formatOrgTypeLabel(
   return ORG_TYPE_LABELS[type] ?? null;
 }
 
-const ORG_LEAN_LABELS: Record<OrgPoliticalLean, string> = {
-  left: "Left",
-  "lean-left": "Lean Left",
-  center: "Center",
-  "lean-right": "Lean Right",
-  right: "Right",
-  mixed: "Mixed",
-  nonpartisan: "Nonpartisan",
-};
-
 /** Human label for an org political-lean enum, e.g. `"lean-left"` → `"Lean Left"`. */
-export function formatOrgLeanLabel(
-  lean: OrgPoliticalLean | null | undefined,
-): string | null {
-  if (!lean) return null;
-  return ORG_LEAN_LABELS[lean] ?? null;
-}
-
 /**
  * Compact USD formatter for org budgets.
  *   1_200_000_000 → "$1.2B"
@@ -116,9 +88,10 @@ export interface DbOrgProfileRow {
   slug: string;
   name: string;
   type: string | null;
-  political_lean: string | null;
   founded_year: number | null;
   annual_budget_usd: number | string | null;  // pg returns NUMERIC as string sometimes
+  annual_budget_fy: string | null;
+  annual_budget_source: string | null;
   major_funders: unknown;  // expected: string[]
   fara_registered: boolean | null;
   fara_countries: unknown;  // expected: string[]
@@ -151,12 +124,6 @@ function asOrgType(v: string | null): OrgType | null {
   if (!v) return null;
   const lower = v.toLowerCase();
   return ORG_TYPES.has(lower) ? (lower as OrgType) : null;
-}
-
-function asOrgLean(v: string | null): OrgPoliticalLean | null {
-  if (!v) return null;
-  const lower = v.toLowerCase();
-  return ORG_LEAN_VALUES.has(lower) ? (lower as OrgPoliticalLean) : null;
 }
 
 /**
@@ -211,12 +178,23 @@ export function parseDbOrgProfile(
     slug,
     name,
     type: asOrgType(row.type),
-    politicalLean: asOrgLean(row.political_lean),
     foundedYear:
       typeof row.founded_year === "number" && Number.isFinite(row.founded_year)
         ? row.founded_year
         : null,
-    annualBudgetUsd: asNumeric(row.annual_budget_usd),
+    // Budget renders only with its fiscal year AND source — same rule as
+    // self_description. An unsourced figure is what migration 013 removed.
+    ...(() => {
+      const usd = asNumeric(row.annual_budget_usd);
+      const fy = row.annual_budget_fy?.trim() || null;
+      const src = row.annual_budget_source?.trim() || null;
+      const cited = usd !== null && fy !== null && !!src && /^https?:\/\//i.test(src);
+      return {
+        annualBudgetUsd: cited ? usd : null,
+        annualBudgetFy: cited ? fy : null,
+        annualBudgetSource: cited ? src : null,
+      };
+    })(),
     majorFunders: asStringArray(row.major_funders),
     faraRegistered: row.fara_registered === true,
     faraCountries: asStringArray(row.fara_countries),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -192,12 +192,6 @@ export interface OrgProfile {
   name: string;
   type: OrgType | null;
   /**
-   * @deprecated Migration 012 (2026-07-27). Sift-assigned and uncited, contrary
-   * to D37 ("Sift surfaces ratings verbatim and never computes its own"). No
-   * longer rendered — see `selfDescription`. Retained for rollback only.
-   */
-  politicalLean: OrgPoliticalLean | null;
-  /**
    * The organization's own characterization of itself, verbatim. NEVER Sift's
    * assessment. Renders only when `selfDescriptionSource` is present — an
    * uncited quote is the same failure `politicalLean` was.
@@ -209,7 +203,14 @@ export interface OrgProfile {
   governanceStructure: string | null;
   governanceSource: string | null;
   foundedYear: number | null;
+  /**
+   * Total functional expenses from the Form 990 at `annualBudgetSource`.
+   * NOT a general "annual budget" — that was the unsourced fixture value this
+   * replaced (migration 013). Renders only with `annualBudgetFy` + source.
+   */
   annualBudgetUsd: number | null;
+  annualBudgetFy: string | null;
+  annualBudgetSource: string | null;
   majorFunders: string[];
   faraRegistered: boolean;
   faraCountries: string[];
@@ -414,7 +415,6 @@ export interface OrgListItem {
   slug: string;
   name: string;
   type: OrgType | null;
-  politicalLean: OrgPoliticalLean | null;
 }
 
 /**


### PR DESCRIPTION
Frontend half of the minimum scope. Pairs with **kristenmartino/sift-api#110** (migration 013 + the data). **Merge sift-api#110 first** — this reads two columns it creates and stops reading one it drops.

## What changed

**Budgets are now checkable.** `annual_budget_usd` means total functional expenses from a named Form 990. The lede reads:

> Total expenses $107.7M · FY ending June 2025

…with a link to the filing. It previously read *"Annual budget ~$120M"* against an unsourced fixture figure. The tilde is gone because the number is now exact.

`lib/org.ts` nulls the figure, the fiscal year and the source **together** unless all three are present and the source is an `http(s)` URL — the same rule already guarding `self_description` and `governance_structure`. An unsourced number is precisely what migration 013 removed, so the parser refuses to surface one.

**`political_lean` is deleted, not deprecated.** Migration 012 left it in place for rollback and stopped rendering it on the dossier — and `/civic` went on publishing it for all 103 orgs for another day. A column that still exists is a column something can still read. Removed from types, queries, parsers, and labels.

**`major_funders` and `notes` still render when present.** The 10 think-tank rows simply no longer have them; the 93 agency rows keep their notes.

## Test change worth reviewing

The test asserting `political_lean` degradation is replaced by one asserting the budget citation rule — no fiscal year, no source, or a non-URL source each null the figure rather than let a bare number reach the page.

## Verification

- `tsc --noEmit` clean; `jest` — **380 passed**, 21 suites
- Rendered against **production data**: `/org/brookings-institution` shows the new budget line with a working ProPublica link; FARA, funders and notes sections correctly absent
- `/civic`, `/agencies`, `/think-tanks`, `/org/manhattan-institute` all HTTP 200

## Context

These 10 rows shipped as *"example rows … during local development"* in sift-api#26 and were never replaced — full provenance in `STATUS.md` and sift#177. Every budget figure was wrong; five of ten ProPublica links 404'd.

**Still deliberately unverified:** `founded_year` on these 10 rows. Low-risk and cheap, but not part of this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)