### PR TITLE
docs(status): founded_year dropped from the 10; flagged on the 93

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -100,7 +100,23 @@ Options: **(a)** drop the section; **(b)** verify all 30; **(c)** verify the top
 
 **2. `notes`.** Brookings' reads *"Centrist policy think tank"* — the political lean D37 removed, surviving in prose. CAP: *"Founded by John Podesta. Closely associated with the Democratic establishment."* Cato: *"Long-running Koch family backing."* ACS: *"Progressive counterpart to the Federalist Society."* `standards-counsel` flagged these during the panel and they are still live. Heritage's *"Authored Project 2025 policy framework"* is the one checkable fact among them.
 
-### Recommended scope — minimum, then stop
+### ✅ Minimum scope completed 2026-07-28
+
+Budgets replaced with total functional expenses read to the dollar from each Form 990, each carrying a fiscal year and a source; the 5 dead ProPublica links corrected; `major_funders`, `notes` and `political_lean` removed. `sift-api`#110 + `sift`#178.
+
+**`founded_year` also dropped, after attempting to verify it.** Only **2 of 10** could be confirmed from the organization's own site — Cato (*"Since 1977…"*) and the Federalist Society (*"Founded in 1982…"*) — and **both matched the stored value**. The other eight do not state a founding year on their About or History pages; Heritage and EPI block automated fetches.
+
+That is a materially better result than the budgets (10/10 wrong), and suggests the fixture author got stable well-known facts right while fabricating the specific ones. But the available fallbacks fall below the standard now applied to every other field here: Wikipedia is secondary, and ProPublica's **"Ruling year" is the IRS determination year — a different fact.** Labelling it "Founded" would repeat the funders-citation error, where the cited record could not support the claim attached to it.
+
+Dropped rather than keeping the two confirmable: **one unsourced field on an otherwise fully-sourced page is the field a reader spot-checks precisely because everything else is cited.**
+
+**Every rendered field on those 10 dossiers now carries a source or is absent.** Verified row by row.
+
+### ⚠️ Still open: `founded_year` on the 93 agency rows
+
+All 93 have it, and it is still rendered and still unsourced. Not dropped, because that population has different provenance — its budget figures are precise to the dollar and include a negative, so it looks like real extraction rather than fixtures. **It has not been verified.** Note also that founding is often already stated, with a citation, inside `governance_structure` (EPA: *"began operations on December 2, 1970"*), so the separate field may be redundant as well as unsourced.
+
+### Original recommended scope — minimum, then stop
 
 Fix budgets to cited expenses, fix the 5 dead links, drop `major_funders` and the editorial `notes`, drop `political_lean`. Result: 10 dossiers where every rendered field is sourced — thinner, and defensible to a librarian.
 


### PR DESCRIPTION
Record for **kristenmartino/sift-api#111**. Docs only.

## The finding

Attempted to verify `founded_year` on the 10 fixture rows against each organization's own site — the standard used for `self_description`.

**Only 2 of 10 state one, and both matched:** Cato (*"Since 1977…"*) and the Federalist Society (*"Founded in 1982…"*). The other eight don't state a founding year on their About or History pages; Heritage and EPI block automated fetches.

That's a much better hit rate than the budgets (10/10 wrong), and it sharpens the picture of how these fixtures were written: **stable well-known facts came out right; the specific ones — budgets, EINs — were fabricated.**

## Why it was dropped anyway

The fallbacks fall below the standard now applied to every other field on these dossiers. Wikipedia is secondary. ProPublica's **"Ruling year" is the IRS determination year** — a different fact, and calling it "Founded" would repeat the funders-citation error where the cited record couldn't support the claim.

Keeping the two confirmable would leave one unsourced field on an otherwise fully-sourced page — the field a reader spot-checks *because* everything else is cited.

## Also flags what this doesn't cover

**All 93 agency rows still have `founded_year`, still rendered, still unverified.** Left alone deliberately: different provenance (precise budget figures including a negative — real extraction, not fixtures). Also noted that founding is often already stated *with a citation* inside `governance_structure`, so the field may be redundant there as well as unsourced.

## Where the 10 rows now stand

Every rendered field carries a source or is absent. Verified row by row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)