### PR TITLE
docs: competitive pass on reference tools — the differentiation claim was too strong

### DIFF
--- a/docs/COMPETITIVE_REFERENCE_TOOLS.md
+++ b/docs/COMPETITIVE_REFERENCE_TOOLS.md
@@ -1,0 +1,101 @@
+# Competitive pass — civic reference tools
+
+**Written:** 2026-07-29
+**Why:** `GROWTH_STRATEGY.md` and the research files cover the *news-aggregator* market thoroughly — Ground News, AllSides, Artifact, SmartNews, Tangle. They contain **zero** mentions of Cornell LII, CRS, or ProQuest. The competitive work was done for the aggregator thesis; on 2026-07-28 the product moved toward reference. This covers the market it moved into.
+
+> **Headline: the differentiation claim is weaker than previously stated in this repo.** Earlier notes said *"nobody assembles the partisan-balance caps as a comparable set."* That is not true. Corrected below.
+
+---
+
+## 1. The finding `/agencies` leads with is not novel
+
+`/agencies` opens with *"13 of these 25 agencies operate under a limit… on how many members may belong to one political party."* Three existing works cover the same ground, two of them more comprehensively.
+
+| Source | Coverage | Format | Date |
+|---|---|---|---|
+| **[Partnership for Public Service](https://ourpublicservice.org/know-the-facts/resource-library/reports/dismantling-independence-legal-compositional-and-normative-erosion-across-federal-boards-and-commissions)** — *Dismantling Independence* | **33 full-time boards; 23 with partisan-balance requirements** | Narrative report. **No per-agency table, no downloadable dataset.** | Apr 2026 |
+| **[Feinstein & Hemel](https://columbialawreview.org/content/partisan-balance-with-bite/)**, *Partisan Balance with Bite*, Columbia L. Rev. 118(1) | **23 PBR agencies**, 1979–2014. Table 1 lists independence indicators, sourced from CRS. | Law review article | — |
+| **Krotoszynski et al.**, Notre Dame L. Rev. (2015) | Cited by Feinstein & Hemel as having *"compiled more extensive tables of PBR agencies"* **with statutory citations** | Law review tables | 2015 |
+| **[CRS R43391](https://www.congress.gov/crs-product/R43391)** — *Independence of Federal Financial Regulators* | Financial regulators; structure, funding, independence | Free CRS report | — |
+
+**Two corrections this forces:**
+
+1. **The universe is ~40, not 25.** Feinstein & Hemel: *"Congress has established at least forty bodies subject to PBRs."* PPS counts 23 of 33 full-time boards. Sift covers 13. **Sift's set is a subset, and its headline number is smaller than the honest total.**
+2. **Krotoszynski et al. is structurally what `/agencies` is** — a table of PBR agencies with statutory citations. It predates Sift by eleven years.
+
+---
+
+## 2. What actually survives as differentiation
+
+Not the knowledge. The **format and access**:
+
+- PPS is a narrative PDF-style report. No table, no dataset, no per-agency page.
+- The law reviews are dense, paywalled or PDF, written for legal academics, and the newest data is from 2014.
+- CRS reports are free and excellent but organised by topic, not browsable per agency.
+
+**Nothing found is a free, linkable, browsable web page with one agency per entry, each cited to its section of the U.S. Code, that a librarian can put on a LibGuide.**
+
+That is a real gap. It is also a much narrower claim than "nobody has assembled this," and it is a **distribution** advantage rather than a **research** one. Distribution advantages are easier to copy.
+
+### The honest version of the pitch
+
+> Not: *"I found something nobody has assembled."*
+> But: *"The scholarship exists and is unreadable. This is the same facts, per agency, cited, free, and linkable."*
+
+That is still worth sending to a librarian. It is not worth telling a collaborator it is novel research.
+
+---
+
+## 3. The thing Sift deliberately excluded is the interesting story
+
+PPS's sharpest finding is current-state: **nine boards and commissions — including CPSC, FDIC, FTC, MSPB and SEC — now operate with no opposition-party members at all.**
+
+Migration 013 deliberately excluded exactly that class of fact: current chair, present composition, appointing president. The reasoning was sound (those rot, and there is no refresh job).
+
+**But it means the live, newsworthy angle belongs to PPS and not to Sift.** "Here is the statutory cap" is reference. "Here is the cap, and here are the nine agencies currently violating its spirit" is a story — and it is the version a policy staffer forwards.
+
+This is a genuine strategic tension, not a defect. Resolving it would mean either accepting a refresh burden or accepting that Sift is the durable-reference layer while someone else owns the timely one. **It should be decided deliberately, not by default.**
+
+---
+
+## 4. Free substitutes, ranked by how much they threaten
+
+| | What it is | Threat |
+|---|---|---|
+| **Cornell LII** | The U.S. Code, free, public domain, better UX | **High.** Publishes every statute Sift cites. Sift adds only aggregation. |
+| **CRS reports** | Professional analyst syntheses, free since 2018 | **High** for depth; low for browsability. |
+| **U.S. Government Manual** | The government's own handbook of federal agencies | **High for the librarian audience** — it is already on their guides. Sift's pitch must be "the Manual tells you what an agency does; it doesn't tell you the statutory cap." |
+| **GovTrack / OpenSecrets / ProPublica / Ballotpedia** | The sources Sift's own dossiers link out to | **Structural.** Sift links to them, which invites the comparison. |
+| **Wikipedia** | Per-agency articles with structure sections | Moderate. Uncited-by-Sift-standards, but free and first in search. |
+
+---
+
+## 5. Paid institutional tier — and what it means for Q3
+
+**Quorum, FiscalNote, LegiStorm, Bloomberg Government, CQ, ProQuest Congressional.**
+
+Pricing is **opaque by design**. FiscalNote publishes no public pricing and requires vendor contact; Quorum advertises a starter tier around $34/mo but real deployments are custom-quoted. Reviews on Capterra and TrustRadius describe FiscalNote's pricing as high relative to alternatives.
+
+**That opacity is itself the finding.** Custom quotes mean sales cycles, which mean procurement, which is precisely the barrier §6 of the launch memo identified — *"could your institution buy this from a sole proprietor with no VPAT?"* This validates the reworded pay question: these institutions have budget lines, and those lines run through a process a one-person vendor cannot enter.
+
+`user-researcher`'s kill criterion stands and is now better grounded: **if ≥3 of 5 policy staffers say their office already pays for one of these, that wedge is dead.**
+
+---
+
+## 6. What this changes
+
+**For the librarian emails — very little.** A government-information librarian is unlikely to know the Notre Dame tables, and the value proposition is that the page is linkable from their guide. The FEC hook still works. Do not claim novelty of *finding*; claim usefulness of *format*.
+
+**For the pitch to a collaborator — a lot.** Anyone joining should be told the free substitutes are strong and the scholarship already exists. They will find Cornell in week two regardless.
+
+**For strategy — the real question surfaces.** If the durable differentiation is format and access rather than knowledge, then the defensible asset is *breadth and upkeep* (all ~40 PBR bodies, kept current) or *the audience relationship* — not the fact of having read the statutes. That is consistent with what `acquirer` said in the launch memo: the dossier dataset and the list transfer; the care does not.
+
+---
+
+## 7. Gaps in this pass
+
+Stated so they are not mistaken for coverage:
+
+- **Krotoszynski et al. (2015) was not read directly** — its content is inferred from Feinstein & Hemel's citation of it. Worth reading before claiming anything about what `/agencies` adds.
+- **No pricing verified** for CQ, ProQuest Congressional or Bloomberg Government. Vendor contact required, which is itself the point.
+- **No assessment of whether librarians already link PPS or the law reviews.** That is answerable directly by reading the guides in the send list, and should be checked before sending — a librarian who already links PPS is a different conversation.


### PR DESCRIPTION
`GROWTH_STRATEGY.md` and the research files cover the news-aggregator market thoroughly — and mention **Cornell LII, CRS and ProQuest exactly zero times**. That work was done for the aggregator thesis; yesterday the product moved toward reference. This covers the market it moved into.

## ⚠️ The uncomfortable finding

This repo has been claiming *"nobody assembles the partisan-balance caps as a comparable set."* **That's false.**

| Source | Coverage | Format |
|---|---|---|
| **[Partnership for Public Service](https://ourpublicservice.org/know-the-facts/resource-library/reports/dismantling-independence-legal-compositional-and-normative-erosion-across-federal-boards-and-commissions)** (Apr 2026) | **33 boards, 23 with partisan-balance requirements** | Narrative, no table, no dataset |
| **[Feinstein & Hemel](https://columbialawreview.org/content/partisan-balance-with-bite/)**, Columbia L. Rev. | 23 PBR agencies, Table 1 of independence indicators | Law review |
| **Krotoszynski et al.**, Notre Dame L. Rev. (2015) | *"more extensive tables of PBR agencies"* **with statutory citations** | Law review |

**Two corrections follow:**

1. **The universe is ~40 bodies subject to PBRs, not 25.** Our set is a subset, and our headline "13 of 25" is a smaller number than the honest total.
2. **Krotoszynski et al. is structurally what `/agencies` is** — a table of PBR agencies with statutory citations, published eleven years earlier.

## What survives

**Format and access, not knowledge.** PPS is narrative. The law reviews are dense, paywalled, and their newest data is from 2014. CRS is topic-organised, not browsable per agency.

Nothing found is a **free, browsable, linkable page with one agency per entry, each cited to its section of the U.S. Code**. That's a real gap and a real reason a librarian would link it.

But it's a **distribution** advantage rather than a **research** one — and those are easier to copy.

**The honest version of the pitch:** not *"I found something nobody has assembled"* but *"the scholarship exists and is unreadable; this is the same facts, per agency, cited, free, and linkable."*

## The strategic tension worth deciding deliberately

PPS's sharpest finding is that **nine commissions now operate with no opposition-party members at all.**

That's exactly the current-state class migration 013 excluded, for good reasons — those facts rot and there's no refresh job. But it means the durable reference layer is ours and **the timely, forwardable story is theirs.** Worth choosing rather than defaulting into.

## Paid tier, and Q3

FiscalNote, Quorum, LegiStorm, CQ, Bloomberg Government, ProQuest Congressional — **pricing is opaque by design.** Custom quotes, vendor contact required.

That opacity *is* the finding: it means sales cycles, which mean procurement, which is precisely the barrier §6 of the launch memo identified. It grounds the reworded pay question, and `user-researcher`'s kill criterion stands: **if ≥3 of 5 staffers say their office already pays for one of these, that wedge is dead.**

## What changes

- **Librarian emails: very little.** A librarian is unlikely to know the Notre Dame tables, and the value is that the page is linkable. Claim usefulness of *format*, not novelty of *finding*.
- **Pitch to a collaborator: a lot.** They'll find Cornell in week two. Tell them first.
- **Strategy:** if the durable edge is format and access, the defensible asset is *breadth and upkeep* or *the audience relationship* — consistent with what `acquirer` said. The care doesn't transfer.

## Gaps, stated

Krotoszynski was not read directly, only via citation. No pricing verified for CQ, ProQuest or Bloomberg Government. And **nobody has checked whether the librarians on the send list already link PPS** — that's answerable while building the list, and a librarian who already links it is a different conversation.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)