### PR TITLE
Name the budget figure after the record it came from

### DIFF
--- a/__tests__/OrgDossier.test.tsx
+++ b/__tests__/OrgDossier.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+
+import OrgDossier from "@/components/org/OrgDossier";
+import type { OrgProfile } from "@/lib/types";
+
+/**
+ * The budget line on an org dossier names a figure AND the record it came
+ * from, and until 2026-08-07 it named the wrong one for a third of the rows.
+ *
+ * `copy.ts` hardcoded "Per the Form 990 on ProPublica Nonprofit Explorer"
+ * alongside "Total expenses". That is right for a nonprofit and wrong for a
+ * federal agency: the 23 agency rows are cited to OMB Historical Tables — no
+ * Form 990 exists for the EPA — and the figure is *net outlays*, not expenses.
+ * Net of offsetting receipts, which is why GSA's FY2025 figure is legitimately
+ * −$379M and read as a bug under the word "expenses".
+ *
+ * These render the component rather than the copy helper, because the defect
+ * was in the wiring: the label was correct in isolation and attached to the
+ * wrong source on the page.
+ */
+
+const baseOrg: OrgProfile = {
+  slug: "example",
+  name: "Example",
+  type: "think-tank",
+  selfDescription: null,
+  selfDescriptionSource: null,
+  selfDescriptionChecked: null,
+  governanceStructure: null,
+  governanceSource: null,
+  foundedYear: null,
+  annualBudgetUsd: null,
+  annualBudgetFy: null,
+  annualBudgetSource: null,
+  annualBudgetKind: null,
+  majorFunders: [],
+  faraRegistered: false,
+  faraCountries: [],
+  externalLinks: {},
+  notes: null,
+};
+
+const nonprofit: OrgProfile = {
+  ...baseOrg,
+  slug: "brookings-institution",
+  name: "Brookings Institution",
+  annualBudgetUsd: 107_734_507,
+  annualBudgetFy: "FY ending June 2025",
+  annualBudgetSource:
+    "https://projects.propublica.org/nonprofits/organizations/530196577",
+  annualBudgetKind: "form990",
+};
+
+const agency: OrgProfile = {
+  ...baseOrg,
+  slug: "environmental-protection-agency",
+  name: "Environmental Protection Agency",
+  type: "agency",
+  annualBudgetUsd: 36_973_000_000,
+  annualBudgetFy: "FY2025",
+  annualBudgetSource:
+    "https://www.whitehouse.gov/wp-content/uploads/2026/04/hist04z1_fy2027.xlsx",
+  annualBudgetKind: "ombOutlays",
+};
+
+describe("OrgDossier budget line", () => {
+  it("calls a 990-sourced figure total expenses", () => {
+    render(<OrgDossier org={nonprofit} />);
+    expect(screen.getByText(/Total expenses/)).toBeInTheDocument();
+    expect(screen.getByText(/Form 990/)).toBeInTheDocument();
+  });
+
+  it("calls an OMB-sourced figure net outlays", () => {
+    render(<OrgDossier org={agency} />);
+    expect(screen.getByText(/Net outlays/)).toBeInTheDocument();
+    expect(screen.getByText(/OMB Historical Tables/)).toBeInTheDocument();
+  });
+
+  it("never labels an agency's OMB figure as a Form 990", () => {
+    render(<OrgDossier org={agency} />);
+    expect(screen.queryByText(/Form 990/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/ProPublica/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Total expenses/)).not.toBeInTheDocument();
+  });
+
+  it("points the source link at the record it names", () => {
+    render(<OrgDossier org={agency} />);
+    const link = screen.getByRole("link", { name: /OMB Historical Tables/ });
+    expect(link).toHaveAttribute("href", agency.annualBudgetSource);
+  });
+
+  it("renders a negative net outlay without calling it an expense (GSA)", () => {
+    render(
+      <OrgDossier
+        org={{
+          ...agency,
+          slug: "general-services-administration",
+          name: "General Services Administration",
+          annualBudgetUsd: -379_000_000,
+        }}
+      />,
+    );
+    expect(screen.getByText(/Net outlays/)).toBeInTheDocument();
+    expect(screen.queryByText(/expenses/i)).not.toBeInTheDocument();
+  });
+
+  it("names neither record when the source is unrecognised", () => {
+    render(
+      <OrgDossier
+        org={{
+          ...agency,
+          annualBudgetSource: "https://example.org/budget.pdf",
+          annualBudgetKind: null,
+        }}
+      />,
+    );
+    expect(screen.getByText(/Per the cited source/)).toBeInTheDocument();
+    expect(screen.queryByText(/Form 990/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/OMB/)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/copy.test.ts
+++ b/__tests__/copy.test.ts
@@ -174,3 +174,35 @@ describe("COPY strings", () => {
     });
   });
 });
+
+describe("org budget labels name the record they came from", () => {
+  const { annualBudgetLabel, budgetSourceLabel } = COPY.orgDossier;
+
+  it("calls a 990 figure total expenses", () => {
+    expect(annualBudgetLabel("$107.7M", "FY ending June 2025", "form990"))
+      .toBe("Total expenses $107.7M · FY ending June 2025");
+    expect(budgetSourceLabel("form990")).toContain("Form 990");
+  });
+
+  it("calls an OMB figure net outlays", () => {
+    expect(annualBudgetLabel("$37.0B", "FY2025", "ombOutlays"))
+      .toBe("Net outlays $37.0B · FY2025");
+    expect(budgetSourceLabel("ombOutlays")).toContain("OMB Historical Tables");
+  });
+
+  it("never calls an OMB figure a Form 990", () => {
+    // 23 agency pages did exactly this until 2026-08-07.
+    expect(budgetSourceLabel("ombOutlays")).not.toContain("990");
+    expect(annualBudgetLabel("$37.0B", "FY2025", "ombOutlays")).not.toContain("expenses");
+  });
+
+  it("names neither when the record is unidentified", () => {
+    expect(annualBudgetLabel("$1", "FY2025", null)).toBe("$1 · FY2025");
+    expect(budgetSourceLabel(null)).toBe("Per the cited source");
+  });
+
+  it("reads correctly for a negative net outlay (GSA, FY2025)", () => {
+    expect(annualBudgetLabel("-$379.0M", "FY2025", "ombOutlays"))
+      .toBe("Net outlays -$379.0M · FY2025");
+  });
+});

--- a/__tests__/org.test.ts
+++ b/__tests__/org.test.ts
@@ -106,6 +106,7 @@ describe("parseDbOrgProfile", () => {
         type: "think-tank",
         annualBudgetFy: "FY ending June 2025",
         annualBudgetSource: "https://projects.propublica.org/nonprofits/organizations/530196577",
+        annualBudgetKind: "form990",
         foundedYear: 1916,
         annualBudgetUsd: 120_000_000,
         majorFunders: [
@@ -359,5 +360,49 @@ describe("parseDbOrgProfile", () => {
       expect(profile?.name).toBe("Brookings Institution");
       expect(profile?.selfDescription).toBeNull();
     });
+  });
+});
+
+describe("annualBudgetKind", () => {
+  const row = (source: string): DbOrgProfileRow => ({
+    ...fullRow,
+    annual_budget_usd: 1000,
+    annual_budget_fy: "FY2025",
+    annual_budget_source: source,
+  });
+
+  it("names a ProPublica 990 source", () => {
+    const o = parseDbOrgProfile(row("https://projects.propublica.org/nonprofits/organizations/1"));
+    expect(o?.annualBudgetKind).toBe("form990");
+  });
+
+  it("names an OMB Historical Tables source", () => {
+    const o = parseDbOrgProfile(row("https://www.whitehouse.gov/wp-content/uploads/2026/04/hist04z1_fy2027.xlsx"));
+    expect(o?.annualBudgetKind).toBe("ombOutlays");
+  });
+
+  it("accepts govinfo as the same OMB series", () => {
+    expect(parseDbOrgProfile(row("https://www.govinfo.gov/content/pkg/x/hist.xlsx"))?.annualBudgetKind)
+      .toBe("ombOutlays");
+  });
+
+  it("returns null for an unrecognised host rather than guessing", () => {
+    expect(parseDbOrgProfile(row("https://example.org/budget.pdf"))?.annualBudgetKind).toBeNull();
+  });
+
+  it("matches on host, not substring — a lookalike URL does not count", () => {
+    const o = parseDbOrgProfile(row("https://evil.com/?u=projects.propublica.org"));
+    expect(o?.annualBudgetKind).toBeNull();
+  });
+
+  it("is null when the budget itself is withheld for want of a source", () => {
+    const o = parseDbOrgProfile({
+      ...fullRow,
+      annual_budget_usd: 1000,
+      annual_budget_fy: null,
+      annual_budget_source: "https://projects.propublica.org/nonprofits/organizations/1",
+    });
+    expect(o?.annualBudgetUsd).toBeNull();
+    expect(o?.annualBudgetKind).toBeNull();
   });
 });

--- a/__tests__/structuredData.test.ts
+++ b/__tests__/structuredData.test.ts
@@ -57,6 +57,7 @@ const org: OrgProfile = {
   annualBudgetUsd: 36_970_000_000,
   annualBudgetFy: "FY2027",
   annualBudgetSource: "https://www.whitehouse.gov/example.xlsx",
+  annualBudgetKind: "ombOutlays",
   majorFunders: [],
   faraRegistered: false,
   faraCountries: [],

--- a/components/org/OrgDossier.tsx
+++ b/components/org/OrgDossier.tsx
@@ -40,7 +40,9 @@ export default function OrgDossier({ org }: OrgDossierProps) {
   // so this is defense in depth against a profile built by another path —
   // the lede must never be the one place an uncited figure gets through.
   if (budgetLabel && org.annualBudgetFy && org.annualBudgetSource)
-    ledeBits.push(c.annualBudgetLabel(budgetLabel, org.annualBudgetFy));
+    ledeBits.push(
+      c.annualBudgetLabel(budgetLabel, org.annualBudgetFy, org.annualBudgetKind),
+    );
 
   // External links: stable order; forward-compat for unknown keys.
   const linkOrder: Array<keyof typeof c.externalLinkLabels> = [
@@ -101,7 +103,7 @@ export default function OrgDossier({ org }: OrgDossierProps) {
                 rel="noopener noreferrer"
                 className="text-(--text-tertiary) no-underline hover:underline hover:text-(--accent)"
               >
-                {c.budgetSourceLabel} <span aria-hidden>↗</span>
+                {c.budgetSourceLabel(org.annualBudgetKind)} <span aria-hidden>↗</span>
               </a>
             </p>
           )}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -6,7 +6,7 @@
 // Rules: contractions always, active voice, no jargon, no exclamation marks.
 // Show the data, link the source, let the reader conclude.
 
-import type { StoryFraming } from "./types";
+import type { BudgetSourceKind, StoryFraming } from "./types";
 
 // ── Outlet-count phrasing (issue #153) ──────────────────
 // One source of truth for how the LIVE curated-outlet count reads, so it can't
@@ -369,11 +369,28 @@ export const COPY = {
     // Single-line lede builder bits.
     foundedYearLabel: (year: number) => `Founded ${year}`,
     // Was `Annual budget ~${budget}` against an unsourced fixture figure.
-    // "Annual budget" was never a checkable claim; total expenses from a named
+    // "Annual budget" was never a checkable claim; a named figure from a named
     // filing is. The tilde is gone too — the figure is now exact.
-    annualBudgetLabel: (budget: string, fy: string) =>
-      `Total expenses ${budget} · ${fy}`,
-    budgetSourceLabel: "Per the Form 990 on ProPublica Nonprofit Explorer",
+    //
+    // Keyed on which record the source is, because the two do not measure the
+    // same thing. A 990 reports total functional expenses. OMB Historical
+    // Tables report net outlays — net of offsetting receipts, hence GSA's
+    // legitimate −$379M, which reads as a bug under the word "expenses".
+    // These were a single hardcoded pair until 2026-08-07, so 23 agency pages
+    // cited an OMB spreadsheet under the name of a Form 990 they do not have.
+    annualBudgetLabel: (budget: string, fy: string, kind: BudgetSourceKind | null) =>
+      kind === "ombOutlays"
+        ? `Net outlays ${budget} · ${fy}`
+        : kind === "form990"
+          ? `Total expenses ${budget} · ${fy}`
+          : // Neither record identified: state the figure, name nothing.
+            `${budget} · ${fy}`,
+    budgetSourceLabel: (kind: BudgetSourceKind | null) =>
+      kind === "ombOutlays"
+        ? "Per OMB Historical Tables, Table 4.1 (outlays by agency)"
+        : kind === "form990"
+          ? "Per the Form 990 on ProPublica Nonprofit Explorer"
+          : "Per the cited source",
     methodologyHint: "Funding data comes from IRS 990s and FARA. Read the methodology.",
   },
   billDossier: {

--- a/lib/org.ts
+++ b/lib/org.ts
@@ -5,6 +5,7 @@
 // budget. Pure functions only; trivially unit-testable.
 
 import type {
+  BudgetSourceKind,
   OrgExternalLinks,
   OrgProfile,
   OrgType,
@@ -129,6 +130,38 @@ function asOrgType(v: string | null): OrgType | null {
 }
 
 /**
+ * Identify which kind of record a budget source points at, so the page can
+ * name the figure correctly.
+ *
+ * Keyed on the source URL rather than on `org.type`, because the label
+ * describes the *record*, not the organization — a nonprofit cited to a 990
+ * and an agency cited to OMB are different claims even when both are typed
+ * `foundation`. Before this, `copy.ts` hardcoded "Per the Form 990 on
+ * ProPublica Nonprofit Explorer" for every row, so 23 federal agencies cited
+ * to an OMB spreadsheet rendered under the name of a filing they do not have.
+ *
+ * Host-matched, not substring-matched: a bare `includes("propublica.org")`
+ * would also match `evil.com/?u=propublica.org`. Unknown hosts return null and
+ * the UI falls back to naming neither.
+ */
+function budgetSourceKind(src: string): BudgetSourceKind | null {
+  let host: string;
+  try {
+    host = new URL(src).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+  const matches = (domain: string) =>
+    host === domain || host.endsWith(`.${domain}`);
+
+  if (matches("propublica.org")) return "form990";
+  // OMB publishes the Historical Tables on whitehouse.gov; govinfo carries the
+  // same series for prior administrations.
+  if (matches("whitehouse.gov") || matches("govinfo.gov")) return "ombOutlays";
+  return null;
+}
+
+/**
  * Coerce pg's NUMERIC representation (often returned as string to preserve
  * precision) into a JS number. Returns null for invalid inputs rather than
  * NaN — the dossier conditionally skips the budget section on null.
@@ -195,6 +228,7 @@ export function parseDbOrgProfile(
         annualBudgetUsd: cited ? usd : null,
         annualBudgetFy: cited ? fy : null,
         annualBudgetSource: cited ? src : null,
+        annualBudgetKind: cited ? budgetSourceKind(src) : null,
       };
     })(),
     majorFunders: asStringArray(row.major_funders),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -193,6 +193,19 @@ export interface BillExternalLinks {
  * list. The methodology page documents that this is symmetric — every
  * registered org gets the same treatment regardless of which country.
  */
+/**
+ * The kind of record a budget figure came from. Decides what the figure is
+ * *called* on the page, because the two measure different things:
+ *
+ * - `form990`     — total functional expenses, from an IRS Form 990.
+ * - `ombOutlays`  — net outlays, from OMB Historical Tables. Net of offsetting
+ *                   receipts, so it is legitimately negative for an agency
+ *                   with large revolving funds (GSA, FY2025: −$379M).
+ *
+ * `null` means the source is neither, and the UI must not assert which.
+ */
+export type BudgetSourceKind = "form990" | "ombOutlays";
+
 export interface OrgProfile {
   slug: string;
   name: string;
@@ -210,12 +223,24 @@ export interface OrgProfile {
   governanceSource: string | null;
   foundedYear: number | null;
   /**
-   * Total functional expenses from the Form 990 at `annualBudgetSource`.
-   * NOT a general "annual budget" — that was the unsourced fixture value this
-   * replaced (migration 013). Renders only with `annualBudgetFy` + source.
+   * The figure at `annualBudgetSource`. NOT a general "annual budget" — that
+   * was the unsourced fixture value this replaced (migration 013). Renders
+   * only with `annualBudgetFy` + source.
+   *
+   * **It does not mean the same thing for every row**, which is why
+   * `annualBudgetKind` exists: for a nonprofit it is total functional expenses
+   * from a Form 990; for a federal agency it is net outlays from OMB
+   * Historical Tables. Labelling the second as the first is a miscitation, and
+   * it also makes GSA's legitimately negative net outlays read as an error.
    */
   annualBudgetUsd: number | null;
   annualBudgetFy: string | null;
+  /**
+   * Which record `annualBudgetSource` points at, so the UI can name the figure
+   * correctly. Derived from the source itself rather than from `type` — the
+   * label describes the record, not the organization.
+   */
+  annualBudgetKind: BudgetSourceKind | null;
   annualBudgetSource: string | null;
   majorFunders: string[];
   faraRegistered: boolean;


### PR DESCRIPTION
`copy.ts` hardcoded **"Total expenses"** and **"Per the Form 990 on ProPublica Nonprofit Explorer"**, and `OrgDossier.tsx:104` rendered that source label unconditionally beside whatever `annualBudgetSource` pointed at.

Right for a nonprofit. Wrong for the 23 federal agencies, which are cited to OMB Historical Tables — **the EPA has no Form 990**. Those pages attributed an OMB spreadsheet to a filing that does not exist for them:

> Total expenses $37.0B · FY2025
> **Per the Form 990 on ProPublica Nonprofit Explorer** ↗ → `whitehouse.gov/…hist04z1_fy2027.xlsx`

The mislabel also made a correct figure look broken. OMB reports **net outlays**, net of offsetting receipts, so GSA's FY2025 figure is legitimately **−$379M** — nonsense under the word "expenses", ordinary under "net outlays".

## The fix

`lib/org.ts` derives `annualBudgetKind` from the source URL, and `copy.ts` keys both the lede and the source label on it:

| kind | lede | source label |
|---|---|---|
| `form990` | `Total expenses X · FY` | Per the Form 990 on ProPublica Nonprofit Explorer |
| `ombOutlays` | `Net outlays X · FY` | Per OMB Historical Tables, Table 4.1 (outlays by agency) |
| `null` | `X · FY` | Per the cited source |

Keyed on **the source, not `org.type`** — the label describes the record, not the organization. A nonprofit cited to a 990 and an agency cited to OMB are different claims even when both are typed `foundation`. Host-matched rather than substring-matched, so `evil.com/?u=projects.propublica.org` doesn't qualify. An unrecognised host names neither rather than guessing.

## Why now

Only reachable since [sift-api#174](https://github.com/kristenmartino/sift-api/pull/174) promoted those 23 citations into the columns the render gate reads. Before that the agency pages showed no budget line at all, so the wrong label had nothing to attach to — the promotion is what made a nine-week-old mislabel visible.

## Verification

Tests render `OrgDossier` rather than the copy helper, because the defect was in the *wiring* — the label was correct in isolation and attached to the wrong source on the page. New `__tests__/OrgDossier.test.tsx` asserts on the DOM: an agency page contains "Net outlays" and "OMB Historical Tables" and contains **no** "Form 990", "ProPublica" or "Total expenses"; the source link's `href` is the record it names; GSA's negative renders without the word "expense".

476 tests pass, `tsc --noEmit` clean.

**I could not verify this in a browser.** `npm run dev` fails to boot on an unrelated in-flight change to `next.config.js` — `remotePatterns` has 62 entries and Next 16 caps it at 50 (`Array must contain at most 50 element(s)`). That work is untouched here and is not part of this PR; the rendered-DOM tests are the substitute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)