### PR TITLE
docs: red-team fixes — unwire the gate, fix the pay clause, add a return hook

### DIFF
--- a/docs/LAUNCH_DECISION_MEMO.md
+++ b/docs/LAUNCH_DECISION_MEMO.md
@@ -195,14 +195,24 @@ The plan is re-denominated at **6 hrs/week, not 10–15** — the number now wri
 2. **Send it to ~40 librarians and ~20 policy staffers**, one question: *"Is this useful, and does your organization pay for anything like it?"* ~5 hrs.
 3. **Count replies.** ~1 hr.
 
-**Why this is the right test.** It answers Q1 (who responds), Q2 (they got a dossier and no comparison — if they ask for comparison, that is the answer), Q3 (they answer willingness-to-pay in writing), and the dossier-value question, **simultaneously, in week one**. And it sidesteps four structural problems the full sequence walks into:
+**Why this is the right test.** ⚠️ **Corrected 2026-07-28 after a red-team review — this paragraph originally overclaimed.** It said the test answers Q1, Q2, Q3 and the dossier-value question *simultaneously*. It does not:
+
+- **Q1 — no.** The wedge definition in Q9 is *returns unprompted*. A reply is not a return, and `/agencies` is static with no email capture, so the test is structurally incapable of producing one unit of that metric.
+- **Q2 — no.** §6 pre-registers Q2 as a within-person comparison over ten paired first-clicks. This shows one arm and infers the other from spontaneous mention; nobody asks for a feature they have never seen.
+- **Q3 — partly**, and only once the email asks §6's actual falsifier rather than the version §6 retired. Fixed in `WEEK_ONE_OUTREACH.md`.
+
+**What it actually is: recruiting for the ten conversations.** Success is enough named humans to book five calls. That is a real and necessary job — the conversations were always the instrument, and this is the funnel that feeds them. See `WEEK_ONE_OUTREACH.md` for the corrected framing. And it sidesteps four structural problems the full sequence walks into:
 
 - **No Art. 50(4) exposure** — public records, not AI text. No disclosure obligation, no Q7 hours.
 - **No AllSides/MBFC licensing dependency** — no ratings on the page.
 - **No signup wall, no 504, no cost exposure, no `/compare/[slug]` build.**
 - **No news-avoidance problem** — and nobody else on the panel named this. Every channel in the §3 sequence points at a front door that is *reading AI summaries of the news*, in a market where §7 of the operating context records 42% actively avoiding news and usage down 12pp since 2020. **The org dossiers are not news. They are reference** — no avoidance problem, no freshness problem, no *Cohere*/*Meltwater* problem.
 
-**Gate.** If nobody replies, that is the day-90 answer arriving in week one, and Q9 triggers cheap and early — which is exactly what Q9 is for. If ten people reply, there is a list, a wedge, and an evidence-backed reason to build the rest.
+**Gate.** ⚠️ **Rewritten 2026-07-28 — the original was arithmetic nonsense.** It read: *"If nobody replies, that is the day-90 answer arriving in week one, and Q9 triggers cheap and early."*
+
+At 60 sends, P(exactly 0 replies) is **under 1%** at any plausible reply rate, and P(≥10) is only **7.3%** at a 10% rate. So the celebrated early kill switch was dead code, and the plan defined outcomes at 0 and ≥10 while the *modal* result is about six — for which there was no branch at all. Pre-registration that omits the median outcome is not pre-registration.
+
+**The gate is unwired from Q9.** Zero replies would indict the list or the send, not the product. Roughly six replies is a success if five of them will take a call. Q9's day-90 trigger stands on its own terms and is not fed by this test.
 
 **Weeks 2–3, only if the gate passes.** Ten conversations in two rounds, using `user-researcher`'s script and pre-registered decision rules — now with respondents rather than cold strangers. Email capture form. AllSides/MBFC letters. Analytics identity (~1 hr).
 
@@ -275,7 +285,7 @@ Blocking = ships before the first external link points a stranger at the site. F
 | **Q6** | Android | **CLOSED 2026-07-27 — paused.** §9 supersedes `STATUS.md`. `sift-android` Phase 2 work is preserved. `acquirer`: sale-neutral (a Phase-2 repo with zero users was never a transferable asset); interview-negative **unless** the conversations happen. |
 | **Q7** | The human-review step | **REOPENED by `red-team`, then closed on a different answer.** The §3 design (Tier A gate + **daily** 15-min sample + weekly diff + a review count **published monthly on `/about`**, ≈1.75 hrs/wk) was rejected on a specific and correct argument: today `colophon:70` is an *accurate statement of a bad fact*, fixable in 15 minutes. A published compliance metric on the Art. 50(4) page that lapses in month two — and a daily obligation with no reader and no deadline will lapse — becomes an *inaccurate statement of a good fact*, in writing, on the page a plaintiff or regulator reads first. That trades a 15-minute fix for a durable liability. The coverage was also aimed wrong: §3.5's hard gate protects 15 static pages while the summarizer firehose (§2.2b) runs unreviewed.<br><br>**Adopted instead: Tier A only — deterministic, automated, zero recurring human hours.** Hold anything matching legal-process vocabulary or naming a person not matchable to `politician_profiles.bioguide_id`. Keep the **shadow-mode week** before committing (the best-designed element of the original). **Publish no review count on `/about` until the process has survived four consecutive unassisted weeks.** `/about` describes the policy; it does not report a metric. If the gate fires >~30/day, shrink the corpus — the sports and entertainment feeds are the obvious cut and are also the lowest civic value. |
 | **Q8** | US-only or global | **Deferred to week 12.** Everything in this memo assumes a US-only posture; that assumption is now explicit. |
-| **Q9** | The walk-away | **CLOSED — and pulled earlier.** Original: <100 weekly actives and <$100 MRR at day 180. Adopted trigger, from `product-analyst`: **if day 90 shows fewer than 5 named humans who returned unprompted, trigger Q9 then, not at day 180.** Five in 90 days at this hour budget does not reach 100 weekly actives before the job search ends. Also triggered early if ten conversations produce "no wedge identified." |
+| **Q9** | The walk-away | **CLOSED — and pulled earlier.** Original: <100 weekly actives and <$100 MRR at day 180. Adopted trigger, from `product-analyst`: **if day 90 shows fewer than 5 named humans who returned unprompted, trigger Q9 then, not at day 180.** Five in 90 days at this hour budget does not reach 100 weekly actives before the job search ends. Also triggered early if ten conversations produce "no wedge identified." ⚠️ **Corrected 2026-07-28:** an earlier revision wired the week-one email test into this trigger. That was wrong — P(0 replies from 60 sends) is under 1%, so it could never fire, and `/agencies` cannot produce an unprompted return in any case. Q9 stands on the day-90 named-humans count alone. |
 
 ---
 

--- a/docs/WEEK_ONE_OUTREACH.md
+++ b/docs/WEEK_ONE_OUTREACH.md
@@ -5,17 +5,43 @@
 **Send target:** ~40 librarians, ~20 policy staffers
 **Artifact:** `/agencies` — 25 federal agencies with cited statutory governance
 
-> **These are not the interview-recruiting emails.** The memo's §3.4 recruiting email deliberately names no product, because it asks about behaviour before showing anything. These *send the link* — they are the test itself. Don't mix them up.
+> **This is recruiting, not a test.** Revised 2026-07-28 after a red-team review. These emails send the link, unlike the memo's §3.4 recruiting email — but what they produce is *access to named humans*, not data that closes a question. Read the next section before sending; the framing matters more than the wording.
 
 ---
 
-## The one question
+## ⚠️ What this can and cannot establish
 
-Everything else is scaffolding around this:
+The memo's §4.2 claimed this test answers Q1, Q2, Q3 and the dossier-value question **simultaneously**. That was an overclaim. Corrected:
 
-> **Is this useful to you or your patrons, and does your institution pay for anything like it?**
+| | Can it? | Why |
+|---|---|---|
+| **Q1 — wedge user** | **No** | The project's own wedge definition is *returns unprompted*. A reply is not a return, and `/agencies` is static with no email capture. This test is structurally incapable of producing one unit of the metric Q9 is denominated in. It also samples 2 of 4 candidate wedges. |
+| **Q2 — dossier vs comparison** | **No** | §6 pre-registers Q2 as a *within-person* comparison: ten people, paired first-clicks. This shows one arm and infers the other from spontaneous mention. Nobody asks for a feature they have never seen. |
+| **Q3 — willingness to pay** | **Partly**, once reworded | §6 retired *"do you pay for Quorum?"* in favour of *"could your institution buy from a sole proprietor with no VPAT?"* The first draft asked the version §6 rejected. Fixed below. |
+| **Recruiting for the ten conversations** | **Yes** | This is the real job. Ten to fifteen named professionals, a verbatim record of how they describe the problem, and the incumbent map. |
 
-The second clause is Q3 answered in writing, months earlier than the original plan reached it. It is the question that separates polite interest from a market.
+**Success is therefore: enough named humans to book five calls.** Not a reply count.
+
+### The gate was arithmetic nonsense
+
+At 60 sends, the pre-registered thresholds behave like this:
+
+| true reply rate | expected replies | P(≥10) | P(exactly 0) |
+|---|---|---|---|
+| 10% | 6.0 | **7.3%** | 0.18% |
+| 12% | 7.2 | 17.8% | 0.05% |
+| 15% | 9.0 | 41.2% | 0.01% |
+
+Two consequences:
+
+1. **"Nobody replies → Q9 fires in week one" is dead code.** P(0 of 60) is under 1% at any plausible rate. If it ever fired it would indict the list or the send, not the product.
+2. **There was no branch for the modal outcome.** The plan defined ≥10 and 0. The likely result is **six**. Pre-registration that omits the median outcome is not pre-registration.
+
+**The gate is unwired from Q9 and from Q1/Q2/Q3.** It is a recruiting funnel with a defined value at every outcome: ~6 replies is a success if five of them will take a call.
+
+### One confound to hold in mind
+
+You selected the one profession whose job description is answering polite, well-sourced questions from strangers about government information. **A good reply rate from librarians may measure professional courtesy, not demand.** Compare the two segments separately — the librarian-vs-staffer *gap* carries more signal than either number.
 
 ---
 
@@ -33,7 +59,12 @@ The second clause is Q3 answered in writing, months earlier than the original pl
 >
 > https://siftnews.io/agencies
 >
-> Two questions, if you have a minute: **is this useful to you or your patrons, and does your institution pay for anything like it?**
+> Two things, if you have a minute:
+>
+> 1. Is this useful to you or your patrons?
+> 2. If something like this were worth paying for, could your library actually buy it from one person, invoiced directly — or does that route not really exist?
+>
+> I'm working through the other 68 agencies. Want me to send you the next batch?
 >
 > Either answer helps. If it's not useful, that's the most useful thing you can tell me.
 >
@@ -59,7 +90,12 @@ Different reader, different opening. A legislative aide doesn't curate resources
 >
 > https://siftnews.io/agencies
 >
-> If you have a minute: **is this useful in your work, and does your office pay for anything that covers this?** A "no, we use X" is genuinely useful — I'd rather know.
+> Two things, if you have a minute:
+>
+> 1. Is this useful in your work? A "no, we use X" is genuinely useful — I'd rather know.
+> 2. If it were, could your office actually buy something like this from one person, invoiced directly — or does procurement not have a shape for that?
+>
+> I'm working through the other 68 agencies. Want the next batch when it's up?
 >
 > Kristen Martino
 
@@ -75,7 +111,13 @@ Different reader, different opening. A legislative aide doesn't curate resources
 
 **The last line licenses a no.** Without it, silence is uninterpretable. With it, *"not useful because X"* is a reply — and replies are the metric, not positive replies.
 
-**Neither asks for a call, a signup, or a share.** One ask. Adding a second halves the response rate and muddies what a reply means.
+**Neither asks for a call, a signup, or a share.** The asks are two questions plus one offer — deliberately short of a meeting request, which is the thing that makes a stranger defer replying.
+
+**The pay question is §6's falsifier, not the one §6 rejected.** *"Does your institution pay for anything like it"* returns a competitor map — CQ, ProQuest Congressional, Bloomberg Government — which is already known and doesn't touch the question that actually kills the institutional path. *"Could you buy it from one person, invoiced directly"* does. A librarian knows the answer instantly and it costs them nothing to say.
+
+**"Want the next batch?" is the only return mechanism in this plan.** `/agencies` is static, there is no email capture anywhere in the app, and Q9's kill criterion is denominated in *unprompted returns*. Without this sentence the test provably yields zero on the project's own metric. One sentence, zero build, converts a reply into permission to contact.
+
+⚠️ **This creates a tension worth naming.** The rule above is one ask; there are now three things in the email. That is a real risk to reply rate, and it is exactly what the five-send pilot exists to detect. If the first five answer only question 1, the rest are too much — cut the pay question from the remaining fifty-five and ask it on the call instead.
 
 ---
 
@@ -102,9 +144,53 @@ Keep the media-bias list for a later `/think-tanks` send. Don't spend it here.
 
 ## Before sending
 
-1. **Read the page cold**, as if you'd received this email. Only the badge has had an outside read, and it failed — "Why this matters" and the "What is missing" note are still unreviewed copy.
-2. **Decide the URL.** See the domain note below.
-3. **Set up the reply tracking** — `product-analyst`'s named-individuals sheet. Who replied, what they said verbatim, whether they asked for anything. Ten replies is the gate; the names matter more than the count.
+### 1. Send five, not sixty
+
+**Today. Then read what comes back before writing the other fifty-five.**
+
+Fifty-five personalized sends at ~2 minutes of research each is roughly five hours of irreversible, single-use list, spent on an email that has had zero contact with a real recipient. Five sends costs twenty-five minutes and tells you the *shape* of a reply:
+
+- Do they engage the pay question at all, or only the useful question? If only the first, the second is mis-worded — cut it from the remaining fifty-five and ask it on the call.
+- Does anyone take the "next batch" offer? That's the only return mechanism here.
+- Does anyone mention the page being part of a news site? That would say the `contextNote` fix didn't land.
+
+Pick five you're least worried about burning. A bad email costs one contact each; a bad email × 60 costs the list.
+
+### 2. ⚠️ Enable Vercel Web Analytics first — it is NOT currently collecting
+
+`@vercel/analytics` is installed and `<Analytics />` is mounted in `app/layout.tsx:112`, **but Web Analytics is not enabled on the project.** The API returns `404 Web Analytics not found`. The script fires and nothing is recorded.
+
+This matters more than it sounds. Without it, two very different futures look identical:
+
+- **0 replies, 30 pageviews** → they read it and didn't care. A *product* signal.
+- **0 replies, 2 pageviews** → the email failed. A *channel* signal.
+
+Enable it in the Vercel dashboard (Project → Analytics), then **record the `/agencies` pageview count immediately before the first send.** It's a two-click toggle and it's what makes a null result readable at all.
+
+### 3. Read the page cold
+
+Only the badge has had an outside read, and it failed. The headline and "Why this matters" are still unreviewed by anyone but their author.
+
+### 4. Set up reply tracking
+
+`product-analyst`'s named-individuals sheet: who replied, what they said **verbatim**, whether they took the next-batch offer, and which segment they came from. Track librarian and staffer reply rates **separately** — the gap between them is more informative than either number.
+
+### 5. Check the recess calendar
+
+It is late July. Congressional staff head into August recess, and in a midterm year it starts earlier and runs thinner. If the House is already gone, **hold the twenty staffer contacts until September.** Burning twenty personalized sends into an empty office is a one-shot loss.
+
+---
+
+## Decide this before any reply arrives
+
+**What happens if ten librarians say yes?**
+
+Write the answer down now. There are two, and they are different companies:
+
+- **"Cite the other 68 agencies."** A manual, non-scaling reference publication with free substitutes (Cornell LII, CRS), no AI, no news, no comparison — and no line item in `STATUS.md` or the memo. It is not what this repo contains.
+- **"Book ten calls about Sift."** The thing the memo actually planned.
+
+In three weeks the first will feel like progress and the second will feel like an imposition. That is exactly why the choice has to be made now, cold, rather than arrived at by momentum. **The tell to watch for: if warm replies produce more rows rather than more phone calls, the decision was made by drift.**
 
 ---
 


### PR DESCRIPTION
Items 1–4 of a red-team review of the week-one test. **Item 5 turned out to be impossible as specified** — see the last section.

## 1. The gate was arithmetic nonsense

At 60 sends:

| true reply rate | expected | **P(≥10)** | **P(0)** |
|---|---|---|---|
| 10% | 6.0 | **7.3%** | 0.18% |
| 15% | 9.0 | 41.2% | 0.01% |

*"Nobody replies → Q9 fires in week one"* was **dead code.** P(0 of 60) is under 1% at any plausible rate, and if it ever fired it would indict the list or the send, not the product.

Worse: the plan defined outcomes at **0** and **≥10** while the modal result is about **six** — for which there was no branch at all. Pre-registration that omits the median outcome isn't pre-registration.

**Gate unwired from Q9 and from Q1/Q2/Q3.** Relabelled as what it is: **recruiting for the ten conversations.** Success = enough named humans to book five calls.

The memo's §4.2 claim that this answers Q1/Q2/Q3 and the dossier question *"simultaneously"* is corrected in place:

- **Q1 — no.** A reply is not an unprompted return, and `/agencies` has no email capture, so the test cannot produce one unit of the metric Q9 counts.
- **Q2 — no.** §6 pre-registers it as a *within-person* comparison; this shows one arm and infers the other from spontaneous mention.
- **Q3 — partly**, once reworded.

## 2. Send five, not sixty

Fifty-five personalized sends is ~5 hours of irreversible single-use list, spent on copy no recipient has ever seen. Five costs 25 minutes and reveals the reply *shape* — whether they engage the pay question at all, whether anyone takes the next-batch offer, whether the news-site framing still confuses.

## 3. Pay clause fixed to §6's own falsifier

Both drafts asked *"does your institution pay for anything like it?"* — which is *"do you pay for Quorum?"*, **the version §6 explicitly retired.** It returns a competitor map that's already known.

Now asks whether they could buy **from one person, invoiced directly** — which is where §6 concluded the institutional path actually dies.

## 4. Return hook added

> *"I'm working through the other 68 agencies. Want the next batch?"*

`/agencies` is static, there's no email capture anywhere in the app, and Q9 is denominated in **unprompted returns**. Without this sentence the test provably yields **zero** on the project's own kill metric. One sentence, zero build, converts a reply into permission to contact.

The doc names the tension honestly: its own rule is *one ask*, and there are now three things. That's exactly what the five-send pilot exists to detect.

## 5. ⚠️ NOT DONE — impossible as specified

The review called pageview capture *"free, already instrumented, 15 minutes."*

`@vercel/analytics` **is** installed and mounted (`app/layout.tsx:112`) — but **Web Analytics is not enabled on the project.** The API returns `404 Web Analytics not found`. The script fires and nothing is collected.

This matters: without it, **"0 replies, 30 pageviews"** (product signal) and **"0 replies, 2 pageviews"** (channel signal) are indistinguishable. Recorded as a two-click dashboard prerequisite before sending — it's the only thing that makes a null result readable.

## Also recorded

- **Track librarian and staffer reply rates separately.** Librarians answer well-sourced questions from strangers for a living; a good rate may measure professional courtesy rather than demand. The *gap* between segments carries more signal than either number.
- **Check the August recess calendar** before spending the twenty staffer contacts.
- **Decide now, in writing, what happens if ten librarians say yes.** *"Cite the other 68 agencies"* is a different company than this repo contains — manual, non-scaling, free substitutes, no AI, no news — and it should be chosen deliberately rather than arrived at by momentum. The tell: if warm replies produce more rows rather than more phone calls, the decision was made by drift.

Docs only. `tsc` clean, 380 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)