### PR TITLE
Commit the paste-ready week-one emails, with a generator and a drift guard

### DIFF
--- a/__tests__/weekOneEmails.test.ts
+++ b/__tests__/weekOneEmails.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { extractEmail, render } from "../scripts/build-week-one-emails.mjs";
+
+/**
+ * `docs/week-one-emails.txt` is a generated, paste-ready copy of the two drafts
+ * in `docs/WEEK_ONE_OUTREACH.md`. Two copies of the same email body is a drift
+ * hazard, and this repo has lost that bet more than once — STATUS.md's velocity
+ * line was wrong in the optimistic direction for eight weeks, DECISIONS.md
+ * quoted a "~97% accuracy" figure with no eval behind it, and `political_lean`
+ * survived in prose after migration 012 dropped the column.
+ *
+ * These emails go to ~60 named professionals under a real person's name, so a
+ * stale copy is worse than an inconvenient one. If the wording changes in the
+ * canonical doc and the generated file is not rebuilt, this fails.
+ */
+const ROOT = process.cwd();
+const SRC = readFileSync(join(ROOT, "docs/WEEK_ONE_OUTREACH.md"), "utf8");
+const GENERATED = readFileSync(join(ROOT, "docs/week-one-emails.txt"), "utf8");
+
+describe("docs/week-one-emails.txt is in sync with WEEK_ONE_OUTREACH.md", () => {
+  it("carries both subject lines verbatim", () => {
+    for (const header of ["Librarian version", "Policy-staffer version"]) {
+      const { subject } = extractEmail(SRC, header);
+      expect(GENERATED).toContain(`Subject: ${subject}`);
+    }
+  });
+
+  it("carries both email bodies verbatim", () => {
+    for (const header of ["Librarian version", "Policy-staffer version"]) {
+      const { body } = extractEmail(SRC, header);
+      // Compare line by line so a failure names the line that drifted.
+      for (const line of body.split("\n").filter((l) => l.trim().length > 0)) {
+        expect(GENERATED).toContain(line);
+      }
+    }
+  });
+
+  it("is byte-identical to a fresh render, apart from the generated-on date", () => {
+    const stamp = GENERATED.match(/^Generated (\d{4}-\d{2}-\d{2})\.$/m)?.[1];
+    expect(stamp).toBeTruthy();
+    expect(render(SRC, stamp)).toBe(GENERATED);
+  });
+
+  it("leaves no markdown that would paste into an email client", () => {
+    expect(GENERATED).not.toMatch(/\*\*/);
+    expect(GENERATED).not.toMatch(/^>\s/m);
+  });
+
+  it("still points at the live artifact", () => {
+    expect(GENERATED).toContain("https://siftnews.io/agencies");
+  });
+
+  it("keeps every placeholder the sender has to fill in", () => {
+    for (const p of [
+      "[name]",
+      "[research guide on government information]",
+      "[the specific resource they link]",
+      "[specific bill / issue area / committee]",
+    ]) {
+      expect(GENERATED).toContain(p);
+    }
+  });
+});

--- a/docs/week-one-emails.txt
+++ b/docs/week-one-emails.txt
@@ -1,0 +1,138 @@
+WEEK-ONE OUTREACH — PASTE-READY EMAILS
+======================================
+
+GENERATED FILE — do not edit by hand.
+  source:     docs/WEEK_ONE_OUTREACH.md  (canonical; edit the wording THERE)
+  regenerate: node scripts/build-week-one-emails.mjs
+  guard:      __tests__/weekOneEmails.test.ts fails if the two drift
+
+Generated 2026-08-10.
+
+Artifact:  https://siftnews.io/agencies
+           Verified 2026-08-05: HTTP 200, 25 cited agencies, 96 links to
+           law.cornell.edu, no auth wall, no AI-generated text.
+
+
+BEFORE YOU SEND — fill these in
+-------------------------------
+Librarian email:
+  [name]
+  [research guide on government information]  <- their actual guide
+  [the specific resource they link]           <- something they actually link
+
+Staffer email:
+  [name]
+  [specific bill / issue area / committee]
+
+The doc's rule: if you can't find something specific to reference, SKIP that
+recipient. A generic opener converts a warm contact into a burned one.
+
+
+SEND PLAN
+---------
+  NOW        5 librarians (pilot) — learn the reply shape before spending the list
+  THIS WEEK  the rest of the librarians, once the pilot returns
+  SEP 14+    all 20 staffers
+
+Staffers wait because Congress is in recess through August and October ahead of
+the midterms. WEEK_ONE_OUTREACH.md: "hold. Twenty unpiloted emails into the
+pre-recess crush is the worst available combination, and staffer contacts are
+the harder list to rebuild."
+
+Success is NOT a reply count. It is enough named humans to book five calls.
+~6 replies from 60 is the expected outcome, and is a success if five will talk.
+
+
+================================================================================
+EMAIL 1 — LIBRARIANS  (send 5 now)
+================================================================================
+
+Subject: A cited page on who controls federal agencies — useful for your guide?
+
+Hi [name],
+
+I saw your [research guide on government information], specifically that you link [the specific resource they link].
+
+I've put together a page on who actually controls 25 federal agencies: how many members, who appoints them, term lengths, and whether the authorizing statute caps how many can share a political party. Thirteen of the twenty-five have that cap written into law. The FEC's six commissioners are limited to three per party — which is the structural reason it deadlocks 3–3, rather than a personality problem. The NLRB has no cap at all.
+
+Every line links to the section of the U.S. Code it came from. Nothing on the page is AI-generated.
+
+https://siftnews.io/agencies
+
+Two things, if you have a minute:
+
+1. Is this useful to you or your patrons?
+2. If something like this were worth paying for, could your library actually buy it from one person, invoiced directly — or does that route not really exist?
+
+I'm working through the other 68 agencies. Want me to send you the next batch?
+
+Either answer helps. If it's not useful, that's the most useful thing you can tell me.
+
+Kristen Martino
+
+P.S. Unrelated, if you have a second: when a story develops over several days, is there anything you use — or point patrons to — that shows what changed? Which facts are new, which got corrected, which outlets came late. I can't find one, and I'd like to know whether that's because nobody needs it.
+
+
+================================================================================
+EMAIL 2 — POLICY STAFFERS  (hold until Sep 14)
+================================================================================
+
+Subject: The partisan-balance caps, in one page with the statutes
+
+Hi [name],
+
+I saw your work on [specific bill / issue area / committee].
+
+I put together a page on the governance of 25 federal agencies — members, appointment, terms, and the statutory partisan-balance caps. Thirteen of the twenty-five have one. The FEC is capped at three of six, the NCUA at two of three, and the NLRB has no cap at all, which is the kind of thing that explains a deadlock story without explaining it as personalities.
+
+Every entry cites the section it came from, so it's usable in a memo rather than just orienting.
+
+https://siftnews.io/agencies
+
+Two things, if you have a minute:
+
+1. Is this useful in your work? A "no, we use X" is genuinely useful — I'd rather know.
+2. If it were, could your office actually buy something like this from one person, invoiced directly — or does procurement not have a shape for that?
+
+I'm working through the other 68 agencies. Want the next batch when it's up?
+
+Kristen Martino
+
+
+================================================================================
+CLAIMS, AND WHERE EACH IS VERIFIED   (checked 2026-08-05)
+================================================================================
+Both emails go to people who read statutes for a living. Every claim was
+checked against the cited statute itself, not just against Sift's own page.
+
+  25 federal agencies ............ prod: 25 agencies with cited governance
+  "thirteen of the twenty-five" .. prod: 13 carry a partisan-balance cap
+  FEC three of six ............... 52 U.S.C. 30106 — "...may be affiliated with
+                                   the same political party"; six members,
+                                   single 6-year term
+  NCUA two of three .............. 12 U.S.C. 1752a — "not more than two members
+                                   of the board shall be members of the same
+                                   political party"
+  NLRB no cap at all ............. 29 U.S.C. 153 — zero party-cap mentions
+  "the other 68 agencies" ........ prod: 93 agency rows, 25 cited, 68 left
+
+  If a staffer pushes back on the FEC line: 30106 caps the APPOINTED members at
+  three per party, and the Commission also seats the Secretary of the Senate and
+  the Clerk of the House as NON-VOTING ex officio members. "Three of six" is
+  correct for the voting membership, and the page says "appointed members".
+
+
+================================================================================
+THE P.S. (librarian email only)
+================================================================================
+Cheapest thing to cut. After the 5-send pilot:
+  - all five answered the numbered questions and skipped the P.S. -> DROP it
+  - even one named a tool -> KEEP it, and write the name down verbatim
+
+
+================================================================================
+DECIDE BEFORE A REPLY ARRIVES
+================================================================================
+"What happens if ten librarians say yes?" WEEK_ONE_OUTREACH.md says write the
+answer down now, because the two available answers are different companies.
+Read its closing section before you send, not after.

--- a/scripts/build-week-one-emails.mjs
+++ b/scripts/build-week-one-emails.mjs
@@ -1,0 +1,167 @@
+/**
+ * Generate docs/week-one-emails.txt from docs/WEEK_ONE_OUTREACH.md.
+ *
+ *   node scripts/build-week-one-emails.mjs
+ *
+ * WEEK_ONE_OUTREACH.md is canonical. This produces a paste-ready copy with the
+ * markdown stripped, because the drafts there live inside blockquotes and
+ * analysis you do not want to paste into an email client.
+ *
+ * The reason this is generated rather than hand-maintained: a second copy of
+ * the email text is a drift hazard, and this repo has been bitten by that
+ * repeatedly — the velocity line in STATUS.md was wrong for eight weeks, the
+ * D26/D27 accuracy figures were quoted with no eval behind them, and
+ * `political_lean` survived in prose after the column was dropped.
+ * `__tests__/weekOneEmails.test.ts` fails if the two ever diverge.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = process.cwd();
+const SRC = join(ROOT, "docs/WEEK_ONE_OUTREACH.md");
+const OUT = join(ROOT, "docs/week-one-emails.txt");
+
+/** Subject line + blockquoted body of one `## <header>` section, markdown stripped. */
+export function extractEmail(src, header) {
+  const start = src.indexOf(`## ${header}`);
+  if (start === -1) throw new Error(`section not found: ${header}`);
+  const rest = src.slice(start + 3);
+  const nextIdx = rest.indexOf("\n## ");
+  const block = nextIdx === -1 ? rest : rest.slice(0, nextIdx);
+
+  const subject = block.match(/\*\*Subject:\*\*\s*(.+)/)?.[1]?.trim();
+  if (!subject) throw new Error(`no subject in: ${header}`);
+
+  const body = [];
+  let started = false;
+  for (const line of block.split("\n")) {
+    if (line.startsWith(">")) {
+      started = true;
+      body.push(line.replace(/^>\s?/, ""));
+    } else if (started) {
+      if (line.trim() === "") { body.push(""); continue; }
+      break;
+    }
+  }
+  while (body.length && body.at(-1).trim() === "") body.pop();
+
+  // Bold/italic markers would paste into the email client as literal asterisks.
+  const text = body
+    .join("\n")
+    .replace(/\*\*(.+?)\*\*/g, "$1")
+    .replace(/\*(.+?)\*/g, "$1");
+  return { subject, body: text };
+}
+
+export function render(src, generatedOn) {
+  const lib = extractEmail(src, "Librarian version");
+  const staff = extractEmail(src, "Policy-staffer version");
+  return `WEEK-ONE OUTREACH — PASTE-READY EMAILS
+======================================
+
+GENERATED FILE — do not edit by hand.
+  source:     docs/WEEK_ONE_OUTREACH.md  (canonical; edit the wording THERE)
+  regenerate: node scripts/build-week-one-emails.mjs
+  guard:      __tests__/weekOneEmails.test.ts fails if the two drift
+
+Generated ${generatedOn}.
+
+Artifact:  https://siftnews.io/agencies
+           Verified 2026-08-05: HTTP 200, 25 cited agencies, 96 links to
+           law.cornell.edu, no auth wall, no AI-generated text.
+
+
+BEFORE YOU SEND — fill these in
+-------------------------------
+Librarian email:
+  [name]
+  [research guide on government information]  <- their actual guide
+  [the specific resource they link]           <- something they actually link
+
+Staffer email:
+  [name]
+  [specific bill / issue area / committee]
+
+The doc's rule: if you can't find something specific to reference, SKIP that
+recipient. A generic opener converts a warm contact into a burned one.
+
+
+SEND PLAN
+---------
+  NOW        5 librarians (pilot) — learn the reply shape before spending the list
+  THIS WEEK  the rest of the librarians, once the pilot returns
+  SEP 14+    all 20 staffers
+
+Staffers wait because Congress is in recess through August and October ahead of
+the midterms. WEEK_ONE_OUTREACH.md: "hold. Twenty unpiloted emails into the
+pre-recess crush is the worst available combination, and staffer contacts are
+the harder list to rebuild."
+
+Success is NOT a reply count. It is enough named humans to book five calls.
+~6 replies from 60 is the expected outcome, and is a success if five will talk.
+
+
+================================================================================
+EMAIL 1 — LIBRARIANS  (send 5 now)
+================================================================================
+
+Subject: ${lib.subject}
+
+${lib.body}
+
+
+================================================================================
+EMAIL 2 — POLICY STAFFERS  (hold until Sep 14)
+================================================================================
+
+Subject: ${staff.subject}
+
+${staff.body}
+
+
+================================================================================
+CLAIMS, AND WHERE EACH IS VERIFIED   (checked 2026-08-05)
+================================================================================
+Both emails go to people who read statutes for a living. Every claim was
+checked against the cited statute itself, not just against Sift's own page.
+
+  25 federal agencies ............ prod: 25 agencies with cited governance
+  "thirteen of the twenty-five" .. prod: 13 carry a partisan-balance cap
+  FEC three of six ............... 52 U.S.C. 30106 — "...may be affiliated with
+                                   the same political party"; six members,
+                                   single 6-year term
+  NCUA two of three .............. 12 U.S.C. 1752a — "not more than two members
+                                   of the board shall be members of the same
+                                   political party"
+  NLRB no cap at all ............. 29 U.S.C. 153 — zero party-cap mentions
+  "the other 68 agencies" ........ prod: 93 agency rows, 25 cited, 68 left
+
+  If a staffer pushes back on the FEC line: 30106 caps the APPOINTED members at
+  three per party, and the Commission also seats the Secretary of the Senate and
+  the Clerk of the House as NON-VOTING ex officio members. "Three of six" is
+  correct for the voting membership, and the page says "appointed members".
+
+
+================================================================================
+THE P.S. (librarian email only)
+================================================================================
+Cheapest thing to cut. After the 5-send pilot:
+  - all five answered the numbered questions and skipped the P.S. -> DROP it
+  - even one named a tool -> KEEP it, and write the name down verbatim
+
+
+================================================================================
+DECIDE BEFORE A REPLY ARRIVES
+================================================================================
+"What happens if ten librarians say yes?" WEEK_ONE_OUTREACH.md says write the
+answer down now, because the two available answers are different companies.
+Read its closing section before you send, not after.
+`;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const src = readFileSync(SRC, "utf8");
+  const out = render(src, new Date().toISOString().slice(0, 10));
+  writeFileSync(OUT, out, "utf8");
+  console.log(`wrote ${OUT} (${out.split("\n").length} lines)`);
+}


### PR DESCRIPTION
Requested. The objection to a second copy of the email text was **drift**, so this ships it as a *derived* artifact rather than a hand-maintained one.

| File | |
|---|---|
| `scripts/build-week-one-emails.mjs` | strips blockquote markers and the bold that would otherwise paste into an email client as literal asterisks |
| `docs/week-one-emails.txt` | the generated, paste-ready file |
| `__tests__/weekOneEmails.test.ts` | 6 assertions, including a **byte-exact re-render comparison** |

`WEEK_ONE_OUTREACH.md` stays canonical. Edit the wording there and run `node scripts/build-week-one-emails.mjs`; if you edit one and not the other, CI fails.

## Why a guard rather than trust

This repo has lost the two-copies bet more than once:

- `STATUS.md`'s velocity line read *"High (10+ PRs / week)"* through eight weeks of near-zero
- `DECISIONS.md` quoted *"~97% accuracy"* with no eval set behind it
- `political_lean` survived in prose after migration 012 dropped the column

These emails go to **~60 named professionals under a real person's name**. A stale copy is worse than an inconvenient one.

## What the file carries besides the two drafts

- **The four placeholders**, with the doc's rule that if you can't find something specific to reference, skip that recipient rather than send a generic opener.
- **The send plan** — 5 librarians now, staffers Sep 14, because Congress is in recess through August and October ahead of the midterms.
- **A claims table** pairing every factual assertion with the statute it was checked against — 52 U.S.C. §30106, 12 U.S.C. §1752a, 29 U.S.C. §153 — plus the FEC ex-officio nuance in case a staffer counts eight bodies at the table.
- **The P.S. keep/drop rule** after the pilot.

Docs + tooling only, no product code. 498 tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)