### PR TITLE
Pin cross-language golden hashes; retract unbacked accuracy claim

### DIFF
--- a/__tests__/usage-tracker.test.ts
+++ b/__tests__/usage-tracker.test.ts
@@ -1,0 +1,148 @@
+import { logUsage, countWebSearches } from "@/lib/usage-tracker";
+
+// lib/usage-tracker.ts logs via console.log on every call. Silence it so test
+// output stays readable, and restore afterwards.
+let logSpy: jest.SpyInstance;
+beforeAll(() => {
+  logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+});
+afterAll(() => {
+  logSpy.mockRestore();
+});
+
+const ONE_M = 1_000_000;
+
+function response(usage: Record<string, number>, content: unknown[] = []) {
+  return { usage, content } as never;
+}
+
+// ─── price table parity ─────────────────────────────────
+
+/**
+ * The cross-language contract.
+ *
+ * lib/usage-tracker.ts and sift-api/services/usage_tracker.py each hardcode the
+ * same five Anthropic prices, in two languages, in two independent git repos,
+ * with no shared source. The identical assertion lives in
+ * sift-api/tests/test_usage_tracker.py::TestPriceTableParity — if either table
+ * drifts, exactly one of the two suites goes red.
+ *
+ * One synthetic payload exercises all five constants at once:
+ *   1M input       x $1.00/M = 1.00
+ *   1M output      x $5.00/M = 5.00
+ *   1M cache write x $1.25/M = 1.25
+ *   1M cache read  x $0.10/M = 0.10
+ *   3 web searches x $0.010  = 0.03
+ *                             ------
+ *                               7.38
+ */
+describe("price table parity with sift-api", () => {
+  const GOLDEN_COST_USD = 7.38;
+
+  it("matches the golden cost shared with sift-api", () => {
+    const payload = logUsage(
+      "test",
+      response({
+        input_tokens: ONE_M,
+        output_tokens: ONE_M,
+        cache_creation_input_tokens: ONE_M,
+        cache_read_input_tokens: ONE_M,
+      }),
+      "claude-haiku-4-5",
+      3,
+    );
+    expect(payload?.cost_usd).toBe(GOLDEN_COST_USD);
+  });
+
+  it.each([
+    ["input", { input_tokens: ONE_M }, 1.0],
+    ["output", { output_tokens: ONE_M }, 5.0],
+    ["cache_write", { cache_creation_input_tokens: ONE_M }, 1.25],
+    ["cache_read", { cache_read_input_tokens: ONE_M }, 0.1],
+  ])("prices %s identically to sift-api", (_name, usage, expected) => {
+    const payload = logUsage("test", response(usage as Record<string, number>), "m", 0);
+    expect(payload?.cost_usd).toBe(expected);
+  });
+
+  it("prices a web search identically to sift-api", () => {
+    const payload = logUsage("test", response({}), "m", 1);
+    expect(payload?.cost_usd).toBe(0.01);
+  });
+});
+
+// ─── logUsage ───────────────────────────────────────────
+
+describe("logUsage", () => {
+  it("returns a payload rather than a swallowed null", () => {
+    // logUsage catches every exception and returns null. Without this, a bug
+    // anywhere in its body would silently disable cost telemetry.
+    const payload = logUsage("topic.search", response({ input_tokens: 100, output_tokens: 50 }));
+    expect(payload).not.toBeNull();
+    expect(payload?.event).toBe("api_usage");
+    expect(payload?.operation).toBe("topic.search");
+  });
+
+  it("reports every token field", () => {
+    const payload = logUsage(
+      "op",
+      response({
+        input_tokens: 1,
+        output_tokens: 2,
+        cache_creation_input_tokens: 3,
+        cache_read_input_tokens: 4,
+      }),
+      "m",
+      0,
+    );
+    expect(payload?.input_tokens).toBe(1);
+    expect(payload?.output_tokens).toBe(2);
+    expect(payload?.cache_creation_input_tokens).toBe(3);
+    expect(payload?.cache_read_input_tokens).toBe(4);
+  });
+
+  it("treats a missing usage object as zero rather than an error", () => {
+    const payload = logUsage("op", { content: [] } as never);
+    expect(payload?.cost_usd).toBe(0);
+    expect(payload?.input_tokens).toBe(0);
+  });
+
+  it("infers web searches from content when the count is not passed", () => {
+    const payload = logUsage(
+      "op",
+      response({}, [
+        { type: "server_tool_use", name: "web_search" },
+        { type: "server_tool_use", name: "web_search" },
+      ]),
+    );
+    expect(payload?.web_searches).toBe(2);
+    expect(payload?.cost_usd).toBe(0.02);
+  });
+
+  it("records the model for cost breakdown", () => {
+    const payload = logUsage("op", response({}), "claude-sonnet-4-6", 0);
+    expect(payload?.model).toBe("claude-sonnet-4-6");
+  });
+});
+
+// ─── countWebSearches ───────────────────────────────────
+
+describe("countWebSearches", () => {
+  it("counts web_search blocks", () => {
+    const r = response({}, [
+      { type: "server_tool_use", name: "web_search" },
+      { type: "text" },
+      { type: "server_tool_use", name: "web_search" },
+    ]);
+    expect(countWebSearches(r)).toBe(2);
+  });
+
+  it("ignores other server tools", () => {
+    expect(countWebSearches(response({}, [{ type: "server_tool_use", name: "code_execution" }]))).toBe(0);
+  });
+
+  it("returns 0 on garbage rather than throwing", () => {
+    expect(countWebSearches(null as never)).toBe(0);
+    expect(countWebSearches(undefined as never)).toBe(0);
+    expect(countWebSearches({} as never)).toBe(0);
+  });
+});

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -133,7 +133,40 @@ describe("extractSourceDomain", () => {
 
 // ─── stableHash ─────────────────────────────────────────
 
+// Pinned goldens. `stableHash` is reimplemented in Python as `stable_hash` in
+// sift-api/services/rss.py, and these EXACT values are asserted in
+// sift-api/tests/test_rss.py too. The two must never diverge:
+//
+//   sift-api/workflows/pipeline_workflow.py:337 derives
+//     article_id = stable_hash(source_url + title)
+//   — the PRIMARY KEY of every `articles` row —
+//   and app/api/news/topic/route.ts:578 computes the SAME id here in TS.
+//
+// Deliberately duplicated literals rather than a shared fixture: sift and
+// sift-api are independent git repos, so sharing would need a submodule or a
+// sync step for zero extra signal. If either side drifts, exactly one of the
+// two suites goes red.
+const GOLDEN_STABLE_HASH: Record<string, string> = {
+  hello: "1n1e4y",
+  world: "1vgtci",
+  "": "0",
+  "test article url": "p4glh3",
+  "https://www.npr.org/2026/06/04/x": "c9vv14",
+};
+
 describe("stableHash", () => {
+  it("matches the golden values shared with sift-api", () => {
+    for (const [input, expected] of Object.entries(GOLDEN_STABLE_HASH)) {
+      expect(stableHash(input)).toBe(expected);
+    }
+  });
+
+  it("renders abs(INT32_MIN) identically to Python", () => {
+    // The one boundary where JS's double-based Math.abs and Python's
+    // ctypes.c_int32 wrap could part ways.
+    expect(Math.abs(-2147483648).toString(36)).toBe("zik0zk");
+  });
+
   it("returns same hash for same input", () => {
     const url = "https://reuters.com/article/123";
     expect(stableHash(url)).toBe(stableHash(url));

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -495,17 +495,22 @@ Each category has 8-11 RSS feeds. Expanded total from ~56 feeds to 100+ feeds. C
 
 We considered three approaches:
 
-1. **Simple embedding cosine similarity** (~90% accuracy distinguishing same-event vs same-topic). Low cost, but fails on cases like "EU AI Act vote" vs "US AI executive order" which embed similarly but are different events.
+1. **Simple embedding cosine similarity** (~90% accuracy distinguishing same-event vs same-topic — ⚠️ unmeasured estimate, see the retraction in D27). Low cost, but fails on cases like "EU AI Act vote" vs "US AI executive order" which embed similarly but are different events.
 
 2. **Full 5-node LangGraph workflow** with a separate ranking node. The ranking node would sort stories by importance — but this is just SQL `ORDER BY article_count DESC, published_date DESC`. An LLM call for ranking is over-engineering.
 
 3. **4-node workflow** (chosen). Drops the ranking node. Each remaining node earns its place:
    - Node 1 (Fetch): DB query, not an LLM call — pulls 48h articles per category
    - Node 2 (Entity Extract): Extracts people/orgs/locations. **Only justified because entities are visible in the UI** as tags on StoryCard
-   - Node 3 (LLM Cluster): The core differentiator — LLM-as-judge distinguishes same-event from same-topic (~97% accuracy)
+   - Node 3 (LLM Cluster): The core differentiator — LLM-as-judge distinguishes same-event from same-topic (accuracy **unmeasured**, see D27)
    - Node 4 (Synthesize+Store): Unified headline, merged summary, per-source framing analysis with tone
 
-**Cost:** All prompts batched (one call per category per node, not per article). ~$0.012 per pipeline run, ~$1.73/day, ~$52/month. vs $345/month if we made per-article calls.
+**Cost:** ⚠️ **Corrected 2026-07-30.** This section previously claimed "all prompts batched (one call per category per node, not per article), ~$0.012 per pipeline run, ~$1.73/day, ~$52/month." Both halves were wrong:
+
+- **Not everything is batched.** `sift-api/services/entity_linker_llm.py:390` `link_articles_llm` makes **one realtime call per article**, re-sending a ~6,500-token entity catalog as a cached system block each time. That is the per-article pattern this entry claims to have avoided.
+- **Actual spend is ~$10/day (~$300/mo)**, roughly 6x the figure above, on a Sift-dedicated API key.
+
+The per-operation breakdown is not yet known: `services/usage_tracker.py:111` `_record_to_ledger` short-circuits unless `ai_cost_guard_enabled` is true, and it defaults to `False` — so the `ai_usage_daily` ledger has never been populated. Attribution is the prerequisite for any cost work.
 
 **Why this matters for a portfolio:** Good judgment > raw complexity. A hiring manager who sees a 5-node workflow where one node is a SQL ORDER BY will question your engineering taste. Four nodes where each earns its place shows you know when to reach for an LLM and when not to.
 
@@ -519,9 +524,17 @@ We considered three approaches:
 **LLM-as-judge approach:** The prompt explicitly instructs Claude to distinguish same-event from same-topic:
 > "same event" means the same specific occurrence -- not just the same broad topic. "EU votes on AI Act" and "US issues AI executive order" are DIFFERENT events.
 
-This achieves ~97% accuracy on event-level clustering. The enrichment from entity extraction (Node 2) further helps — shared people, organizations, and locations are strong signals.
+⚠️ **Accuracy claim retracted 2026-07-30.** This entry previously stated "This achieves ~97% accuracy on event-level clustering," and the ~90% figure for embedding similarity above carries the same caveat. **Both were estimates with no backing eval set.** There was no labeled corpus, no metric, and until 2026-07-30 no test of `services/story_clusterer.py` at all. Neither number should be cited.
 
-**Alternative considered:** Two-pass hybrid (embedding pre-filter + LLM refinement). Rejected because the article volume per category (max 50) is small enough that a single LLM call handles it. The two-pass approach adds complexity without benefit at this scale.
+A real measurement is in progress: a labeled corpus at `sift-api/data/eval/clustering_corpus.jsonl` scored by `sift-api/services/cluster_metrics.py` on chance-corrected Adjusted Rand Index, V-measure, and pairwise precision/recall, with a free deterministic replay gate in CI. This entry will be updated with the measured values and a link to the baseline artifact.
+
+The enrichment from entity extraction (Node 2) helps in principle — shared people, organizations, and locations are strong signals — but that too is unmeasured.
+
+**Alternative considered:** Two-pass hybrid (embedding pre-filter + LLM refinement). Rejected on the grounds that "the article volume per category (max 50) is small enough that a single LLM call handles it."
+
+⚠️ **That premise turned out to rest on a bug.** The "max 50" is `LIMIT 50` in `sift-api/workflows/story_workflow.py:54`, applied to an already-filtered 48h window. It is not a natural ceiling — in a busy category, articles beyond rank 50 are **never candidates for threading at all**, silently and invisibly in logs. A second, related bug compounded it: `story_clusterer.py` sent up to 50 articles with a fixed `max_tokens=1024`, so an overflowing response truncated to invalid JSON and the category produced **zero stories with no error logged** (fixed 2026-07-30).
+
+The hybrid is therefore being reconsidered — but on **correctness and scale** grounds (it is what makes raising the 50-article cap tractable), not on the cost grounds usually cited for it. Note that clustering here is a *single listwise call per category*, not pairwise, so vector pre-filtering does not eliminate an O(n²) call pattern; splitting a window into many small pools re-pays the fixed prompt per pool and can cost *more*. Embeddings would serve as a candidate **generator**, with the LLM retained as the **decider** — a refinement of this decision, not a reversal of it.
 
 ---
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,12 +14,51 @@ const config: Config = {
     "^@/(.*)$": "<rootDir>/$1",
   },
   testPathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/"],
+
+  // Without this, Jest only instruments files that a test happens to import,
+  // so untested files are absent from the DENOMINATOR entirely. The 80%
+  // threshold below was therefore passing against ~24 measured files out of
+  // ~79 real ones — it could never fail no matter how much untested code
+  // landed. Naming the sources explicitly is what makes the gate mean anything.
+  collectCoverageFrom: [
+    "lib/**/*.{ts,tsx}",
+    "components/**/*.{ts,tsx}",
+    "app/api/**/route.ts",
+    "!**/*.d.ts",
+    "!lib/types.ts",
+    // Excluded with cause, not to flatter the number: thin wrappers over a
+    // live pg Pool, browser-only APIs, and streaming plumbing. These are
+    // exercised by the CI production build and the prerender step rather than
+    // by unit tests.
+    "!lib/db.ts",
+    "!lib/hooks.ts",
+    "!lib/sse.ts",
+  ],
+
+  // A RATCHET, not a target. These are the honest measured values from the day
+  // collectCoverageFrom was added (2026-07-30), floored just below so the gate
+  // is real from day one. Raise as coverage improves; never lower to turn a red
+  // build green.
+  //
+  // Note: naming "./lib/" as its own group REMOVES those files from "global",
+  // so `global` here means components/ + app/api/ only. Measured on 2026-07-30:
+  //   ./lib/  statements 74.6  branches 76.1  lines 76.3  functions 76.2
+  //   global  statements 10.8  branches  8.0  lines 11.0  functions 10.2
+  //
+  // The ~10% global figure is the honest state of component and API-route
+  // testing, previously hidden entirely by the missing collectCoverageFrom.
   coverageThreshold: {
     global: {
-      branches: 70,
-      functions: 80,
-      lines: 80,
-      statements: 80,
+      branches: 6,
+      functions: 8,
+      lines: 8,
+      statements: 8,
+    },
+    "./lib/": {
+      branches: 74,
+      functions: 74,
+      lines: 74,
+      statements: 72,
     },
   },
 };


### PR DESCRIPTION
Three tests here could not fail, one coverage gate was measuring nothing, and the decision log carried an accuracy number with no artifact behind it.

## Retracted accuracy claim

`docs/DECISIONS.md` D26/D27 claimed **"~97% accuracy on event-level clustering"** (and ~90% for embedding similarity). There was no eval set, no metric, and until now no test of `services/story_clusterer.py` at all. Both numbers are retracted and marked unmeasured pending real measurement — the harness is in kristenmartino/sift-api#113.

Two adjacent claims in D26 were also wrong and are corrected:

- *"All prompts batched — one call per category per node, not per article"* is false. `entity_linker_llm` makes one realtime call **per article**, re-sending a ~6,500-token catalog each time. That is precisely the per-article pattern the entry claims to have avoided.
- *"~$1.73/day, ~$52/month"* is off by roughly 6×; actual is ~$10/day. The per-operation breakdown is unknown because `usage_tracker` only writes the ledger when `ai_cost_guard_enabled` is true, and it defaults to false — so `ai_usage_daily` has never been populated.

D27's rejection of a two-pass hybrid rested on *"article volume per category (max 50) is small enough."* That max is `LIMIT 50` in `story_workflow.py` — not a natural ceiling but a cap that silently drops articles from threading entirely. The premise was a bug.

## Golden hashes

`__tests__/utils.test.ts` asserted `stableHash(url) === stableHash(url)` — true for any implementation whatsoever.

`stableHash` generates `article_id`, the **primary key of every row in `articles`**, and is independently reimplemented in Python as `stable_hash` in `sift-api/services/rss.py`. Nothing in either repo would have caught the two drifting apart, and a drift orphans every stored article.

Now pinned to five verified literals, with the same values asserted in `sift-api/tests/test_rss.py`. Includes `abs(INT32_MIN)` → `"zik0zk"`, the one boundary where JS's double-based `Math.abs` and Python's `ctypes.c_int32` wrap could diverge.

Verified: mutating `<< 5` → `<< 6` fails this suite while the Python suite stays green.

Literals are deliberately duplicated rather than shared — the repos are independent, so a shared fixture needs a submodule or sync step for zero extra signal.

## Price table parity

`lib/usage-tracker.ts` and `sift-api/services/usage_tracker.py` hardcode the same five Anthropic prices, in two languages, with no shared source. Neither had any test.

One synthetic payload exercises all five at once (1M tokens each of input/output/cache-write/cache-read + 3 web searches = **$7.38**), asserted identically in both suites. Drift in either turns exactly one suite red. Verified in both directions.

## Coverage gate

`jest.config.ts` set an 80% threshold with **no `collectCoverageFrom`**, so Jest only instrumented files a test happened to import — ~24 of ~79 files were in the denominator. The gate could never fail no matter how much untested code landed.

Naming the sources drops the honest figure to ~10% for components/API routes and ~75% for `lib/`. Thresholds are set just under measured, as a ratchet. A threshold you have to disable in three weeks is worse than no threshold.

`lib/db.ts`, `lib/hooks.ts`, `lib/sse.ts` are excluded with cause — thin wrappers over a live pg Pool, browser APIs, and streaming plumbing, covered by the CI production build rather than unit tests. Not excluded to flatter the number.

## Verification

396 tests pass across 22 suites, `tsc --noEmit` clean, coverage gate passes at the honest thresholds and demonstrably fails when raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
