### PR TITLE
Render advocacy-group scorecards with their source and year

### DIFF
--- a/__tests__/PoliticianDossier.test.tsx
+++ b/__tests__/PoliticianDossier.test.tsx
@@ -41,7 +41,7 @@ const austin: PoliticianProfile = {
   chamber: "executive",
   committees: [],
   topIndustriesCurrentCycle: [],
-  interestGroupRatings: {},
+  interestGroupRatings: [],
   externalLinks: { official: "https://www.defense.gov" },
   notes: null,
   role: {

--- a/__tests__/politician.test.ts
+++ b/__tests__/politician.test.ts
@@ -19,7 +19,15 @@ const fullRow: DbPoliticianProfileRow = {
     { industry: "Securities & investment", amount_usd: 1_200_000 },
     { industry: "Real estate", amount_usd: 620_000 },
   ],
-  interest_group_ratings: { LCV: 92, "AFL-CIO": 100, NRA: "F" },
+  interest_group_ratings: [{
+    rater: "LCV",
+    rater_name: "League of Conservation Voters",
+    score: 92,
+    unit: "percent",
+    year: 2025,
+    lifetime_score: 88,
+    source_url: "https://www.lcv.org/moc/chuck-schumer/",
+  }],
   external_links: {
     govtrack: "https://www.govtrack.us/congress/members/charles_schumer/300087",
     opensecrets: "https://www.opensecrets.org/members-of-congress/charles-schumer/summary",
@@ -132,7 +140,15 @@ describe("parseDbPoliticianProfile", () => {
           { industry: "Securities & investment", amount_usd: 1_200_000 },
           { industry: "Real estate", amount_usd: 620_000 },
         ],
-        interestGroupRatings: { LCV: 92, "AFL-CIO": 100, NRA: "F" },
+        interestGroupRatings: [{
+          rater: "LCV",
+          raterName: "League of Conservation Voters",
+          score: 92,
+          unit: "percent",
+          year: 2025,
+          lifetimeScore: 88,
+          sourceUrl: "https://www.lcv.org/moc/chuck-schumer/",
+        }],
         externalLinks: {
           govtrack: "https://www.govtrack.us/congress/members/charles_schumer/300087",
           opensecrets: "https://www.opensecrets.org/members-of-congress/charles-schumer/summary",
@@ -288,47 +304,87 @@ describe("parseDbPoliticianProfile", () => {
     });
   });
 
-  describe("interest_group_ratings JSONB validation", () => {
-    it("accepts numeric scores and string letter-grades side by side", () => {
+  describe("interest_group_ratings provenance (migration 019)", () => {
+    // The column used to hold a bare { LCV: 92 } dict — a claim about a
+    // living person's voting record with no year and no citation. These
+    // cases pin the rule that replaced it: an entry renders only if it
+    // carries score + year + an https source_url.
+    const valid = {
+    rater: "LCV",
+    rater_name: "League of Conservation Voters",
+    score: 20,
+    unit: "percent",
+    year: 2025,
+    lifetime_score: 20,
+    source_url: "https://www.lcv.org/moc/lisa-a-murkowski/",
+  };
+
+    it("parses a fully-formed entry", () => {
       const profile = parseDbPoliticianProfile({
         ...fullRow,
-        interest_group_ratings: { LCV: 92, NRA: "F", ADA: 88 },
+        interest_group_ratings: [valid],
       });
-      expect(profile?.interestGroupRatings).toEqual({ LCV: 92, NRA: "F", ADA: 88 });
+      expect(profile!.interestGroupRatings).toEqual([{
+        rater: "LCV",
+        raterName: "League of Conservation Voters",
+        score: 20,
+        unit: "percent",
+        year: 2025,
+        lifetimeScore: 20,
+        sourceUrl: "https://www.lcv.org/moc/lisa-a-murkowski/",
+      }]);
     });
 
-    it("drops null / boolean / non-finite values", () => {
+    it.each([
+      ["score", { ...valid, score: undefined }],
+      ["year", { ...valid, year: undefined }],
+      ["source_url", { ...valid, source_url: undefined }],
+      ["rater", { ...valid, rater: "  " }],
+      ["a non-numeric score", { ...valid, score: "high" }],
+      ["a non-http source", { ...valid, source_url: "javascript:alert(1)" }],
+    ])("drops an entry missing %s", (_label, entry) => {
       const profile = parseDbPoliticianProfile({
         ...fullRow,
-        interest_group_ratings: {
-          LCV: 92,
-          BAD_BOOL: true,
-          BAD_NULL: null,
-          BAD_NAN: NaN,
-          BAD_INF: Infinity,
-          NRA: "F",
-        },
+        interest_group_ratings: [entry],
       });
-      expect(profile?.interestGroupRatings).toEqual({ LCV: 92, NRA: "F" });
+      expect(profile!.interestGroupRatings).toEqual([]);
     });
 
-    it("drops empty-string values", () => {
+    it("keeps the sound entries and drops the unsound ones together", () => {
       const profile = parseDbPoliticianProfile({
         ...fullRow,
-        interest_group_ratings: { LCV: 92, EMPTY: "  ", NRA: "F" },
+        interest_group_ratings: [valid, { ...valid, rater: "ACU", year: undefined }],
       });
-      expect(profile?.interestGroupRatings).toEqual({ LCV: 92, NRA: "F" });
+      expect(profile!.interestGroupRatings.map((r) => r.rater)).toEqual(["LCV"]);
     });
 
-    it("returns {} for an array passed as ratings", () => {
+    it("treats lifetime_score as optional", () => {
       const profile = parseDbPoliticianProfile({
         ...fullRow,
-        interest_group_ratings: ["LCV", "NRA"],
+        interest_group_ratings: [{ ...valid, lifetime_score: undefined }],
       });
-      expect(profile?.interestGroupRatings).toEqual({});
+      expect(profile!.interestGroupRatings[0].lifetimeScore).toBeNull();
     });
+
+    it("returns [] for the pre-019 dict shape", () => {
+      // An old { LCV: 92 } value carries no year and no source, so there is
+      // nothing in it that may legally be rendered.
+      const profile = parseDbPoliticianProfile({
+        ...fullRow,
+        interest_group_ratings: { LCV: 92, NRA: "F" },
+      });
+      expect(profile!.interestGroupRatings).toEqual([]);
+    });
+
+    it.each([[null], [undefined], ["nope"], [42]])(
+      "returns [] for %p", (v) => {
+        const profile = parseDbPoliticianProfile({
+          ...fullRow, interest_group_ratings: v,
+        });
+        expect(profile!.interestGroupRatings).toEqual([]);
+      },
+    );
   });
-
   describe("external_links JSONB validation", () => {
     it("accepts string URLs and trims whitespace", () => {
       const profile = parseDbPoliticianProfile({

--- a/__tests__/publishFloor.test.ts
+++ b/__tests__/publishFloor.test.ts
@@ -27,7 +27,7 @@ const politician: PoliticianProfile = {
   chamber: "senate",
   committees: ["Appropriations"],
   topIndustriesCurrentCycle: [],
-  interestGroupRatings: {},
+  interestGroupRatings: [],
   externalLinks: {},
   notes: null,
   role: {

--- a/__tests__/structuredData.test.ts
+++ b/__tests__/structuredData.test.ts
@@ -20,7 +20,18 @@ const politician: PoliticianProfile = {
   chamber: "senate",
   committees: ["Appropriations", "Indian Affairs"],
   topIndustriesCurrentCycle: [{ industry: "Oil & Gas", amount_usd: 250_000 }],
-  interestGroupRatings: { LCV: 92 },
+  // A real entry, not []. The assertion below is that JSON-LD never restates
+  // an advocacy group's score as Sift's structured claim; an empty fixture
+  // would make that test pass without proving anything.
+  interestGroupRatings: [{
+    rater: "LCV",
+    raterName: "League of Conservation Voters",
+    score: 92,
+    unit: "percent",
+    year: 2025,
+    lifetimeScore: 88,
+    sourceUrl: "https://www.lcv.org/moc/lisa-a-murkowski/",
+  }],
   externalLinks: {
     govtrack: "https://www.govtrack.us/congress/members/lisa_murkowski/300075",
     wikipedia: "https://en.wikipedia.org/wiki/Lisa_Murkowski",
@@ -119,10 +130,16 @@ describe("politicianJsonLd", () => {
     expect(JSON.stringify(politicianJsonLd(politician))).not.toContain("Uncited prose");
   });
 
-  it("never emits PAC figures or interest-group ratings", () => {
+  it("never emits PAC figures or advocacy-group scores", () => {
+    // These are third-party assessments the page presents verbatim with a
+    // link. Restating one as Sift's own machine-readable claim about a named
+    // living person is the framing D37 rejects.
     const s = JSON.stringify(politicianJsonLd(politician));
     expect(s).not.toContain("250000");
     expect(s).not.toContain("LCV");
+    expect(s).not.toContain("League of Conservation Voters");
+    expect(s).not.toContain("92");
+    expect(s).not.toContain("lcv.org");
   });
 
   it("omits jobTitle for a chamber with no defined role", () => {

--- a/components/politician/PoliticianDossier.tsx
+++ b/components/politician/PoliticianDossier.tsx
@@ -144,7 +144,7 @@ export default function PoliticianDossier({
     }
   }
 
-  const ratingsEntries = Object.entries(politician.interestGroupRatings);
+  const ratingsEntries = politician.interestGroupRatings;
   const industriesEmpty = politician.topIndustriesCurrentCycle.length === 0;
   const ratingsEmpty = ratingsEntries.length === 0;
   // The "not yet enriched" caption is about OpenSecrets/Vote Smart data for
@@ -300,24 +300,46 @@ export default function PoliticianDossier({
           </section>
         )}
 
-        {/* Interest-group ratings */}
+        {/* Advocacy-group scorecards.
+            Each row is one organization's own published score, attributed by
+            name, dated, and linked to their page for this member. Sift does
+            not average them, derive a composite, or characterize what a score
+            means — the same posture D37 requires for AllSides and MBFC on
+            outlet dossiers. `lib/politician.ts` guarantees every entry here
+            carries a year and an https source. */}
         {!ratingsEmpty && (
           <section className="mb-10">
             <p className="font-body text-kicker uppercase text-(--text-tertiary) mb-3">
               {c.sections.interestGroupRatings}
             </p>
-            <ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-1.5">
-              {ratingsEntries.map(([group, rating]) => (
+            <ul className="flex flex-col gap-2">
+              {ratingsEntries.map((r) => (
                 <li
-                  key={group}
-                  className="grid grid-cols-[1fr_auto] gap-x-3 items-baseline border-b border-(--border-subtle) pb-1.5"
+                  key={`${r.rater}-${r.year}`}
+                  className="border-b border-(--border-subtle) pb-2"
                 >
-                  <span className="font-body text-outlet uppercase tracking-wider text-(--text-tertiary)">
-                    {group}
-                  </span>
-                  <span className="font-mono text-[13px] tabular-nums text-(--text-secondary)">
-                    {typeof rating === "number" ? `${rating}%` : rating}
-                  </span>
+                  <div className="grid grid-cols-[1fr_auto] gap-x-3 items-baseline">
+                    <span className="font-body text-[14px] text-(--text-secondary)">
+                      {r.raterName}
+                      <span className="text-(--text-tertiary)"> · {r.year}</span>
+                    </span>
+                    <span className="font-mono text-[13px] tabular-nums text-(--text-primary)">
+                      {r.unit === "percent" ? `${r.score}%` : r.score}
+                    </span>
+                  </div>
+                  <p className="font-body text-meta text-(--text-tertiary) mt-0.5">
+                    {r.lifetimeScore !== null && (
+                      <>{r.lifetimeScore}% lifetime · </>
+                    )}
+                    <a
+                      href={r.sourceUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-(--text-tertiary) no-underline hover:underline hover:text-(--accent)"
+                    >
+                      {r.rater} scorecard <span aria-hidden>↗</span>
+                    </a>
+                  </p>
                 </li>
               ))}
             </ul>

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -260,7 +260,11 @@ export const COPY = {
     sections: {
       committees: "Committee assignments",
       topIndustries: "Top industries by PAC contributions (2022 cycle)",
-      interestGroupRatings: "Interest-group ratings",
+      // Deliberately NOT "Interest-group ratings" (plural, general).
+      // Only one scorecard is obtainable today, so the heading names
+      // what it is: a third party's own record, attributed. Revisit
+      // the wording when a second, differently-aligned rater lands.
+      interestGroupRatings: "Advocacy-group scorecards",
       links: "Where to read more",
       notes: "Notes",
       // Migration 015. Committees / PAC industries / interest-group ratings

--- a/lib/politician.ts
+++ b/lib/politician.ts
@@ -7,6 +7,7 @@
 
 import type {
   IndustryDonation,
+  InterestGroupRating,
   PoliticianChamber,
   PoliticianExternalLinks,
   PoliticianProfile,
@@ -229,17 +230,50 @@ export function asTopIndustries(v: unknown): IndustryDonation[] {
   return out;
 }
 
-function asInterestGroupRatings(v: unknown): Record<string, number | string> {
-  if (!v || typeof v !== "object" || Array.isArray(v)) return {};
-  const out: Record<string, number | string> = {};
-  for (const [key, value] of Object.entries(v as Record<string, unknown>)) {
-    const trimmedKey = key.trim();
-    if (!trimmedKey) continue;
-    if (typeof value === "number" && Number.isFinite(value)) {
-      out[trimmedKey] = value;
-    } else if (typeof value === "string" && value.trim().length > 0) {
-      out[trimmedKey] = value.trim();
-    }
+/**
+ * Parse the interest_group_ratings JSONB array (migration 019).
+ *
+ * Drops any entry missing score, year or source_url. That is the load-bearing
+ * line: the column previously held a bare {rater: score} dict, and putting an
+ * unsourced, undated number about a living person on a page is the defect
+ * migrations 013 and 015 each had to remove. Enforced here rather than in JSX
+ * so every consumer — page, JSON-LD, API — inherits it.
+ *
+ * Tolerates the pre-019 object shape by returning [] for it: an old dict
+ * carries no provenance, so there is nothing in it that may be rendered.
+ */
+function asInterestGroupRatings(v: unknown): InterestGroupRating[] {
+  if (!Array.isArray(v)) return [];
+  const out: InterestGroupRating[] = [];
+  for (const raw of v) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const e = raw as Record<string, unknown>;
+
+    const rater = typeof e.rater === "string" ? e.rater.trim() : "";
+    const score = typeof e.score === "number" && Number.isFinite(e.score)
+      ? e.score
+      : null;
+    const year = typeof e.year === "number" && Number.isFinite(e.year)
+      ? e.year
+      : null;
+    const sourceUrl = typeof e.source_url === "string" ? e.source_url.trim() : "";
+
+    // All four are required. A rating with no citation is not renderable.
+    if (!rater || score === null || year === null) continue;
+    if (!/^https?:\/\//i.test(sourceUrl)) continue;
+
+    const raterName = typeof e.rater_name === "string" && e.rater_name.trim()
+      ? e.rater_name.trim()
+      : rater;
+    const lifetime = typeof e.lifetime_score === "number"
+      && Number.isFinite(e.lifetime_score)
+      ? e.lifetime_score
+      : null;
+    const unit = typeof e.unit === "string" && e.unit.trim()
+      ? e.unit.trim()
+      : "percent";
+
+    out.push({ rater, raterName, score, unit, year, lifetimeScore: lifetime, sourceUrl });
   }
   return out;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -470,6 +470,32 @@ export interface PoliticianExternalLinks {
  * change over time (LCV, NRA, ADA, ACU, NEA, AFL-CIO, etc.). The UI renders
  * them as a key/value list without assuming any particular keys exist.
  */
+/**
+ * One advocacy group's published score for a member of Congress.
+ *
+ * **Not Sift's assessment.** Each entry is a named third party's own number,
+ * shown with the year and a link to their page for that member — the same
+ * treatment `outlet_profiles` gives AllSides and MBFC.
+ *
+ * `score`, `year` and `sourceUrl` are non-nullable by construction:
+ * `lib/politician.ts:asInterestGroupRatings` drops any entry missing one,
+ * the way `lib/org.ts` nulls the budget triple. An uncited rating about a
+ * living person must never reach the page.
+ */
+export interface InterestGroupRating {
+  /** Short form used as the on-page label, e.g. "LCV". */
+  rater: string;
+  /** Full organization name, e.g. "League of Conservation Voters". */
+  raterName: string;
+  score: number;
+  /** Only "percent" today; present so a letter-grade rater can be added. */
+  unit: string;
+  year: number;
+  /** Career-long score where the rater publishes one. */
+  lifetimeScore: number | null;
+  sourceUrl: string;
+}
+
 export interface PoliticianProfile {
   bioguideId: string;
   name: string;
@@ -478,7 +504,7 @@ export interface PoliticianProfile {
   chamber: PoliticianChamber | null;
   committees: string[];
   topIndustriesCurrentCycle: IndustryDonation[];
-  interestGroupRatings: Record<string, number | string>;
+  interestGroupRatings: InterestGroupRating[];
   externalLinks: PoliticianExternalLinks;
   notes: string | null;
   /**


### PR DESCRIPTION
Renders the migration-019 array shape for `interest_group_ratings`, populated for the first time (532 members, LCV 2025) by sift-api#153.

```
League of Conservation Voters · 2025            20%
20% lifetime · LCV scorecard ↗
```

## The parser is the enforcement point

`asInterestGroupRatings` drops any entry missing score, year, or an https `source_url`. The column previously held a bare `{ LCV: 92 }` dict — an unsourced, undated claim about how a named living person voted. Doing the check in the parser rather than in JSX means the page, the JSON-LD builder, and any future API consumer all inherit it. Same pattern as `lib/org.ts` nulling the budget triple.

## Framed as one lens, deliberately

Heading is **"Advocacy-group scorecards"**, not "Interest-group ratings". Only one scorecard is obtainable today (four others are blocked — see the sift-api PR), and a single advocacy group's number must not read as a general rating. Each row names the organization in full, carries the year, and links to their page for that member — the AllSides/MBFC treatment per D37. Sift does not average raters or characterize what a score means.

## JSON-LD omits all of it

A third-party assessment restated as Sift's own machine-readable claim about a named living person is exactly the framing D37 rejects, and structured data strips the attribution that makes it fair.

**The existing exclusion test was passing against an empty fixture** after the type change, so it proved nothing. It now uses a real rating and asserts the rater, the full name, the score and the domain are all absent from the emitted JSON-LD.

## Tests

The old ratings tests asserted the dict shape; replaced with cases pinning the new rule — six ways an entry can lack provenance (all dropped), plus sound and unsound entries mixed with only the sound one kept.

492 pass, tsc clean.

*Unrelated note:* a bare `npx jest` globs into `.claude/worktrees/`, so another session's worktree surfaces as 11 failing suites. Worth a `testPathIgnorePatterns` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)