### PR TITLE
feat: serve on siftnews.io; point metadataBase at it

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,7 +44,16 @@ export const metadata: Metadata = {
   },
   description:
     "Sift curates outlets across the political spectrum and adds the footnotes — the civic context the news assumes, the framing across the spectrum, and the financial and political ties behind every story. Every claim links to a public record.",
-  metadataBase: new URL("https://siftnews.kristenmartino.ai"),
+  // siftnews.io as of 2026-07-28. Drives canonical URLs and OG/Twitter card
+  // resolution, so it has to be the domain people are actually sent to —
+  // /agencies and /think-tanks go out in the week-one test on this host.
+  //
+  // The three Clerk entries in next.config.js still pin
+  // clerk.siftnews.kristenmartino.ai. That is deliberate and separable: the
+  // pages being sent use no auth, so they serve correctly here, while
+  // sign-in / bookmarks / compare stay on the old host until the Clerk
+  // production instance is migrated. See docs/WEEK_ONE_OUTREACH.md.
+  metadataBase: new URL("https://siftnews.io"),
   openGraph: {
     title: "Sift — The news, with footnotes.",
     description:


### PR DESCRIPTION
`siftnews.io` was registered 2026-07-28 and is now **attached to the Vercel project**. It already serves `/`, `/agencies` and `/think-tanks` correctly — verified live, with the right counts, badges and gap note.

## ⚠️ Merge before sending any links

Until this deploys, **`siftnews.io/agencies` serves correct content with a canonical pointing back at `siftnews.kristenmartino.ai`** — which tells crawlers the old URL is authoritative. `metadataBase` drives canonical and OG/Twitter card resolution, so it has to be the host people are actually sent to.

Once deployed, both hosts emit a canonical of `siftnews.io`. That's the correct way to run them side by side: no redirect needed, no duplicate-content problem, and the portfolio case-study link keeps working — which `GROWTH_STRATEGY.md` §7 specifically wanted preserved for a year.

## What is deliberately NOT changed

The three Clerk CSP entries in `next.config.js` still pin `clerk.siftnews.kristenmartino.ai`.

`red-team` costed the domain move at 4–6 hours, but that bundled two separable things:

| | Cost | Scope |
|---|---|---|
| **This PR** | ~20 min | Domain attached, `metadataBase` updated. The pages the test sends use **no auth**, so they serve correctly today. |
| **Deferred** | 4–6 hrs | Migrate the Clerk production instance + CSP. Only sign-in, bookmarks and compare depend on it — and it still has no day-90 payoff on its own. |

**Tradeoff to accept knowingly:** someone landing on `siftnews.io` and clicking "Sign in" hits a broken flow. At zero users that's theoretical, and it's what turns a six-hour migration into a twenty-minute one.

## Why this matters beyond the URL

`acquirer` called the portfolio subdomain **fatal for transferability** — *"no buyer can acquire a subdomain of your personal portfolio,"* and Website Closers' diligence checklist opens with domain ownership. That objection is now answered, for $46/yr and twenty minutes.

It also removes the first thing a skeptical librarian would notice about a resource they're being asked to evaluate.

## Verification

- `tsc --noEmit` clean; `jest` — 380 passed
- `https://siftnews.io/agencies` → **200**, correct content: 25 agencies, 13 badged, all three cap variants rendering, gap note accurate
- `https://siftnews.io/think-tanks` → 200
- `https://siftnews.io/` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)