### PR TITLE
Make the dossier set discoverable, with a publish floor

### DIFF
--- a/__tests__/publishFloor.test.ts
+++ b/__tests__/publishFloor.test.ts
@@ -1,0 +1,234 @@
+import {
+  dossierRobotsMeta,
+  isPublishableBill,
+  isPublishableOrg,
+  isPublishableOutlet,
+  isPublishablePolitician,
+} from "@/lib/publishFloor";
+import type {
+  BillProfile,
+  OrgProfile,
+  OutletProfile,
+  PoliticianProfile,
+} from "@/lib/types";
+
+/**
+ * These tests pin the publish floor. The same rule is expressed a second time
+ * as SQL in `listSitemapEntries` (lib/db.ts) — if you change a predicate,
+ * change that query too, and update the "mirrors the SQL" cases below.
+ */
+
+const politician: PoliticianProfile = {
+  bioguideId: "M001153",
+  name: "Lisa Murkowski",
+  party: "R",
+  state: "AK",
+  chamber: "senate",
+  committees: ["Appropriations"],
+  topIndustriesCurrentCycle: [],
+  interestGroupRatings: {},
+  externalLinks: {},
+  notes: null,
+};
+
+const org = {
+  slug: "epa",
+  name: "Environmental Protection Agency",
+  type: "agency",
+  selfDescription: null,
+  selfDescriptionSource: null,
+  selfDescriptionChecked: null,
+  governanceStructure: null,
+  governanceSource: null,
+  foundedYear: 1970,
+  annualBudgetUsd: null,
+  annualBudgetFy: null,
+  annualBudgetSource: null,
+  majorFunders: [],
+  faraRegistered: false,
+  faraCountries: [],
+  externalLinks: {},
+  notes: null,
+} as unknown as OrgProfile;
+
+const bill: BillProfile = {
+  billId: "hr-5376-117",
+  congress: 117,
+  title: "An Act...",
+  shortTitle: "Inflation Reduction Act of 2022",
+  sponsorBioguide: null,
+  cosponsors: [],
+  status: "enacted",
+  introducedDate: "2021-09-27",
+  lobbyingForUsd: null,
+  lobbyingAgainstUsd: null,
+  externalLinks: { congress: "https://www.congress.gov/bill/117/hr5376" },
+  notes: null,
+};
+
+const outlet = {
+  slug: "npr",
+  name: "NPR",
+  parentCompany: null,
+  parentCompanyUrl: null,
+  foundedYear: null,
+  fundingModel: null,
+  allSidesRating: null,
+  allSidesUrl: null,
+  allSidesLastChecked: null,
+  mbfcFactual: null,
+  mbfcUrl: null,
+  mbfcLastChecked: null,
+  majorFunders: [],
+  externalLinks: {},
+  notes: null,
+} as unknown as OutletProfile;
+
+describe("isPublishablePolitician", () => {
+  it("publishes sitting Congress with committees or PAC industries", () => {
+    expect(isPublishablePolitician(politician)).toBe(true);
+    expect(
+      isPublishablePolitician({
+        ...politician,
+        committees: [],
+        topIndustriesCurrentCycle: [{ industry: "Oil & Gas", amount_usd: 1 }],
+      }),
+    ).toBe(true);
+  });
+
+  it("withholds a sitting member with neither", () => {
+    expect(
+      isPublishablePolitician({
+        ...politician,
+        committees: [],
+        topIndustriesCurrentCycle: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("withholds executive and foreign-executive regardless of content", () => {
+    // Their only substantive content is uncited notes plus a Wikipedia link.
+    for (const chamber of ["executive", "former", null] as const) {
+      expect(
+        isPublishablePolitician({
+          ...politician,
+          chamber: chamber as PoliticianProfile["chamber"],
+        }),
+      ).toBe(false);
+    }
+  });
+});
+
+describe("isPublishableOrg", () => {
+  it("withholds an org with no sourced substantive field", () => {
+    expect(isPublishableOrg(org)).toBe(false);
+  });
+
+  it("publishes on any one sourced field", () => {
+    expect(
+      isPublishableOrg({
+        ...org,
+        governanceStructure: "Five commissioners...",
+        governanceSource: "https://example.gov",
+      }),
+    ).toBe(true);
+    expect(
+      isPublishableOrg({
+        ...org,
+        selfDescription: "We do things.",
+        selfDescriptionSource: "https://example.org/about",
+      }),
+    ).toBe(true);
+    expect(
+      isPublishableOrg({
+        ...org,
+        annualBudgetUsd: 1_000,
+        annualBudgetSource: "https://example.gov/990",
+      }),
+    ).toBe(true);
+  });
+
+  it("requires the source, not just the value", () => {
+    expect(
+      isPublishableOrg({ ...org, governanceStructure: "Five commissioners..." }),
+    ).toBe(false);
+    expect(isPublishableOrg({ ...org, selfDescription: "We do things." })).toBe(false);
+    expect(isPublishableOrg({ ...org, annualBudgetUsd: 1_000 })).toBe(false);
+  });
+
+  it("treats whitespace-only strings as absent", () => {
+    expect(
+      isPublishableOrg({
+        ...org,
+        governanceStructure: "   ",
+        governanceSource: "https://example.gov",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isPublishableBill", () => {
+  it("needs a status and at least one link", () => {
+    expect(isPublishableBill(bill)).toBe(true);
+    expect(isPublishableBill({ ...bill, status: null })).toBe(false);
+    expect(isPublishableBill({ ...bill, externalLinks: {} })).toBe(false);
+  });
+});
+
+describe("isPublishableOutlet", () => {
+  it("withholds an outlet with no cited rating", () => {
+    expect(isPublishableOutlet(outlet)).toBe(false);
+  });
+
+  it("publishes on either rating when it carries its URL", () => {
+    expect(
+      isPublishableOutlet({
+        ...outlet,
+        allSidesRating: "center",
+        allSidesUrl: "https://allsides.com/npr",
+      }),
+    ).toBe(true);
+    expect(
+      isPublishableOutlet({
+        ...outlet,
+        mbfcFactual: "high",
+        mbfcUrl: "https://mediabiasfactcheck.com/npr/",
+      }),
+    ).toBe(true);
+  });
+
+  it("withholds a rating with no source URL", () => {
+    expect(isPublishableOutlet({ ...outlet, allSidesRating: "center" })).toBe(false);
+    expect(isPublishableOutlet({ ...outlet, mbfcFactual: "high" })).toBe(false);
+  });
+});
+
+describe("dossierRobotsMeta", () => {
+  it("omits the robots key entirely when publishable", () => {
+    // Regression guard. This first shipped as `robots: dossierRobots(x)`
+    // returning undefined, on the assumption that undefined inherits. It does
+    // not: Next merges metadata by key, and a key *present* in the child wins
+    // even when its value is undefined. Every publishable dossier lost the
+    // max-image-preview:large googlebot directive from app/layout.tsx, which
+    // only showed up when the rendered HTML was inspected. An empty object is
+    // what actually inherits.
+    const meta = dossierRobotsMeta(true);
+    expect(meta).toEqual({});
+    expect("robots" in meta).toBe(false);
+  });
+
+  it("noindexes but still follows when below the floor", () => {
+    // follow:true on purpose — the page's outbound links to public records
+    // are still worth crawling even when the page shouldn't rank.
+    expect(dossierRobotsMeta(false)).toEqual({
+      robots: { index: false, follow: true },
+    });
+  });
+
+  it("spreads into metadata without clobbering sibling keys", () => {
+    const publishable = { title: "t", ...dossierRobotsMeta(true) };
+    const withheld = { title: "t", ...dossierRobotsMeta(false) };
+    expect("robots" in publishable).toBe(false);
+    expect(withheld.robots).toEqual({ index: false, follow: true });
+  });
+});

--- a/__tests__/structuredData.test.ts
+++ b/__tests__/structuredData.test.ts
@@ -1,0 +1,206 @@
+import {
+  billJsonLd,
+  jsonLdString,
+  orgJsonLd,
+  outletJsonLd,
+  politicianJsonLd,
+} from "@/lib/structuredData";
+import type {
+  BillProfile,
+  OrgProfile,
+  OutletProfile,
+  PoliticianProfile,
+} from "@/lib/types";
+
+const politician: PoliticianProfile = {
+  bioguideId: "M001153",
+  name: "Lisa Murkowski",
+  party: "R",
+  state: "AK",
+  chamber: "senate",
+  committees: ["Appropriations", "Indian Affairs"],
+  topIndustriesCurrentCycle: [{ industry: "Oil & Gas", amount_usd: 250_000 }],
+  interestGroupRatings: { LCV: 92 },
+  externalLinks: {
+    govtrack: "https://www.govtrack.us/congress/members/lisa_murkowski/300075",
+    wikipedia: "https://en.wikipedia.org/wiki/Lisa_Murkowski",
+  },
+  notes: "Uncited prose that must never reach structured data.",
+};
+
+const org: OrgProfile = {
+  slug: "environmental-protection-agency",
+  name: "Environmental Protection Agency",
+  type: "agency",
+  selfDescription: null,
+  selfDescriptionSource: null,
+  selfDescriptionChecked: null,
+  governanceStructure: null,
+  governanceSource: null,
+  foundedYear: 1970,
+  annualBudgetUsd: 36_970_000_000,
+  annualBudgetFy: "FY2027",
+  annualBudgetSource: "https://www.whitehouse.gov/example.xlsx",
+  majorFunders: [],
+  faraRegistered: false,
+  faraCountries: [],
+  externalLinks: {
+    official: "https://www.epa.gov/",
+    wikipedia: "https://en.wikipedia.org/wiki/United_States_Environmental_Protection_Agency",
+    // Provenance for the budget figure — NOT another identity for the EPA.
+    budget_source: "https://www.whitehouse.gov/wp-content/uploads/hist04z1_fy2027.xlsx",
+    budget_source_fiscal_year: "FY2027",
+  },
+  notes: null,
+} as OrgProfile;
+
+const bill: BillProfile = {
+  billId: "hr-5376-117",
+  congress: 117,
+  title: "An Act to provide for reconciliation pursuant to title II of S. Con. Res. 14.",
+  shortTitle: "Inflation Reduction Act of 2022",
+  sponsorBioguide: "Y000065",
+  cosponsors: [],
+  status: "enacted",
+  introducedDate: "2021-09-27",
+  lobbyingForUsd: 1_000_000,
+  lobbyingAgainstUsd: null,
+  externalLinks: {
+    congress: "https://www.congress.gov/bill/117th-congress/house-bill/5376",
+  },
+  notes: null,
+};
+
+const outlet: OutletProfile = {
+  slug: "npr",
+  name: "NPR",
+  parentCompany: "National Public Radio Inc.",
+  parentCompanyUrl: null,
+  foundedYear: 1970,
+  fundingModel: "public-service",
+  allSidesRating: "center",
+  allSidesUrl: "https://www.allsides.com/news-source/npr-media-bias",
+  allSidesLastChecked: "2026-01-01",
+  mbfcFactual: "high",
+  mbfcUrl: "https://mediabiasfactcheck.com/npr/",
+  mbfcLastChecked: "2026-01-01",
+  majorFunders: [],
+  externalLinks: { wikipedia: "https://en.wikipedia.org/wiki/NPR" },
+  notes: null,
+};
+
+describe("politicianJsonLd", () => {
+  it("emits a Person with the canonical id and committee memberships", () => {
+    const ld = politicianJsonLd(politician);
+    expect(ld["@type"]).toBe("Person");
+    expect(ld["@id"]).toBe("https://siftnews.io/politician/M001153");
+    expect(ld.jobTitle).toBe("United States Senator");
+    expect(ld.memberOf).toHaveLength(3); // Senate + 2 committees
+  });
+
+  it("never emits notes — uncited prose about a living person", () => {
+    expect(JSON.stringify(politicianJsonLd(politician))).not.toContain("Uncited prose");
+  });
+
+  it("never emits PAC figures or interest-group ratings", () => {
+    const s = JSON.stringify(politicianJsonLd(politician));
+    expect(s).not.toContain("250000");
+    expect(s).not.toContain("LCV");
+  });
+
+  it("omits jobTitle for a chamber with no defined role", () => {
+    const ld = politicianJsonLd({ ...politician, chamber: null });
+    expect(ld.jobTitle).toBeUndefined();
+    expect(ld.memberOf).toHaveLength(2); // committees only
+  });
+});
+
+describe("orgJsonLd", () => {
+  it("uses GovernmentOrganization for agencies and Organization otherwise", () => {
+    expect(orgJsonLd(org)["@type"]).toBe("GovernmentOrganization");
+    expect(orgJsonLd({ ...org, type: "think-tank" })["@type"]).toBe("Organization");
+  });
+
+  it("excludes provenance links from sameAs", () => {
+    const ld = orgJsonLd(org);
+    expect(ld.sameAs).toEqual([
+      "https://en.wikipedia.org/wiki/United_States_Environmental_Protection_Agency",
+      "https://www.epa.gov/",
+    ]);
+    expect(JSON.stringify(ld)).not.toContain("hist04z1");
+    expect(JSON.stringify(ld)).not.toContain("FY2027");
+  });
+
+  it("never emits foundingDate — founded_year is unsourced", () => {
+    expect(orgJsonLd(org).foundingDate).toBeUndefined();
+  });
+
+  it("never emits the budget figure", () => {
+    expect(JSON.stringify(orgJsonLd(org))).not.toContain("36970000000");
+  });
+
+  it("emits description only when the self-description carries its source", () => {
+    expect(orgJsonLd(org).description).toBeUndefined();
+    expect(
+      orgJsonLd({ ...org, selfDescription: "We do things." }).description,
+    ).toBeUndefined();
+    expect(
+      orgJsonLd({
+        ...org,
+        selfDescription: "We do things.",
+        selfDescriptionSource: "https://example.org/about",
+      }).description,
+    ).toBe("We do things.");
+  });
+});
+
+describe("billJsonLd", () => {
+  it("emits Legislation with the display identifier", () => {
+    const ld = billJsonLd(bill);
+    expect(ld["@type"]).toBe("Legislation");
+    expect(ld.legislationIdentifier).toBe("H.R. 5376 (117th Congress)");
+    expect(ld.legislationDate).toBe("2021-09-27");
+  });
+
+  it("claims legislationPassedBy only for enacted bills", () => {
+    expect(billJsonLd(bill).legislationPassedBy).toBeDefined();
+    for (const status of ["introduced", "committee", "failed", "vetoed"] as const) {
+      expect(billJsonLd({ ...bill, status }).legislationPassedBy).toBeUndefined();
+    }
+  });
+
+  it("never emits lobbying figures", () => {
+    expect(JSON.stringify(billJsonLd(bill))).not.toContain("1000000");
+  });
+});
+
+describe("outletJsonLd", () => {
+  it("emits NewsMediaOrganization with the parent company", () => {
+    const ld = outletJsonLd(outlet);
+    expect(ld["@type"]).toBe("NewsMediaOrganization");
+    expect(ld.parentOrganization).toEqual({
+      "@type": "Organization",
+      name: "National Public Radio Inc.",
+    });
+  });
+
+  it("never restates AllSides or MBFC ratings as Sift's own claim", () => {
+    const s = JSON.stringify(outletJsonLd(outlet));
+    expect(s).not.toContain("allsides");
+    expect(s).not.toContain("mediabiasfactcheck");
+    expect(s).not.toContain("center");
+  });
+});
+
+describe("jsonLdString", () => {
+  it("escapes < so a value cannot close the script tag early", () => {
+    const out = jsonLdString({ name: "</script><img src=x onerror=alert(1)>" });
+    expect(out).not.toContain("</script>");
+    expect(out).toContain("\\u003c");
+  });
+
+  it("round-trips to the same object once unescaped", () => {
+    const ld = politicianJsonLd(politician);
+    expect(JSON.parse(jsonLdString(ld).replace(/\\u003c/g, "<"))).toEqual(ld);
+  });
+});

--- a/app/bill/[id]/page.tsx
+++ b/app/bill/[id]/page.tsx
@@ -4,6 +4,8 @@ import { notFound } from "next/navigation";
 import BillDossier from "@/components/bill/BillDossier";
 import { getBillById, getPoliticianByBioguide } from "@/lib/db";
 import { formatBillIdDisplay } from "@/lib/bill";
+import { dossierRobotsMeta, isPublishableBill } from "@/lib/publishFloor";
+import { billJsonLd, jsonLdString } from "@/lib/structuredData";
 
 // ISR — same heartbeat as the other dossier routes.
 export const revalidate = 600;
@@ -29,6 +31,10 @@ export async function generateMetadata({
   return {
     title: `${display} — Bill dossier`,
     description,
+    // Below-floor dossiers are not advertised. Spread, not assign: a
+    // `robots` key present here would override the root config even when
+    // undefined, dropping max-image-preview. See lib/publishFloor.ts.
+    ...dossierRobotsMeta(isPublishableBill(bill)),
     openGraph: {
       title: fullTitle,
       description,
@@ -55,5 +61,13 @@ export default async function BillDossierPage({ params }: BillRouteProps) {
     ? await getPoliticianByBioguide(bill.sponsorBioguide)
     : null;
 
-  return <BillDossier bill={bill} sponsor={sponsor} />;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLdString(billJsonLd(bill)) }}
+      />
+      <BillDossier bill={bill} sponsor={sponsor} />
+    </>
+  );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -68,6 +68,23 @@ export const metadata: Metadata = {
     description:
       "The civic context the news assumes. The framing across the political spectrum. The money behind every story.",
   },
+  // max-image-preview:large is a robots *meta* directive, not a robots.txt
+  // one — Google reads it from the meta tag or the X-Robots-Tag header and
+  // ignores it in robots.txt. Without it, dossier and article results get a
+  // thumbnail instead of a full-size image (GROWTH_STRATEGY.md:68).
+  // Set at the root so every route inherits it; a route that should not be
+  // indexed overrides `robots` in its own generateMetadata.
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+  },
 };
 
 // Browser chrome (iOS Safari address bar, Android task switcher) follows the OS

--- a/app/org/[slug]/page.tsx
+++ b/app/org/[slug]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from "next/navigation";
 
 import OrgDossier from "@/components/org/OrgDossier";
 import { getOrgBySlug } from "@/lib/db";
+import { dossierRobotsMeta, isPublishableOrg } from "@/lib/publishFloor";
+import { jsonLdString, orgJsonLd } from "@/lib/structuredData";
 
 // ISR — same heartbeat as the landing + outlet/politician dossiers.
 // Org metadata changes slowly (annual budgets refresh on 990 cycles,
@@ -24,10 +26,17 @@ export async function generateMetadata({
   // org's name in the unfurl card. og:image inherits the site default
   // for now; per-route images are a Phase 2 polish.
   const fullTitle = `${org.name} — Org dossier | Sift`;
-  const description = `Type, funding, political lean, and FARA disclosure for ${org.name} on Sift.`;
+  // No "political lean" here — migration 013 dropped the column precisely so
+  // Sift stops characterizing organizations. The description shouldn't keep
+  // advertising a field the page no longer has.
+  const description = `Governance, cited annual expenses, self-description, and FARA disclosure for ${org.name} on Sift.`;
   return {
     title: `${org.name} — Org dossier`,
     description,
+    // Below-floor dossiers are not advertised. Spread, not assign: a
+    // `robots` key present here would override the root config even when
+    // undefined, dropping max-image-preview. See lib/publishFloor.ts.
+    ...dossierRobotsMeta(isPublishableOrg(org)),
     openGraph: {
       title: fullTitle,
       description,
@@ -45,5 +54,13 @@ export default async function OrgDossierPage({ params }: OrgRouteProps) {
   const { slug } = await params;
   const org = await getOrgBySlug(slug);
   if (!org) notFound();
-  return <OrgDossier org={org} />;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLdString(orgJsonLd(org)) }}
+      />
+      <OrgDossier org={org} />
+    </>
+  );
 }

--- a/app/outlet/[slug]/page.tsx
+++ b/app/outlet/[slug]/page.tsx
@@ -4,6 +4,8 @@ import { notFound } from "next/navigation";
 import OutletDossier from "@/components/outlet/OutletDossier";
 import { getOutletBySlug, getRecentArticlesByOutletSlug } from "@/lib/db";
 import { parseContextPrimer } from "@/lib/primer";
+import { dossierRobotsMeta, isPublishableOutlet } from "@/lib/publishFloor";
+import { jsonLdString, outletJsonLd } from "@/lib/structuredData";
 import type { Article, CategoryId } from "@/lib/types";
 
 // ISR — same heartbeat as the landing page (10 minutes). The dossier reads
@@ -29,6 +31,10 @@ export async function generateMetadata({
   return {
     title: `${outlet.name} — Outlet dossier`,
     description,
+    // Below-floor dossiers are not advertised. Spread, not assign: a
+    // `robots` key present here would override the root config even when
+    // undefined, dropping max-image-preview. See lib/publishFloor.ts.
+    ...dossierRobotsMeta(isPublishableOutlet(outlet)),
     openGraph: {
       title: fullTitle,
       description,
@@ -77,5 +83,13 @@ export default async function OutletDossierPage({ params }: DossierRouteProps) {
     };
   });
 
-  return <OutletDossier outlet={outlet} recentArticles={recentArticles} />;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLdString(outletJsonLd(outlet)) }}
+      />
+      <OutletDossier outlet={outlet} recentArticles={recentArticles} />
+    </>
+  );
 }

--- a/app/politician/[bioguide]/page.tsx
+++ b/app/politician/[bioguide]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from "next/navigation";
 
 import PoliticianDossier from "@/components/politician/PoliticianDossier";
 import { getPoliticianByBioguide } from "@/lib/db";
+import { dossierRobotsMeta, isPublishablePolitician } from "@/lib/publishFloor";
+import { jsonLdString, politicianJsonLd } from "@/lib/structuredData";
 
 // ISR — same heartbeat as the landing + outlet dossier (10 minutes).
 // Politician metadata changes slowly (committees shift quarterly,
@@ -33,6 +35,10 @@ export async function generateMetadata({
   return {
     title: `${politician.name} — Politician dossier`,
     description,
+    // Below-floor dossiers are not advertised. Spread, not assign: a
+    // `robots` key present here would override the root config even when
+    // undefined, dropping max-image-preview. See lib/publishFloor.ts.
+    ...dossierRobotsMeta(isPublishablePolitician(politician)),
     openGraph: {
       title: fullTitle,
       description,
@@ -52,5 +58,17 @@ export default async function PoliticianDossierPage({
   const { bioguide } = await params;
   const politician = await getPoliticianByBioguide(bioguide);
   if (!politician) notFound();
-  return <PoliticianDossier politician={politician} />;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        // Serialized by lib/structuredData.ts, which escapes `<`. Emits only
+        // fields the page itself renders — notably not `notes`.
+        dangerouslySetInnerHTML={{
+          __html: jsonLdString(politicianJsonLd(politician)),
+        }}
+      />
+      <PoliticianDossier politician={politician} />
+    </>
+  );
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,35 @@
+import type { MetadataRoute } from "next";
+
+/**
+ * robots.txt at /robots.txt.
+ *
+ * Note on `max-image-preview: large` (GROWTH_STRATEGY.md:68): it does *not*
+ * belong here. Google reads it from the robots meta tag or the X-Robots-Tag
+ * header and ignores it in robots.txt, so it lives in the root `robots`
+ * metadata in app/layout.tsx instead.
+ *
+ * Keep the host in step with `metadataBase` in app/layout.tsx and BASE in
+ * app/sitemap.ts.
+ */
+const BASE = "https://siftnews.io";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: [
+          // JSON endpoints — nothing to index, and crawling /api/news or
+          // /api/compare would run the live AI paths on crawler traffic.
+          "/api/",
+          // Auth surfaces: no content, and no reason to advertise them.
+          "/sign-in",
+          "/sign-up",
+        ],
+      },
+    ],
+    sitemap: `${BASE}/sitemap.xml`,
+    host: BASE,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,70 @@
+import type { MetadataRoute } from "next";
+
+import { listSitemapEntries } from "@/lib/db";
+
+/**
+ * XML sitemap at /sitemap.xml.
+ *
+ * Until this existed there was no declared crawl path to any dossier — no
+ * sitemap, no robots.txt, no structured data — so the 838-row dossier set
+ * that OPERATING_CONTEXT §2 calls the sellable asset was invisible to search.
+ *
+ * Dossier URLs come from `listSitemapEntries`, which applies the publish
+ * floor (see its docstring). Thin rows are deliberately absent: they still
+ * render and still resolve entity chips, they just aren't advertised.
+ *
+ * `siftnews.io` matches `metadataBase` in app/layout.tsx — keep them in step
+ * or canonical URLs and sitemap URLs will disagree.
+ */
+const BASE = "https://siftnews.io";
+
+// Hand-maintained because it's short and the tradeoffs differ per page.
+// Excluded on purpose: /(auth)/sign-in and /sign-up (nothing to index and no
+// value in advertising an auth surface), and every /api/* route.
+const STATIC_ROUTES: Array<{
+  path: string;
+  changeFrequency: MetadataRoute.Sitemap[number]["changeFrequency"];
+  priority: number;
+}> = [
+  { path: "/", changeFrequency: "hourly", priority: 1.0 },
+  { path: "/news", changeFrequency: "hourly", priority: 0.9 },
+  { path: "/civic", changeFrequency: "weekly", priority: 0.8 },
+  { path: "/agencies", changeFrequency: "monthly", priority: 0.7 },
+  { path: "/think-tanks", changeFrequency: "monthly", priority: 0.7 },
+  { path: "/methodology", changeFrequency: "monthly", priority: 0.5 },
+  { path: "/colophon", changeFrequency: "monthly", priority: 0.3 },
+  { path: "/privacy", changeFrequency: "yearly", priority: 0.2 },
+  { path: "/terms", changeFrequency: "yearly", priority: 0.2 },
+];
+
+// Revalidate hourly. The dossier set changes on a seeder run, not per request,
+// and regenerating a ~650-URL document on every crawler hit is wasted work.
+export const revalidate = 3600;
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const now = new Date();
+
+  const staticEntries: MetadataRoute.Sitemap = STATIC_ROUTES.map((r) => ({
+    url: `${BASE}${r.path}`,
+    lastModified: now,
+    changeFrequency: r.changeFrequency,
+    priority: r.priority,
+  }));
+
+  // A DB blip must not take the sitemap down entirely — serving the static
+  // routes is strictly better than serving a 500 to a crawler.
+  let dossierEntries: MetadataRoute.Sitemap = [];
+  try {
+    const rows = await listSitemapEntries();
+    dossierEntries = rows.map((r) => ({
+      url: `${BASE}${r.path}`,
+      lastModified: r.lastModified,
+      changeFrequency: "monthly" as const,
+      priority: 0.6,
+    }));
+  } catch (err) {
+    console.error("sitemap: dossier query failed, serving static routes only", err);
+  }
+
+  return [...staticEntries, ...dossierEntries];
+}

--- a/components/org/OrgDossier.tsx
+++ b/components/org/OrgDossier.tsx
@@ -35,7 +35,11 @@ export default function OrgDossier({ org }: OrgDossierProps) {
   const ledeBits: string[] = [];
   if (typeLabel) ledeBits.push(typeLabel);
   if (org.foundedYear) ledeBits.push(c.foundedYearLabel(org.foundedYear));
-  if (budgetLabel && org.annualBudgetFy)
+  // Source is required here as well as on the citation line below. lib/org.ts
+  // already nulls the whole triple unless usd + fy + source are all present,
+  // so this is defense in depth against a profile built by another path —
+  // the lede must never be the one place an uncited figure gets through.
+  if (budgetLabel && org.annualBudgetFy && org.annualBudgetSource)
     ledeBits.push(c.annualBudgetLabel(budgetLabel, org.annualBudgetFy));
 
   // External links: stable order; forward-compat for unknown keys.

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -948,6 +948,84 @@ export async function listAllBillsLite(): Promise<BillListItem[]> {
   }
 }
 
+// ─── Sitemap ───────────────────────────────────────────
+
+export type SitemapEntry = { path: string; lastModified: Date };
+
+/**
+ * Dossier URLs that are substantial enough to advertise to crawlers.
+ *
+ * ⚠️ INVARIANT: the WHERE clauses below and the predicates in
+ * `lib/publishFloor.ts` express the same rule and must agree. Two
+ * implementations exist because the sitemap needs a set-level query while the
+ * dossier routes need a check on a profile object already in hand — the
+ * routes use the predicates to emit `robots: { index: false }` for anything
+ * this query omits. Change one, change the other;
+ * `__tests__/publishFloor.test.ts` pins the rule in prose and examples.
+ *
+ * This is the publish floor, generalised from `listCitedAgencies` above: the
+ * catalog the linker knows about and the set we ask Google to index are two
+ * different things. A thin row still renders and still resolves a chip; it
+ * just isn't advertised. Google's scaled-content-abuse policy targets exactly
+ * "one row of data poured into a template", and 838 dossiers of wildly uneven
+ * depth is that shape if published wholesale.
+ *
+ * Only `/outlet/*` renders an article list; politician, org and bill pages are
+ * profile-only, so for those three the floor is entirely about how populated
+ * the row is.
+ *
+ * Per type, and why:
+ *
+ * - **politician** — sitting Congress with committees or PAC industries.
+ *   `chamber IN ('house','senate')` deliberately excludes the 102
+ *   executive/foreign-executive rows: their only substantive content is the
+ *   uncited `notes` prose plus a Wikipedia link, and `founded_year` was
+ *   dropped from orgs rather than sourced to Wikipedia (STATUS.md:109-113).
+ *   Publishing uncited claims about living people is the sharper version of
+ *   that same mistake. Source those rows and they qualify.
+ * - **org** — at least one fully-sourced substantive field. Same rule
+ *   `listCitedAgencies` applies to /agencies, widened past governance.
+ * - **bill** — a status and at least one external link.
+ * - **outlet** — at least one rating carrying its source URL.
+ */
+export async function listSitemapEntries(): Promise<SitemapEntry[]> {
+  try {
+    const result = await pool.query<{ path: string; updated_at: Date | null }>(
+      `SELECT '/politician/' || bioguide_id AS path, updated_at
+         FROM politician_profiles
+        WHERE chamber IN ('house', 'senate')
+          AND (jsonb_array_length(COALESCE(committees, '[]'::jsonb)) > 0
+            OR jsonb_array_length(COALESCE(top_industries_current_cycle, '[]'::jsonb)) > 0)
+       UNION ALL
+       SELECT '/org/' || slug, updated_at
+         FROM org_profiles
+        WHERE (governance_structure IS NOT NULL AND governance_source IS NOT NULL)
+           OR (self_description IS NOT NULL AND self_description_source IS NOT NULL)
+           OR (annual_budget_usd IS NOT NULL AND annual_budget_source IS NOT NULL)
+       UNION ALL
+       SELECT '/bill/' || bill_id, updated_at
+         FROM bill_profiles
+        WHERE status IS NOT NULL
+          AND external_links::text NOT IN ('{}', 'null')
+       UNION ALL
+       SELECT '/outlet/' || slug, updated_at
+         FROM outlet_profiles
+        WHERE (allsides_rating IS NOT NULL AND allsides_url IS NOT NULL)
+           OR (mbfc_factual IS NOT NULL AND mbfc_url IS NOT NULL)`,
+    );
+    return result.rows.map((r) => ({
+      path: r.path,
+      lastModified: r.updated_at ?? new Date(),
+    }));
+  } catch (err) {
+    // Same graceful degradation as the other profile queries: a pre-Phase-3
+    // database yields a static-routes-only sitemap rather than a 500.
+    const msg = String(err);
+    if (msg.includes("does not exist")) return [];
+    throw err;
+  }
+}
+
 // ─── Outlet Dossier (Phase 2.C.1) ──────────────────────
 
 /**

--- a/lib/publishFloor.ts
+++ b/lib/publishFloor.ts
@@ -1,0 +1,113 @@
+/**
+ * The publish floor — which dossiers Sift asks search engines to index.
+ *
+ * The catalog and the published set are two different things:
+ *
+ * - **Catalog set** — every row the entity linker knows about. Large by
+ *   design. A thin row still renders and still resolves a chip, so a link
+ *   from an article never dead-ends.
+ * - **Published set** — rows substantial enough to advertise. These enter
+ *   `app/sitemap.ts`; everything else emits `robots: { index: false }`.
+ *
+ * Why the split exists: Google's scaled-content-abuse policy targets exactly
+ * "one row of data poured into a template", and 838 dossiers of very uneven
+ * depth is that shape if published wholesale. `OPERATING_CONTEXT.md` §2 calls
+ * the dossier dataset the sellable asset — publishing the thin tail devalues
+ * the part that is genuinely good.
+ *
+ * The precedent is `listCitedAgencies` in lib/db.ts, which has always refused
+ * to publish an agency whose governance text lacks its source URL (15 of 93).
+ * These predicates generalise that rule to all four types.
+ *
+ * Note that only `/outlet/*` renders an article list; politician, org and
+ * bill pages are profile-only, so for those three "is this page worth
+ * indexing" is entirely a question of how populated the row is.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * INVARIANT: these predicates and the SQL in `listSitemapEntries` (lib/db.ts)
+ * express the same rule and must agree. They are separate implementations
+ * because the sitemap needs a set-level query and the pages need a check on
+ * an object already in hand. `__tests__/publishFloor.test.ts` pins the rule;
+ * if you change one, change the other and update that test.
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+import type {
+  BillProfile,
+  OrgProfile,
+  OutletProfile,
+  PoliticianProfile,
+} from "./types";
+
+function present(s: string | null | undefined): boolean {
+  return typeof s === "string" && s.trim().length > 0;
+}
+
+/**
+ * Sitting Congress with committee assignments or PAC industry data.
+ *
+ * The chamber restriction excludes the 102 executive / foreign-executive
+ * rows. Their only substantive content is the uncited `notes` prose plus a
+ * Wikipedia link, and `founded_year` was dropped from orgs rather than
+ * sourced to Wikipedia (STATUS.md:109-113) — publishing uncited claims about
+ * a living person is the sharper version of that same mistake. Source those
+ * rows with primary records and they qualify.
+ */
+export function isPublishablePolitician(p: PoliticianProfile): boolean {
+  if (p.chamber !== "house" && p.chamber !== "senate") return false;
+  return p.committees.length > 0 || p.topIndustriesCurrentCycle.length > 0;
+}
+
+/**
+ * At least one substantive field that carries its own source.
+ *
+ * Budget counts because lib/org.ts nulls the whole triple unless the figure,
+ * fiscal year and source URL are all present — so a non-null figure here is
+ * already a cited one.
+ */
+export function isPublishableOrg(o: OrgProfile): boolean {
+  return (
+    (present(o.governanceStructure) && present(o.governanceSource)) ||
+    (present(o.selfDescription) && present(o.selfDescriptionSource)) ||
+    (o.annualBudgetUsd !== null && present(o.annualBudgetSource))
+  );
+}
+
+/** A legislative status plus at least one link to the public record. */
+export function isPublishableBill(b: BillProfile): boolean {
+  return present(b.status) && Object.values(b.externalLinks).some(present);
+}
+
+/**
+ * At least one rating that carries its source URL.
+ *
+ * A rating without its link is an uncited third-party judgement about a named
+ * organization — the thing D37 is most careful about.
+ */
+export function isPublishableOutlet(o: OutletProfile): boolean {
+  return (
+    (present(o.allSidesRating) && present(o.allSidesUrl)) ||
+    (present(o.mbfcFactual) && present(o.mbfcUrl))
+  );
+}
+
+/**
+ * Partial `Metadata` to **spread** into a dossier route's return value.
+ *
+ * Spread, not assign — and that distinction is load-bearing. Next merges
+ * metadata shallowly by key, and a key *present* in the child overrides the
+ * parent even when its value is `undefined`. So `robots: dossierRobots(true)`
+ * does not inherit the root config; it erases it, and every publishable
+ * dossier silently loses the `max-image-preview:large` googlebot directive
+ * that app/layout.tsx sets. Returning `{}` omits the key entirely, which is
+ * what actual inheritance requires.
+ *
+ * `follow: true` on below-floor pages is deliberate: the page still carries
+ * real outbound links to public records, and those are worth crawling even
+ * when the page itself shouldn't rank. This is "don't index yet", not
+ * "ignore this page".
+ */
+export function dossierRobotsMeta(
+  publishable: boolean,
+): { robots?: { index: boolean; follow: boolean } } {
+  return publishable ? {} : { robots: { index: false, follow: true } };
+}

--- a/lib/structuredData.ts
+++ b/lib/structuredData.ts
@@ -1,0 +1,203 @@
+/**
+ * schema.org JSON-LD for the four dossier types.
+ *
+ * These builders live outside the dossier components on purpose: structured
+ * data is a document-level concern, and keeping it in `page.tsx` next to
+ * `generateMetadata` means the markup and the meta tags can't drift.
+ *
+ * ── The rule that governs every field below ──
+ *
+ * **JSON-LD must never assert more than the page renders, and never more
+ * than the row can source.** Structured data is a machine-readable claim
+ * that search engines may surface as fact, detached from the page's own
+ * caveats and citation links — so it is the *worst* place for an unsourced
+ * value, not a harmless one.
+ *
+ * Concretely, and each for a reason already established in this repo:
+ *
+ * - **No `foundingDate`, for orgs or outlets.** `founded_year` was dropped
+ *   from the 10 think-tank rows rather than sourced to Wikipedia, and
+ *   STATUS.md:117 records that the 93 agency rows still carry it "rendered
+ *   and still unsourced". Emitting it here would turn a known-unsourced
+ *   field into machine-readable data.
+ * - **No `description` from `notes`.** Uncited prose, and on politicians it
+ *   is uncited prose about a living person.
+ * - **No budget, lobbying, or PAC figures.** Sift surfaces public-record
+ *   numbers with attribution; JSON-LD strips the attribution.
+ * - **No AllSides / MBFC ratings.** They are third-party assessments the
+ *   page presents verbatim with a link. Restating them as Sift's own
+ *   structured claim about a named organization is exactly the framing D37
+ *   rejected — and `sameAs` would be wrong too, since a rating page is not
+ *   another identity for the outlet.
+ * - **`description` for orgs only when `selfDescriptionSource` exists**,
+ *   mirroring the render gate. It is the org's own words, not Sift's.
+ */
+import { formatBillIdDisplay } from "./bill";
+import type {
+  BillProfile,
+  OrgProfile,
+  OutletProfile,
+  PoliticianProfile,
+} from "./types";
+
+/** Matches `metadataBase` in app/layout.tsx and BASE in app/sitemap.ts. */
+const BASE = "https://siftnews.io";
+
+/**
+ * `sameAs` by allowlisted key — never by taking every value in the blob.
+ *
+ * schema.org defines `sameAs` as another *identity* for the entity: its own
+ * site, its Wikipedia/Wikidata page, its profile on a directory. A source
+ * document is not an identity. `org_profiles.external_links` carries
+ * `budget_source` on 89 rows (and a non-URL `budget_source_fiscal_year` on
+ * 23), so a value-based filter published a White House budget spreadsheet as
+ * "another EPA". These blobs are open dictionaries, so a new provenance key
+ * added later would silently reintroduce that — an allowlist fails closed.
+ */
+function sameAs(
+  links: Record<string, string | undefined>,
+  allowedKeys: readonly string[],
+): string[] {
+  return allowedKeys
+    .map((k) => links[k])
+    .filter((v): v is string => typeof v === "string" && /^https?:\/\//i.test(v))
+    .sort();
+}
+
+// Identity links only. Deliberately excluded: org `budget_source` /
+// `budget_source_fiscal_year` (provenance for a figure), and any `irs_990`
+// or `fara` filing — a document about the entity, not the entity.
+const POLITICIAN_SAME_AS = [
+  "official", "wikipedia", "wikidata", "govtrack", "opensecrets",
+  "ballotpedia", "votesmart",
+] as const;
+const ORG_SAME_AS = ["official", "wikipedia", "propublica"] as const;
+const BILL_SAME_AS = ["congress", "govtrack", "wikipedia"] as const;
+const OUTLET_SAME_AS = ["official", "wikipedia"] as const;
+
+/** Drop null/undefined/empty-array keys so the emitted JSON stays tight. */
+function compact<T extends Record<string, unknown>>(obj: T): T {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => {
+      if (v === null || v === undefined) return false;
+      if (Array.isArray(v) && v.length === 0) return false;
+      return true;
+    }),
+  ) as T;
+}
+
+const CHAMBER_ORG: Record<string, string> = {
+  senate: "United States Senate",
+  house: "United States House of Representatives",
+};
+
+const CHAMBER_ROLE: Record<string, string> = {
+  senate: "United States Senator",
+  house: "United States Representative",
+};
+
+export function politicianJsonLd(p: PoliticianProfile): Record<string, unknown> {
+  const url = `${BASE}/politician/${p.bioguideId}`;
+  const chamber = p.chamber ?? "";
+  const affiliationName = CHAMBER_ORG[chamber];
+
+  return compact({
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "@id": url,
+    mainEntityOfPage: url,
+    url,
+    name: p.name,
+    // Congress.gov's canonical id. A stable public identifier, not a claim.
+    identifier: p.bioguideId,
+    jobTitle: CHAMBER_ROLE[chamber] ?? undefined,
+    // Committees are rendered on the page and come from the canonical
+    // unitedstates/congress-legislators YAMLs via scripts/scrape_committees.py.
+    memberOf: [
+      ...(affiliationName
+        ? [{ "@type": "GovernmentOrganization", name: affiliationName }]
+        : []),
+      ...p.committees.map((c) => ({ "@type": "Organization", name: c })),
+    ],
+    sameAs: sameAs(p.externalLinks as Record<string, string | undefined>, POLITICIAN_SAME_AS),
+  });
+}
+
+export function orgJsonLd(o: OrgProfile): Record<string, unknown> {
+  const url = `${BASE}/org/${o.slug}`;
+  return compact({
+    "@context": "https://schema.org",
+    // Agencies get the more specific type; everything else stays generic
+    // rather than guessing between NGO, Corporation and the rest.
+    "@type": o.type === "agency" ? "GovernmentOrganization" : "Organization",
+    "@id": url,
+    mainEntityOfPage: url,
+    url,
+    name: o.name,
+    identifier: o.slug,
+    // The organization's own characterization, verbatim, and only when it
+    // carries the source the renderer also requires.
+    description:
+      o.selfDescription && o.selfDescriptionSource ? o.selfDescription : undefined,
+    sameAs: sameAs(o.externalLinks as Record<string, string | undefined>, ORG_SAME_AS),
+  });
+}
+
+export function billJsonLd(b: BillProfile): Record<string, unknown> {
+  const url = `${BASE}/bill/${b.billId}`;
+  return compact({
+    "@context": "https://schema.org",
+    "@type": "Legislation",
+    "@id": url,
+    mainEntityOfPage: url,
+    url,
+    name: b.shortTitle || b.title,
+    // Full official title when a short title is what we're showing as `name`.
+    alternateName: b.shortTitle ? b.title : undefined,
+    legislationIdentifier: formatBillIdDisplay(b.billId),
+    // Introduction date is a public record on congress.gov.
+    legislationDate: b.introducedDate ?? undefined,
+    // Only for bills that actually became law. schema.org reads
+    // `legislationPassedBy` as "who passed or made this law", so emitting it
+    // unconditionally would assert that an introduced-and-died bill is a
+    // statute — the machine-readable version of the error the status label
+    // on the page exists to prevent.
+    legislationPassedBy:
+      b.status === "enacted"
+        ? { "@type": "GovernmentOrganization", name: "United States Congress" }
+        : undefined,
+    sameAs: sameAs(b.externalLinks as Record<string, string | undefined>, BILL_SAME_AS),
+  });
+}
+
+export function outletJsonLd(o: OutletProfile): Record<string, unknown> {
+  const url = `${BASE}/outlet/${o.slug}`;
+  return compact({
+    "@context": "https://schema.org",
+    "@type": "NewsMediaOrganization",
+    "@id": url,
+    mainEntityOfPage: url,
+    url,
+    name: o.name,
+    identifier: o.slug,
+    parentOrganization: o.parentCompany
+      ? compact({
+          "@type": "Organization",
+          name: o.parentCompany,
+          url: o.parentCompanyUrl ?? undefined,
+        })
+      : undefined,
+    sameAs: sameAs(o.externalLinks as Record<string, string | undefined>, OUTLET_SAME_AS),
+  });
+}
+
+/**
+ * Serialize for a `<script type="application/ld+json">` body.
+ *
+ * `<` is escaped because the JSON sits inside a script element: a value
+ * containing `</script` would otherwise close the tag early. Dossier values
+ * are curated, but they are still data rendered into markup.
+ */
+export function jsonLdString(data: Record<string, unknown>): string {
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}


### PR DESCRIPTION
## Why

There was **no declared crawl path to any dossier**: no `sitemap.ts`, no `robots.ts`, and zero structured data anywhere in the app. The 838-row dossier set that `OPERATING_CONTEXT.md` §2 calls the sellable asset was invisible to search. `GROWTH_STRATEGY.md:68` scopes this at ~6 hrs and it was unstarted.

Publishing all 838 wholesale is the wrong fix — Google's scaled-content-abuse policy targets exactly "one row of data poured into a template", and these rows vary enormously in depth. So the floor ships with the plumbing, generalising the rule `listCitedAgencies` has always applied to `/agencies` (15 of 93 rows publish).

## What

| | |
|---|---|
| `app/sitemap.ts` | **674 URLs** — 9 static + 665 dossiers (534 politician, 71 outlet, 35 org, 25 bill) |
| `app/robots.ts` | allows all but `/api/` and the auth routes |
| `lib/publishFloor.ts` | per-type predicates; below-floor routes emit `robots: { index: false, follow: true }` |
| `lib/structuredData.ts` | `Person` / `Organization` / `Legislation` / `NewsMediaOrganization` |

**Catalog set and published set are now deliberately different.** A thin row still renders and still resolves an entity chip, so a link from an article never dead-ends — it just isn't advertised. `follow: true` on withheld pages is intentional: their outbound links to public records are still worth crawling.

## The judgment call

The **102 executive / foreign-executive politicians are withheld**, including Trump, Biden, Putin and the Cabinet — among the highest-mention entities in the corpus.

Their only substantive content is uncited `notes` prose about living people ("First African-American Secretary of Defense") plus a Wikipedia link. `founded_year` was dropped from orgs rather than sourced to Wikipedia (`STATUS.md:109-113`); publishing uncited claims about named living people is the sharper version of that same mistake, and only `/outlet/*` renders an article list, so on these profile-only pages the uncited prose *is* the page. Source them with primary records and they qualify — tracked separately.

## Structured-data rule

Never assert more than the page renders or the row can source. JSON-LD is surfaced as fact with the page's citation links stripped, making it the worst place for an unsourced value. Excluded: `foundingDate` (unsourced on the 93 agency rows per `STATUS.md:117`), `notes` on every type, all budget/lobbying/PAC figures, and the AllSides/MBFC ratings — restating a third-party assessment as Sift's own structured claim is what D37 rejected.

## Two traps, both caught only by reading rendered HTML

- **`max-image-preview:large` does not belong in robots.txt.** Google reads it from the robots meta tag or `X-Robots-Tag` and ignores it there. It now lives in the root metadata in `layout.tsx`. (`GROWTH_STRATEGY.md:68` implies otherwise.)
- **`robots: undefined` does not inherit.** Next merges metadata by key and a key *present* in the child wins even when undefined — so returning undefined for publishable dossiers silently dropped that same directive from every one of them. `dossierRobotsMeta` returns a spreadable object that omits the key. The unit test asserting the old behaviour was itself wrong and is now a regression guard.

Also: `sameAs` uses a key allowlist rather than every value in `external_links`, which had published the EPA's White House budget spreadsheet as "another EPA"; and `legislationPassedBy` is gated on `status === "enacted"` so an introduced-and-died bill isn't asserted to be a statute.

## Drive-by fixes

- Org page description advertised "political lean", dropped in migration 013.
- `OrgDossier` budget lede gated on fiscal year without checking for a source. Latent only — `lib/org.ts:191` already nulls the whole triple — so this is defence in depth.

## Verification

Run against prod, **13/13 on both sides of the floor for all four types**: SQL floor == sitemap membership == page robots meta == `max-image-preview` inheritance. Sitemap parsed as well-formed XML: 674 entries, no duplicates, correct host, every entry carrying `lastmod`. 426 tests pass, `tsc` clean.

## Known follow-ups

1. **The floor is expressed twice** — TS predicates in `publishFloor.ts` and SQL in `listSitemapEntries`. An invariant comment binds them in both files and the test pins the rule, but it can rot. Not unified here because a concurrent branch owns that query; the clean version has the sitemap apply the predicates to rows it fetches.
2. **No visible "limited public record" state** on below-floor pages yet — worth designing rather than bolting on.

Pairs with sift-api#129, which raised entity-link coverage from 7.6% via curated aliases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)