### PR TITLE
Wire the grim dampener into ranking; prefer a non-grim landing hero

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -47,6 +47,7 @@ const MOCK_DB_ROWS: DbArticle[] = [
     read_time: 2,
     why_it_matters: null,
     importance_score: null,
+    tone: null,
     context_primer: null,
     reading_levels: null,
     created_at: new Date("2026-03-28T10:00:00Z"),
@@ -63,6 +64,7 @@ const MOCK_DB_ROWS: DbArticle[] = [
     read_time: 3,
     why_it_matters: null,
     importance_score: null,
+    tone: null,
     context_primer: null,
     reading_levels: null,
     created_at: new Date("2026-03-28T08:00:00Z"),
@@ -245,6 +247,7 @@ describe("GET /api/news", () => {
           framings: [{ source_name: "Reuters", framing: "Focuses on timeline", tone: "neutral" }],
           entities: [{ people: ["Alice"], organizations: ["Acme"], locations: ["NYC"], event_description: "test event" }],
           article_count: 2,
+          grim_share: null,
           representative_image_url: null,
           published_date: new Date("2026-03-28T10:00:00Z"),
           synthesis_status: "complete",
@@ -266,6 +269,41 @@ describe("GET /api/news", () => {
       expect(body.stories[0].framings[0].sourceName).toBe("Reuters");
       expect(body.stories[0].entities[0].people).toEqual(["Alice"]);
       expect(body.stories[0].articles).toHaveLength(2);
+      // grim_share null → no story tone (D48: absent = neutral, no penalty).
+      expect(body.stories[0].tone).toBeUndefined();
+    });
+
+    it("passes article tone through and derives story tone from grim_share", async () => {
+      mockGetStoriesWithArticles.mockResolvedValue({
+        stories: [{
+          id: "story1",
+          headline: "Grim Story",
+          summary: "A synthesized summary.",
+          category: "technology",
+          framings: [],
+          entities: [],
+          article_count: 2,
+          // pg returns AVG() as a numeric string.
+          grim_share: "0.5",
+          representative_image_url: null,
+          published_date: new Date("2026-03-28T10:00:00Z"),
+          synthesis_status: "complete",
+        }],
+        storyArticles: {},
+        standaloneArticles: [
+          { ...MOCK_DB_ROWS[0], tone: "grim" },
+          { ...MOCK_DB_ROWS[1], tone: "invalid-value" },
+        ],
+      });
+
+      const res = await GET(makeRequest("technology"));
+      const body = await res.json();
+
+      expect(body.articles[0].tone).toBe("grim");
+      // Unknown DB values never reach the API contract.
+      expect(body.articles[1].tone).toBeUndefined();
+      // grim_share >= 0.5 → the story itself is grim.
+      expect(body.stories[0].tone).toBe("grim");
     });
   });
 

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -10,7 +10,11 @@ import { parseContextPrimer, attachPrimerTermLinks } from "@/lib/primer";
 import { parseEntityLinks } from "@/lib/entityLinks";
 import { enrichLinksWithContext } from "@/lib/civicContext";
 import { stripHtml, sanitizeUrl } from "@/lib/sanitize";
-import type { CategoryId, Article, Story, StoryFraming, EntitySet, NewsApiResponse, NewsApiError } from "@/lib/types";
+import type { CategoryId, Article, ArticleTone, Story, StoryFraming, EntitySet, NewsApiResponse, NewsApiError } from "@/lib/types";
+
+function isArticleTone(v: unknown): v is ArticleTone {
+  return v === "grim" || v === "neutral" || v === "light";
+}
 
 const BAD_SUMMARIES = ["unable to provide summary"];
 
@@ -96,6 +100,7 @@ export async function GET(request: NextRequest) {
         readTime: row.read_time || 1,
         ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
         ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
+        ...(isArticleTone(row.tone) ? { tone: row.tone } : {}),
         ...(primer ? { contextPrimer: primer } : {}),
         ...(outlet ? { outlet } : {}),
         ...(entityLinks.length > 0 ? { entityLinks } : {}),
@@ -170,6 +175,8 @@ export async function GET(request: NextRequest) {
         imageUrl: cleanImageUrl(s.representative_image_url),
         publishedDate: s.published_date ? s.published_date.toISOString() : null,
         articles: childArticles,
+        // A story is grim when at least half its live members are (D48).
+        ...(Number(s.grim_share ?? 0) >= 0.5 ? { tone: "grim" as const } : {}),
       };
     });
 

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -277,6 +277,11 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     ];
 
     // Rank by composite score: (importance + source_boost) * recency_decay
+    // D48 grim dampener (mirrors GRIM_DAMPENER in lib/db.ts): low-importance
+    // grim items rank as if ~12h older; importance 4-5 somber news and
+    // untagged items are untouched — de-stack tabloid crime, never hide
+    // major news.
+    const GRIM_DAMPENER = 0.6;
     const now = Date.now();
     function rankScore(item: FeedItem): number {
       const pubDate = item.data.publishedDate;
@@ -288,10 +293,14 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
 
       if (item.type === "story") {
         const sourceBoost = Math.min((item.data.articleCount - 1), 4) * 0.5;
-        return (3 + sourceBoost) * decay;
+        // Corroboration is the story-level analog of importance: a
+        // two-outlet grim story dampens, a five-outlet disaster does not.
+        const damp = item.data.tone === "grim" && item.data.articleCount <= 2 ? GRIM_DAMPENER : 1;
+        return (3 + sourceBoost) * decay * damp;
       }
       const importance = item.data.importanceScore ?? 3;
-      return importance * decay;
+      const damp = item.data.tone === "grim" && importance <= 3 ? GRIM_DAMPENER : 1;
+      return importance * decay * damp;
     }
 
     items.sort((a, b) => rankScore(b) - rankScore(a));

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -45,6 +45,16 @@ const pool = new Pool({
 // NY Post held 23/50 of 'top' when this was added (2026-08-10).
 const MAX_ARTICLES_PER_SOURCE = 6;
 
+// D48 grim dampener: articles tagged tone='grim' with importance <= 3 rank
+// as if ~12 hours older (e^-0.51 ≈ 0.6). Importance 4-5 somber news and
+// NULL-tone (unclassified) rows are untouched — the rule de-stacks
+// low-importance tabloid crime, it never hides major news. Set to 1.0 to
+// fully revert. Mirrored client-side in NewsAggregator.tsx rankScore().
+const GRIM_DAMPENER = 0.6;
+
+// SQL fragment appended to the importance × recency rank product.
+const GRIM_DAMPENER_SQL = `CASE WHEN tone = 'grim' AND COALESCE(importance_score, 3) <= 3 THEN ${GRIM_DAMPENER} ELSE 1.0 END`;
+
 export interface DbArticle {
   id: string;
   title: string;
@@ -57,6 +67,7 @@ export interface DbArticle {
   read_time: number;
   why_it_matters: string | null;
   importance_score: number | null;
+  tone: string | null; // grim | neutral | light | NULL (migrations/020); NULL = neutral
   created_at: Date;
   // Civic-literacy MVP additions. Both columns added in
   // sift-api/migrations/005_context_primer_and_reading_levels.sql.
@@ -82,7 +93,7 @@ export async function getArticlesByCategory(
 ): Promise<DbArticle[]> {
   const result = await pool.query<DbArticle>(
     `SELECT id, title, summary, source_url, source_name, image_url,
-            category, published_date, read_time, why_it_matters, importance_score, context_primer, reading_levels, created_at
+            category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at
      FROM articles
      WHERE category = $1 AND from_search = false
        AND summary IS NOT NULL AND summary != ''
@@ -91,7 +102,8 @@ export async function getArticlesByCategory(
             OR (published_date IS NULL AND created_at > NOW() - INTERVAL '30 days'))
      ORDER BY
        COALESCE(importance_score, 3)::float *
-       EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700))
+       EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700)) *
+       ${GRIM_DAMPENER_SQL}
      DESC NULLS LAST
      LIMIT $2`,
     [category, limit]
@@ -112,6 +124,9 @@ export interface DbStory {
   representative_image_url: string | null;
   published_date: Date | null;
   synthesis_status: string;
+  // Fraction of live member articles tagged tone='grim' (0..1); the API
+  // boundary derives Story.tone = 'grim' when >= 0.5. NULL tones count as 0.
+  grim_share: string | number | null;
 }
 
 export interface DbStoryArticle extends DbArticle {
@@ -134,6 +149,7 @@ export async function getStoriesWithArticles(
     const storiesResult = await pool.query<DbStory>(
       `SELECT s.id, s.headline, s.summary, s.category, s.framings, s.entities,
               COUNT(a.id)::int AS article_count,
+              AVG(CASE WHEN a.tone = 'grim' THEN 1.0 ELSE 0 END) AS grim_share,
               s.representative_image_url, s.published_date, s.synthesis_status
        FROM stories s
        LEFT JOIN articles a
@@ -169,7 +185,7 @@ export async function getStoriesWithArticles(
     try {
       const storyArticlesResult = await pool.query<DbStoryArticle>(
         `SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, context_primer, reading_levels, created_at, story_id
+                category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at, story_id
          FROM articles
          WHERE story_id = ANY($1::text[])
            AND from_search = false
@@ -204,9 +220,10 @@ export async function getStoriesWithArticles(
     const standaloneResult = await pool.query<DbArticle>(
       `WITH scored AS (
          SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, context_primer, reading_levels, created_at,
+                category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at,
                 COALESCE(importance_score, 3)::float *
-                EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700))
+                EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700)) *
+                ${GRIM_DAMPENER_SQL}
                 AS rank_score
          FROM articles
          WHERE category = $1 AND from_search = false
@@ -224,7 +241,7 @@ export async function getStoriesWithArticles(
          FROM scored
        )
        SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, context_primer, reading_levels, created_at
+              category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at
        FROM capped
        WHERE source_rank <= ${MAX_ARTICLES_PER_SOURCE}
        ORDER BY rank_score DESC
@@ -238,9 +255,10 @@ export async function getStoriesWithArticles(
     const fallback = await pool.query<DbArticle>(
       `WITH scored AS (
          SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, context_primer, reading_levels, created_at,
+                category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at,
                 COALESCE(importance_score, 3)::float *
-                EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700))
+                EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700)) *
+                ${GRIM_DAMPENER_SQL}
                 AS rank_score
          FROM articles
          WHERE category = $1 AND from_search = false
@@ -257,7 +275,7 @@ export async function getStoriesWithArticles(
          FROM scored
        )
        SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, context_primer, reading_levels, created_at
+              category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at
        FROM capped
        WHERE source_rank <= ${MAX_ARTICLES_PER_SOURCE}
        ORDER BY rank_score DESC
@@ -277,22 +295,41 @@ export async function getStoriesWithArticles(
  * Prefers articles that (a) have an image, (b) sit in the "top" category,
  * and (c) rank high on importance × recency. Returns null if the DB has
  * nothing usable — caller renders a fallback layout.
+ *
+ * D48 tone preference: among the top 12 by rank, the best non-grim article
+ * wins if it scores at least half the overall best (≈ within one importance
+ * point or ~17 hours) — so the landing page doesn't lead with a death story
+ * every day, but a dominant story (a fresh importance-5 disaster) still
+ * takes the hero. NULL tone counts as non-grim.
  */
 export async function getTopStoryForLanding(): Promise<DbArticle | null> {
   try {
     const result = await pool.query<DbArticle>(
-      `SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, context_primer, reading_levels, created_at
-       FROM articles
-       WHERE category = 'top'
-         AND from_search = false
-         AND image_url IS NOT NULL
-         AND summary IS NOT NULL AND summary != ''
-         AND LOWER(summary) NOT LIKE 'unable to provide%'
+      `WITH ranked AS (
+         SELECT id, title, summary, source_url, source_name, image_url,
+                category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at,
+                COALESCE(importance_score, 3)::float *
+                EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700))
+                AS rank_score
+         FROM articles
+         WHERE category = 'top'
+           AND from_search = false
+           AND image_url IS NOT NULL
+           AND summary IS NOT NULL AND summary != ''
+           AND LOWER(summary) NOT LIKE 'unable to provide%'
+           AND (published_date > NOW() - INTERVAL '30 days'
+                OR (published_date IS NULL AND created_at > NOW() - INTERVAL '30 days'))
+         ORDER BY rank_score DESC
+         LIMIT 12
+       )
+       SELECT id, title, summary, source_url, source_name, image_url,
+              category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at
+       FROM ranked
        ORDER BY
-         COALESCE(importance_score, 3)::float *
-         EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700))
-       DESC NULLS LAST
+         CASE WHEN tone IS DISTINCT FROM 'grim'
+               AND rank_score >= 0.5 * (SELECT MAX(rank_score) FROM ranked)
+              THEN 0 ELSE 1 END,
+         rank_score DESC
        LIMIT 1`
     );
     return result.rows[0] ?? null;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,6 +18,16 @@ export interface Category {
   icon: string;
 }
 
+/**
+ * Article-level tone (migrations/020) — NOT the same concept as
+ * StoryFraming["tone"], which describes an outlet's coverage style. This
+ * describes the underlying event: "grim" = death/violent crime/fatal
+ * disaster; "light" = feel-good/culture/achievement; "neutral" = everything
+ * else including serious-but-not-deadly news. Absent = unclassified,
+ * treated as neutral by every ranking site (D48).
+ */
+export type ArticleTone = "grim" | "neutral" | "light";
+
 export interface Article {
   id: string;
   title: string;
@@ -30,6 +40,7 @@ export interface Article {
   readTime: number;
   whyItMatters?: string;
   importanceScore?: number;
+  tone?: ArticleTone;
   /**
    * AI-generated "What you should know first" panel — civic-literacy MVP.
    * Populated by sift-api's primer_generator. Null/undefined when the article
@@ -644,6 +655,12 @@ export interface Story {
   imageUrl: string | null;
   publishedDate: string | null;
   articles: Article[];
+  /**
+   * Derived at the API boundary: "grim" when ≥ half the member articles are
+   * tagged grim (see ArticleTone — distinct from StoryFraming["tone"]).
+   * Feeds the D48 dampener for thinly-corroborated grim stories.
+   */
+  tone?: ArticleTone;
 }
 
 export type FeedItem =


### PR DESCRIPTION
Consume-side half of the D48 tone signal. **Stacked on #211** (retargets to main when it merges). **Deploy order matters**: [sift-api#187](https://github.com/kristenmartino/sift-api/pull/187) must merge and deploy first so `articles.tone` exists in prod; this PR's queries reference the column unguarded.

The rule, in one sentence: low-importance grim items rank as if 12 hours older; major somber news is exempt; nothing is hidden, only de-stacked.

- **Dampener** in both the SQL pool queries and the client `rankScore()`: `tone='grim' AND importance ≤ 3` → × `GRIM_DAMPENER` (0.6). Importance 4–5 grim (the Colombia earthquake) keeps its exact rank; NULL tone = neutral = untouched. Stories dampen only when grim AND `articleCount ≤ 2` — corroboration is the story-level analog of importance. Constant → 1.0 fully reverts.
- **Story tone** derived at the API boundary from a new `grim_share` aggregate (≥ 0.5 of live members grim → story is grim).
- **Landing hero**: among the top 12 by rank, the best non-grim wins if it scores ≥ 50% of the max (≈ within one importance point or ~17h); otherwise the dominant story takes it regardless of tone. NULL tone counts as non-grim. The query also gains the 30-day floor every other feed query already had.
- `Article.tone`/`Story.tone` typed as `ArticleTone`, documented as distinct from `StoryFraming.tone` (outlet coverage style). Unknown DB values are dropped at the API boundary.

tsc clean; repo jest suites pass with two new tone tests (passthrough + grim_share threshold + unknown-value rejection). Post-merge: run `backfill_tone.py`, then replay old-vs-new ranking against prod (the pre-merge check promised in the plan) and update the sift-api explain mirrors with the dampener CASE once the column is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)