### PR TITLE
Expire foreign dossiers on their last check; fix a silently-null predecessor

### DIFF
--- a/__tests__/PoliticianDossier.test.tsx
+++ b/__tests__/PoliticianDossier.test.tsx
@@ -30,6 +30,7 @@ const emptyRole: PoliticianProfile["role"] = {
   confirmationVoteResult: null,
   predecessorName: null,
   predecessorSource: null,
+  roleVerifiedAt: null,
 };
 
 const austin: PoliticianProfile = {
@@ -60,6 +61,7 @@ const austin: PoliticianProfile = {
     confirmationVoteResult: "Confirmed 93-2",
     predecessorName: "Mark T. Esper",
     predecessorSource: "https://www.congress.gov/nomination/117th-congress/78",
+    roleVerifiedAt: "2026-08-07",
   },
 };
 
@@ -152,6 +154,7 @@ describe("PoliticianDossier — executive office section", () => {
             confirmationVoteUrl: null,
             predecessorName: "Mark T. Esper",
             predecessorSource: null,
+          roleVerifiedAt: null,
             nominationUrl: null,
           },
         }}

--- a/__tests__/politician.test.ts
+++ b/__tests__/politician.test.ts
@@ -155,6 +155,7 @@ describe("parseDbPoliticianProfile", () => {
           confirmationVoteResult: null,
           predecessorName: null,
           predecessorSource: null,
+          roleVerifiedAt: null,
         },
       });
     });

--- a/__tests__/politicianQueryColumns.test.ts
+++ b/__tests__/politicianQueryColumns.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The politician dossier query and the row parser are two lists that must
+ * agree, and nothing type-checks them against each other: `pg` returns
+ * `undefined` for a column that was not selected, and every migration-015/017
+ * field on `DbPoliticianProfileRow` is optional (so a pre-015 database still
+ * parses). A column missing from the SELECT is therefore invisible — it
+ * type-checks, every unit test passes, and the field silently reads null in
+ * production.
+ *
+ * That is not hypothetical. `predecessor_source` shipped in the parser and the
+ * seeder but never made it into the SELECT, so `predecessorName` — which the
+ * parser deliberately gates on its source — was null on every rendered dossier
+ * from #198 until this test was written. The component and parser tests all
+ * passed, because they build rows by hand rather than through the query.
+ */
+const DB_TS = readFileSync(join(process.cwd(), "lib/db.ts"), "utf8");
+const POLITICIAN_TS = readFileSync(join(process.cwd(), "lib/politician.ts"), "utf8");
+
+function politicianSelectColumns(): Set<string> {
+  const start = DB_TS.indexOf("SELECT bioguide_id, name, party, state, chamber,");
+  expect(start).toBeGreaterThan(-1);
+  const end = DB_TS.indexOf("FROM politician_profiles", start);
+  const body = DB_TS.slice(start + "SELECT".length, end);
+  return new Set(
+    body
+      .split(",")
+      .map((c) => c.trim().replace(/\s+AS\s+\w+$/i, ""))
+      .filter((c) => /^[a-z_]+$/.test(c)),
+  );
+}
+
+/** Every `row.<column>` the parser reads out of a DB row. */
+function columnsParserReads(): Set<string> {
+  const out = new Set<string>();
+  for (const m of POLITICIAN_TS.matchAll(/\browf?\.([a-z_]+)/g)) out.add(m[1]);
+  for (const m of POLITICIAN_TS.matchAll(/\brow\.([a-z_]+)/g)) out.add(m[1]);
+  return out;
+}
+
+describe("getPoliticianByBioguide SELECT vs parseDbPoliticianProfile", () => {
+  it("selects every column the parser reads", () => {
+    const selected = politicianSelectColumns();
+    const missing = [...columnsParserReads()].filter((c) => !selected.has(c)).sort();
+    expect(missing).toEqual([]);
+  });
+
+  it("selects the columns the publish floor and provenance depend on", () => {
+    // Named explicitly so a future edit to either list is a deliberate act.
+    const selected = politicianSelectColumns();
+    for (const column of [
+      "role_title",
+      "role_title_source",
+      "role_verified_at",
+      "predecessor_name",
+      "predecessor_source",
+      "nomination_date",
+      "nomination_url",
+      "confirmation_date",
+      "confirmation_vote_url",
+      "confirmation_vote_result",
+      "role_start_date",
+      "role_end_date",
+      "role_dates_source",
+      "id_source",
+    ]) {
+      expect(selected.has(column)).toBe(true);
+    }
+  });
+});

--- a/__tests__/publishFloor.test.ts
+++ b/__tests__/publishFloor.test.ts
@@ -4,6 +4,7 @@ import {
   isPublishableOrg,
   isPublishableOutlet,
   isPublishablePolitician,
+  ROLE_VERIFICATION_MAX_AGE_DAYS,
 } from "@/lib/publishFloor";
 import type {
   BillProfile,
@@ -43,6 +44,7 @@ const politician: PoliticianProfile = {
     confirmationVoteResult: null,
     predecessorName: null,
     predecessorSource: null,
+    roleVerifiedAt: null,
   },
 };
 
@@ -186,6 +188,70 @@ describe("isPublishablePolitician", () => {
         committees: ["Appropriations"],
       }),
     ).toBe(false);
+  });
+});
+
+describe("isPublishablePolitician — foreign-executive expiry (017)", () => {
+  const NOW = new Date("2026-08-07T12:00:00Z");
+  const foreign = (roleVerifiedAt: string | null): PoliticianProfile => ({
+    ...politician,
+    chamber: "foreign-executive",
+    committees: [],
+    topIndustriesCurrentCycle: [],
+    role: {
+      ...politician.role,
+      roleTitle: "Prime Minister",
+      roleTitleSource: "https://www.gov.uk/government/people/keir-starmer",
+      roleVerifiedAt,
+    },
+  });
+
+  it("publishes a foreign row checked recently", () => {
+    expect(isPublishablePolitician(foreign("2026-08-01"), NOW)).toBe(true);
+  });
+
+  it("withholds one never checked", () => {
+    // A sourced title is not enough on its own here: the source is a live page
+    // that names the person, so an unknown check date is an unknown claim.
+    expect(isPublishablePolitician(foreign(null), NOW)).toBe(false);
+  });
+
+  it("withholds one checked longer ago than the window", () => {
+    const stale = new Date(NOW);
+    stale.setUTCDate(stale.getUTCDate() - (ROLE_VERIFICATION_MAX_AGE_DAYS + 1));
+    expect(
+      isPublishablePolitician(foreign(stale.toISOString().slice(0, 10)), NOW),
+    ).toBe(false);
+  });
+
+  it("still publishes exactly at the boundary", () => {
+    const edge = new Date(NOW);
+    edge.setUTCDate(edge.getUTCDate() - ROLE_VERIFICATION_MAX_AGE_DAYS);
+    expect(
+      isPublishablePolitician(foreign(edge.toISOString().slice(0, 10)), NOW),
+    ).toBe(true);
+  });
+
+  it("rejects an unparseable date rather than treating it as fresh", () => {
+    expect(isPublishablePolitician(foreign("not-a-date"), NOW)).toBe(false);
+  });
+
+  it("does NOT expire US executive or scotus rows", () => {
+    // Their title is a statute and their appointment a permanent roll-call;
+    // departure is caught by the successor's confirmation, not by a recheck.
+    // Expiring them would drop 56 correct rows for lack of a script run.
+    for (const chamber of ["executive", "scotus"] as const) {
+      expect(
+        isPublishablePolitician(
+          { ...foreign(null), chamber },
+          NOW,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("does not expire sitting Congress, which has no role source at all", () => {
+    expect(isPublishablePolitician(politician, NOW)).toBe(true);
   });
 });
 

--- a/__tests__/structuredData.test.ts
+++ b/__tests__/structuredData.test.ts
@@ -40,6 +40,7 @@ const politician: PoliticianProfile = {
     confirmationVoteResult: null,
     predecessorName: null,
     predecessorSource: null,
+    roleVerifiedAt: null,
   },
 };
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -683,7 +683,8 @@ export async function getPoliticianByBioguide(
               role_start_date, role_end_date, role_dates_source,
               nomination_date, nomination_url,
               confirmation_date, confirmation_vote_url,
-              confirmation_vote_result, predecessor_name
+              confirmation_vote_result, predecessor_name, predecessor_source,
+              role_verified_at
        FROM politician_profiles
        WHERE bioguide_id = $1
        LIMIT 1`,
@@ -1010,9 +1011,16 @@ export async function listSitemapEntries(): Promise<SitemapEntry[]> {
         WHERE (chamber IN ('house', 'senate')
                AND (jsonb_array_length(COALESCE(committees, '[]'::jsonb)) > 0
                  OR jsonb_array_length(COALESCE(top_industries_current_cycle, '[]'::jsonb)) > 0))
-           OR (chamber IN ('executive', 'foreign-executive', 'scotus')
+           OR (chamber IN ('executive', 'scotus')
                AND role_title IS NOT NULL
                AND role_title_source IS NOT NULL)
+           -- Foreign rows additionally expire. Mirrors
+           -- ROLE_VERIFICATION_MAX_AGE_DAYS in lib/publishFloor.ts — change both.
+           OR (chamber = 'foreign-executive'
+               AND role_title IS NOT NULL
+               AND role_title_source IS NOT NULL
+               AND role_verified_at IS NOT NULL
+               AND role_verified_at >= CURRENT_DATE - INTERVAL '90 days')
        UNION ALL
        SELECT '/org/' || slug, updated_at
          FROM org_profiles

--- a/lib/politician.ts
+++ b/lib/politician.ts
@@ -138,6 +138,7 @@ export interface DbPoliticianProfileRow {
   confirmation_vote_result?: string | null;
   predecessor_name?: string | null;
   predecessor_source?: string | null;
+  role_verified_at?: string | Date | null;
 }
 
 /** `pg` hands DATE columns back as Date objects; normalize to YYYY-MM-DD. */
@@ -186,6 +187,9 @@ function asRoleProvenance(
       ? row.predecessor_name?.trim() || null
       : null,
     predecessorSource,
+    // Not gated on another column: this IS the provenance of the check, and a
+    // row that was never verified must read as never verified, not as absent.
+    roleVerifiedAt: asIsoDate(row.role_verified_at),
     confirmationDate: voteUrl ? asIsoDate(row.confirmation_date) : null,
     confirmationVoteResult: voteUrl
       ? row.confirmation_vote_result?.trim() || null

--- a/lib/publishFloor.ts
+++ b/lib/publishFloor.ts
@@ -58,7 +58,56 @@ function present(s: string | null | undefined): boolean {
  * second clause is a sourcing test even though it reads like a presence test.
  * The 46 foreign heads of state have no such record and stay below the floor.
  */
-export function isPublishablePolitician(p: PoliticianProfile): boolean {
+/**
+ * How long a foreign-executive row may go unchecked and still be advertised.
+ *
+ * A judgement, not a derivation: long enough that a quarterly re-run keeps the
+ * set published, short enough that a head of government who has left office is
+ * withheld within one quarter rather than indefinitely. `listSitemapEntries`
+ * mirrors this as a SQL interval — change both.
+ */
+export const ROLE_VERIFICATION_MAX_AGE_DAYS = 90;
+
+/**
+ * True when a foreign row's source was refetched recently enough to still
+ * stand behind the claim.
+ *
+ * Only foreign rows decay. Their `roleTitleSource` is a live page that names
+ * the person — gov.uk naming Keir Starmer — so it stops being true the moment
+ * they leave office, and nothing else on the row records that they did.
+ * gov.uk now says Starmer was Prime Minister "from 5 July 2024 to 20 July
+ * 2026" while Sift's own prose still called him the sitting PM; that is the
+ * failure this exists to bound.
+ *
+ * US executive and scotus rows do not decay and are deliberately exempt: their
+ * title comes from a statute, their appointment from a Senate roll-call, and
+ * their *departure* from the successor's roll-call, which sets roleEndDate.
+ * All three are permanent records. Expiring them would drop 56 correct rows
+ * out of the sitemap because nobody re-ran a script.
+ */
+function verificationIsCurrent(verifiedAt: string | null, now: Date): boolean {
+  if (!present(verifiedAt)) return false;
+  const checked = Date.parse(`${verifiedAt}T00:00:00Z`);
+  if (Number.isNaN(checked)) return false;
+  // Whole days from UTC midnight, because the SQL half of this rule compares
+  // `role_verified_at >= CURRENT_DATE - INTERVAL '90 days'` — pure date
+  // arithmetic. Comparing against the current *instant* instead would make the
+  // two disagree for most of every day: a row checked exactly 90 days ago
+  // reads as 90.5 days old here and 90 days old in Postgres, so the sitemap
+  // would list a page whose own metadata says noindex.
+  const today = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+  );
+  const ageDays = (today - checked) / 86_400_000;
+  return ageDays >= 0 && ageDays <= ROLE_VERIFICATION_MAX_AGE_DAYS;
+}
+
+export function isPublishablePolitician(
+  p: PoliticianProfile,
+  now: Date = new Date(),
+): boolean {
   if (p.chamber === "house" || p.chamber === "senate") {
     return p.committees.length > 0 || p.topIndustriesCurrentCycle.length > 0;
   }
@@ -67,7 +116,13 @@ export function isPublishablePolitician(p: PoliticianProfile): boolean {
     p.chamber === "foreign-executive" ||
     p.chamber === "scotus"
   ) {
-    return present(p.role.roleTitle) && present(p.role.roleTitleSource);
+    if (!present(p.role.roleTitle) || !present(p.role.roleTitleSource)) {
+      return false;
+    }
+    return (
+      p.chamber !== "foreign-executive" ||
+      verificationIsCurrent(p.role.roleVerifiedAt, now)
+    );
   }
   return false;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -395,6 +395,12 @@ export interface PoliticianRoleProvenance {
    * who are never confirmed. The UI must say the narrower thing.
    */
   predecessorSource: string | null;
+  /**
+   * Date `roleTitleSource` was last refetched and confirmed (migration 017).
+   * Load-bearing for foreign-executive rows only, whose source is a live page
+   * naming the person and therefore decays; see `lib/publishFloor.ts`.
+   */
+  roleVerifiedAt: string | null;
 }
 
 /**


### PR DESCRIPTION
Read half of kristenmartino/sift-api#160.

## Expiry

Only `foreign-executive` rows decay: their `roleTitleSource` is a live page naming the person, so it stops being true when they leave office and nothing else on the row records that they did. `gov.uk` now says Keir Starmer was Prime Minister *"from 5 July 2024 to 20 July 2026"* while Sift called him the sitting PM.

US executive and `scotus` rows are **deliberately exempt** — statute for the title, a permanent Senate roll-call for the appointment, and the successor's roll-call for the departure. Expiring them would drop 56 correct rows for lack of a script run.

Both halves of the rule move together, as `publishFloor.ts` has always required: `ROLE_VERIFICATION_MAX_AGE_DAYS` here, the mirrored `INTERVAL` in `listSitemapEntries`.

**They compare whole days from UTC midnight**, because the SQL half compares `CURRENT_DATE`. Using the current *instant* instead made a row checked exactly 90 days ago read as 90.5 days old in TS and 90 in Postgres — so the sitemap would have listed a page whose own metadata said `noindex`. The boundary test caught it.

## A bug found while here

**`predecessor_source` was never added to `getPoliticianByBioguide`'s SELECT.**

Three things conspired to hide it:
- `pg` returns `undefined` for a column that was not selected.
- Every migration-015 field on `DbPoliticianProfileRow` is optional, so a pre-015 database still parses.
- The parser deliberately gates `predecessorName` on its source.

So **the predecessor row has been null on every rendered dossier since #198** — for all 35 executive rows and all 9 Justices. It type-checked, and every test passed, because the parser and component tests build rows by hand rather than going through the query.

`__tests__/politicianQueryColumns.test.ts` closes the class rather than the instance: it reads the SELECT out of `lib/db.ts` and asserts it covers every column the parser reads. **Confirmed to fail on the pre-fix code**, naming `predecessor_source`.

That gap is structural — two lists that must agree with nothing type-checking them against each other — so it would have recurred on the next column.

459 tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)