### PR TITLE
fix(agencies): copy fixes from a critical read of the live page

### DIFF
--- a/components/agencies/AgenciesGovernance.tsx
+++ b/components/agencies/AgenciesGovernance.tsx
@@ -48,11 +48,16 @@ export default function AgenciesGovernance({
           <p className="font-body text-[16px] text-(--text-secondary) mt-3 max-w-[62ch] leading-relaxed">
             {c.dek}
           </p>
-          {sorted.length > 0 && (
-            <p className="font-body text-meta uppercase text-(--text-tertiary) mt-4 tracking-wide">
-              {c.countLine(sorted.length)}
-            </p>
-          )}
+          {/* Cold read, #1: the masthead above says "the news, with footnotes"
+              and the nav shows a Sports tab. Someone arriving from a cold
+              email about statutory reference has to reconcile that before
+              reading a word — so say it here rather than let them find it.
+              Also pulls the "what is missing" count up from the footer, where
+              most readers never reach it. */}
+          <p className="font-body text-[15px] text-(--text-tertiary) mt-4 max-w-[62ch] leading-relaxed">
+            {c.contextNote}
+          </p>
+
         </header>
 
         <hr className="border-0 border-t border-(--border) mb-10" />

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -577,7 +577,14 @@ export const COPY = {
   agencies: {
     eyebrow: "Public records",
     headline: "Who controls a federal agency",
-    dek: "Appointment, terms, and the partisan-balance limits Congress wrote into statute \u2014 for the agencies whose governing law Sift has read and cited. Every line links to the section it came from.",
+    dek: "Appointment, terms, and the partisan-balance limits Congress wrote into statute, for 25 federal agencies \u2014 each cited to the section of the U.S. Code it came from.",
+    // #1 from the cold read: the masthead above this page says "the news, with
+    // footnotes" and the nav shows a Sports tab. A government-information
+    // librarian arriving from a cold email sees a news aggregator and has to
+    // reconcile that with "no AI-generated text" before reading a word. Owning
+    // the mismatch in one line beats letting them find it.
+    contextNote:
+      "Part of Sift, a news-context project \u2014 but this page is public-records reference, and contains no AI-generated text. 25 of the 93 agencies Sift holds appear here: the ones whose governing law has been read and cited.",
     // Per-agency and concrete. The first reader of this page asked what
     // "statutory partisan-balance limit" meant — naming a category made a
     // reader decode it; the numbers state the constraint outright. They
@@ -591,7 +598,7 @@ export const COPY = {
     capExplainerHeading: "Why this matters",
     // The finding, stated plainly. Counts are computed from live data.
     capExplainer: (capped: number, total: number) =>
-      `${capped} of these ${total} agencies operate under a limit, written into their authorizing statute, on how many members may belong to one political party. That constraint \u2014 not personality, and not the current administration \u2014 is why some of them deadlock. Where a statute sets no such limit, that absence is a fact about the agency too.`,
+      `${capped} of these ${total} agencies operate under a limit, written into their authorizing statute, on how many members may belong to one political party. The Federal Election Commission is the clearest case: six voting members, no more than three from either party, and no tie-breaking seat \u2014 so a party-line split is 3\u20133 and nothing carries. That is structural, not a matter of personality or of who is currently in office. Where a statute sets no such limit \u2014 the National Labor Relations Board, for instance \u2014 that absence is a fact about the agency too.`,
     countLine: (total: number) =>
       `${total} ${total === 1 ? "agency" : "agencies"} with cited governing law`,
     sourcePrefix: "Source:",
@@ -603,7 +610,7 @@ export const COPY = {
       "No part of this page is AI-generated. These are statutory facts, quoted or summarized from the sections linked beside each one.",
     incompleteHeading: "What is missing",
     incomplete: (shown: number, totalAgencies: number) =>
-      `Sift holds dossiers on ${totalAgencies} federal agencies. ${shown} appear here \u2014 the ones whose governing law has been read and cited. The rest are omitted rather than summarized from memory.`,
+      `The other ${totalAgencies - shown} agencies Sift holds are omitted rather than summarized from memory. Each one appears here only once its governing statute has been read and cited \u2014 which is slower than filling the gaps from general knowledge, and is the point.`,
     empty: "No agency governance has been cited yet.",
     backLink: "Back to Sift",
   },


### PR DESCRIPTION
Three changes, in the order a reader hits them.

## 1. Own the nav mismatch

The masthead above this page says *"The news, with footnotes"* and the category strip shows **Sports** and **Entertainment** tabs.

A government-information librarian arriving from a cold email about statutory reference sees a news aggregator, and has to reconcile that with *"nothing is AI-generated"* before reading a word. **That's the biggest credibility gap on the page, and it sits above the headline.**

New line under the dek says it outright rather than letting them find it — part of a news-context project, but this page is public-records reference with no AI-generated text. It also pulls the **25-of-93 gap up from the footer**, where most readers never reach it.

## 2. Name the FEC in the finding

Before: *"13 of these 25 operate under a limit … is why some of them deadlock."* Pattern stated, instance left for the reader to reconstruct by diffing 25 statutes.

Now it says it: **six voting members, no more than three from either party, no tie-breaking seat — so a party-line split is 3–3 and nothing carries.** Names the NLRB as the counter-case.

This is the example the outreach email leads with, and it wasn't on the page it links to.

## 3. Drop the process voice

The dek read *"for the agencies whose governing law **Sift has read and cited**"* — first person about our own workflow, on a page that otherwise stays out of the way. Now: *"for 25 federal agencies — each cited to the section of the U.S. Code it came from."*

## Knock-on cleanup

Adding the context note made the separate uppercase count line directly beneath it pure repetition — removed. The footer "What is missing" no longer restates the same numbers, only what the top line doesn't say: *why* the rest are absent.

## Retracted, not a bug

An earlier read suggested CPSC, EEOC, FCC and FDIC were missing their partisan-balance badges. **That was an artifact of my own text extraction** deduping short repeated strings — "Max 3 of 5 from one party" appears many times, and my reader collapsed them.

Verified against the server HTML per agency: **all 13 badges render**, matching the count the page claims.

## Still unreviewed by anyone outside

- **The headline.** *"Who controls a federal agency"* — highest-leverage string on the page, and I wrote it, so I have no distance on it.
- **Whether "Why this matters" reads as condescending** to a reader who already knows this material.

The cheapest fix for both is sending to **one** friendly librarian before the batch of forty.

## Verification

- `tsc --noEmit` clean; `jest` — 380 passed
- Rendered against production data and re-read top to bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)