### PR TITLE
fix(lint): clear the 21 problems surfaced by the ESLint CLI migration

### DIFF
--- a/app/methodology/page.tsx
+++ b/app/methodology/page.tsx
@@ -121,7 +121,7 @@ export default async function MethodologyPage() {
             // The page still reads as a methodology doc; the missing list is
             // an acceptable empty state rather than a broken section.
             <p className="font-body text-[14px] text-(--text-tertiary) italic max-w-[60ch] leading-relaxed">
-              The curated outlet list will appear here once it's seeded.
+              The curated outlet list will appear here once it&apos;s seeded.
             </p>
           )}
         </section>

--- a/components/CardImage.tsx
+++ b/components/CardImage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Image from "next/image";
 import { CATEGORY_COLORS } from "@/lib/constants";
 import type { CardImageProps } from "@/lib/types";
@@ -11,9 +11,13 @@ export default function CardImage({ src, alt, featured, category }: CardImagePro
     src ? "loading" : "error"
   );
 
-  useEffect(() => {
+  // Reset when the source changes — guarded render-time adjust, the React-docs
+  // pattern for state that depends on a prop.
+  const [prevSrc, setPrevSrc] = useState(src);
+  if (prevSrc !== src) {
+    setPrevSrc(src);
     setStatus(src ? "loading" : "error");
-  }, [src]);
+  }
 
   // No image — render nothing (parent handles text-first layout)
   if (!src || status === "error") return null;

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -51,7 +51,9 @@ export default function LandingPage({ leadStory, outlets }: LandingPageProps) {
       return;
     }
 
-    setAnimate(true);
+    // One frame later than mount — effects must not set state synchronously,
+    // and the reveal gating only needs to be in place before the IO fires.
+    const raf = requestAnimationFrame(() => setAnimate(true));
     const io = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
@@ -64,7 +66,10 @@ export default function LandingPage({ leadStory, outlets }: LandingPageProps) {
       { threshold: 0.15 },
     );
     reveals.forEach((el) => io.observe(el));
-    return () => io.disconnect();
+    return () => {
+      cancelAnimationFrame(raf);
+      io.disconnect();
+    };
   }, []);
 
   return (

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -22,6 +22,10 @@ const TopicSearch = dynamic(() => import("./TopicSearch"), { ssr: false });
 const TopicModal = dynamic(() => import("./TopicModal"), { ssr: false });
 const CompareView = dynamic(() => import("./CompareView"), { ssr: false });
 
+// Stable empty list — keeps the derived bookmarked-articles value referentially
+// equal across renders while the bookmarks view is closed.
+const NO_ARTICLES: Article[] = [];
+
 // ─── Component ──────────────────────────────────────────
 
 // Read URL params once on mount (avoids re-reading on every render)
@@ -60,8 +64,6 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
   const [refreshed, setRefreshed] = useState(false);
   const pillContainerRef = useRef<HTMLDivElement>(null);
   const [indicatorStyle, setIndicatorStyle] = useState<{ left: number; width: number } | null>(null);
-  const [bookmarkedArticles, setBookmarkedArticles] = useState<Article[]>([]);
-  const [loadingBookmarks, setLoadingBookmarks] = useState(false);
   const [pendingRemoval, setPendingRemoval] = useState<{ topic: CustomTopic; timer: ReturnType<typeof setTimeout> } | null>(null);
 
   const { articles, stories, loading, error, slow, lastUpdated, loadCategory } = useNewsLoader();
@@ -152,6 +154,12 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     updateIndicator();
   }, [activeCategory, activeCustomTopic, showBookmarks, searchMode, compareMode, updateIndicator]);
 
+  const exitCompareMode = () => {
+    setCompareMode(false);
+    setCompareInputValue("");
+    clearCompare();
+  };
+
   // Cmd+K / Ctrl+K keyboard shortcut for search
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -169,23 +177,32 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     return () => window.removeEventListener("keydown", handler);
   }, [clearTopicSearch]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Fetch full bookmarked articles from DB when viewing bookmarks (signed in)
+  // Fetch full bookmarked articles from DB when viewing bookmarks (signed in).
+  // The key derives from view + user + bookmark set, so closing the view or
+  // toggling a bookmark invalidates the last fetch; the list and the loading
+  // flag then derive from whether the stored result matches the current key.
+  const bookmarksKey = useMemo(
+    () => (showBookmarks && userId ? Array.from(bookmarks).sort().join("\n") : null),
+    [showBookmarks, userId, bookmarks]
+  );
+  const [bookmarkFetch, setBookmarkFetch] = useState<{ key: string; articles: Article[] } | null>(null);
   useEffect(() => {
-    if (!showBookmarks || !userId) {
-      setBookmarkedArticles([]);
-      return;
-    }
+    if (bookmarksKey === null) return;
     let cancelled = false;
-    setLoadingBookmarks(true);
     fetch("/api/bookmarks?full=1")
       .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
       .then((data: { articles: Article[] }) => {
-        if (!cancelled) setBookmarkedArticles(data.articles);
+        if (!cancelled) setBookmarkFetch({ key: bookmarksKey, articles: data.articles });
       })
-      .catch((err) => console.error("Failed to fetch bookmarked articles:", err))
-      .finally(() => { if (!cancelled) setLoadingBookmarks(false); });
+      .catch((err) => {
+        console.error("Failed to fetch bookmarked articles:", err);
+        if (!cancelled) setBookmarkFetch({ key: bookmarksKey, articles: [] });
+      });
     return () => { cancelled = true; };
-  }, [showBookmarks, userId, bookmarks]);
+  }, [bookmarksKey]);
+  const bookmarkedArticles =
+    bookmarkFetch !== null && bookmarkFetch.key === bookmarksKey ? bookmarkFetch.articles : NO_ARTICLES;
+  const loadingBookmarks = bookmarksKey !== null && bookmarkFetch?.key !== bookmarksKey;
 
   const handleRefresh = async () => {
     if (activeCustomTopic) {
@@ -242,12 +259,6 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     startCompare(topic, sources);
   };
 
-  const exitCompareMode = () => {
-    setCompareMode(false);
-    setCompareInputValue("");
-    clearCompare();
-  };
-
   const customTopicMode = !!activeCustomTopic;
 
   const currentArticles = useMemo((): Article[] => {
@@ -282,7 +293,9 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     // untagged items are untouched — de-stack tabloid crime, never hide
     // major news.
     const GRIM_DAMPENER = 0.6;
-    const now = Date.now();
+    // Age against the fetch timestamp, not wall clock — ranking must be a pure
+    // function of the data snapshot, and the snapshot carries its own "now".
+    const now = lastUpdated ? lastUpdated.getTime() : 0;
     function rankScore(item: FeedItem): number {
       const pubDate = item.data.publishedDate;
       // Clamp at 0: a future-dated article must not get decay > 1 and pin
@@ -306,7 +319,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     items.sort((a, b) => rankScore(b) - rankScore(a));
 
     return items;
-  }, [currentArticles, stories, activeCategory, searchMode, showBookmarks, customTopicMode]);
+  }, [currentArticles, stories, activeCategory, searchMode, showBookmarks, customTopicMode, lastUpdated]);
 
   const hasData = feedItems.length > 0;
   const activeCatLabel = CATEGORIES.find((c) => c.id === activeCategory)?.label;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,11 @@ const eslintConfig = defineConfig([
     // Git worktrees checked out under .claude/ are separate repo copies.
     ".claude/**",
   ]),
+  {
+    // CommonJS by design — Next.js loads this file directly in Node.
+    files: ["next.config.js"],
+    rules: { "@typescript-eslint/no-require-imports": "off" },
+  },
 ]);
 
 export default eslintConfig;

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -1,37 +1,74 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo, useSyncExternalStore } from "react";
 import { STORAGE_KEYS, SLOW_THRESHOLD_MS, API_TIMEOUT_MS, MAX_CUSTOM_TOPICS } from "./constants";
-import type { Article, Story, ArticleCache, StoryCache, CategoryId, CustomTopic, NewsApiResponse, CompareResponse, CompareClaim, SSEResultsEvent, SSEDoneEvent, SSEErrorEvent } from "./types";
+import type { Article, ArticleCache, StoryCache, CategoryId, CustomTopic, NewsApiResponse, CompareResponse, CompareClaim, SSEResultsEvent, SSEDoneEvent, SSEErrorEvent } from "./types";
 import { readSSE } from "./sse";
 
 // ─── useLocalStorage ────────────────────────────────────
 
-function useLocalStorage<T>(key: string, initialValue: T): [T, (val: T | ((prev: T) => T)) => void] {
-  // Always initialize with default to avoid SSR/client hydration mismatch.
-  // localStorage is read in useEffect after hydration.
-  const [stored, setStored] = useState<T>(initialValue);
+// localStorage is an external store, so the hook is built on
+// useSyncExternalStore: the server snapshot is the caller's default (matching
+// the SSR markup), and the first client snapshot after hydration reads the
+// real value. The cache keyed on the raw string keeps snapshots referentially
+// stable, which useSyncExternalStore's tear check requires.
+const lsListeners = new Set<() => void>();
+const lsCache = new Map<string, { raw: string | null; value: unknown }>();
 
-  // Sync from localStorage after hydration (client-only)
-  useEffect(() => {
+function subscribeLocalStorage(cb: () => void) {
+  lsListeners.add(cb);
+  return () => {
+    lsListeners.delete(cb);
+  };
+}
+
+function readLocalStorage<T>(key: string, initialValue: T): T {
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(key);
+  } catch {}
+  const cached = lsCache.get(key);
+  if (cached && cached.raw === raw) return cached.value as T;
+  let value: T = initialValue;
+  if (raw !== null) {
     try {
-      const item = localStorage.getItem(key);
-      if (item !== null) setStored(JSON.parse(item));
+      value = JSON.parse(raw);
     } catch {}
-  }, [key]);
+  }
+  lsCache.set(key, { raw, value });
+  return value;
+}
+
+// Stable defaults for the call sites below — getServerSnapshot must return
+// one identity, not a fresh literal per render.
+const EMPTY_IDS: string[] = [];
+const EMPTY_TOPICS: CustomTopic[] = [];
+
+function useLocalStorage<T>(key: string, initialValue: T): [T, (val: T | ((prev: T) => T)) => void] {
+  const stored = useSyncExternalStore(
+    subscribeLocalStorage,
+    () => readLocalStorage(key, initialValue),
+    () => initialValue
+  );
 
   // Custom setter that also persists to localStorage
   const setValue = useCallback(
     (val: T | ((prev: T) => T)) => {
-      setStored((prev) => {
-        const next = val instanceof Function ? val(prev) : val;
-        try {
-          localStorage.setItem(key, JSON.stringify(next));
-        } catch {}
-        return next;
-      });
+      const prev = readLocalStorage(key, initialValue);
+      const next = val instanceof Function ? val(prev) : val;
+      try {
+        localStorage.setItem(key, JSON.stringify(next));
+      } catch {}
+      // Cache against what storage actually holds, so a failed write still
+      // keeps `next` in memory for this session.
+      let raw: string | null = null;
+      try {
+        raw = localStorage.getItem(key);
+      } catch {}
+      lsCache.set(key, { raw, value: next });
+      lsListeners.forEach((l) => l());
     },
-    [key]
+    [key, initialValue]
   );
 
   return [stored, setValue];
@@ -41,34 +78,29 @@ function useLocalStorage<T>(key: string, initialValue: T): [T, (val: T | ((prev:
 
 export function useBookmarks(userId?: string | null) {
   // localStorage fallback for signed-out users
-  const [localIds, setLocalIds] = useLocalStorage<string[]>(STORAGE_KEYS.bookmarks, []);
+  const [localIds, setLocalIds] = useLocalStorage<string[]>(STORAGE_KEYS.bookmarks, EMPTY_IDS);
 
-  // Server-synced state for signed-in users
-  const [serverIds, setServerIds] = useState<string[]>([]);
-  const [synced, setSynced] = useState(false);
+  // Server truth, keyed by the user it was fetched for — sign-out (or a user
+  // switch) makes it derive as unsynced instead of resetting state in an effect.
+  const [serverState, setServerState] = useState<{ userId: string; ids: string[] } | null>(null);
 
   const isSignedIn = !!userId;
 
   // Fetch bookmarks from API on mount when signed in
   useEffect(() => {
-    if (!isSignedIn) {
-      setSynced(false);
-      return;
-    }
+    if (!userId) return;
     let cancelled = false;
     fetch("/api/bookmarks")
       .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
       .then((data: { ids: string[] }) => {
-        if (!cancelled) {
-          setServerIds(data.ids);
-          setSynced(true);
-        }
+        if (!cancelled) setServerState({ userId, ids: data.ids });
       })
       .catch((err) => console.error("Failed to fetch bookmarks:", err));
     return () => { cancelled = true; };
-  }, [isSignedIn]);
+  }, [userId]);
 
-  const ids = isSignedIn && synced ? serverIds : localIds;
+  const server = userId && serverState !== null && serverState.userId === userId ? serverState : null;
+  const ids = server ? server.ids : localIds;
   const bookmarkSet = useMemo(() => new Set(ids), [ids]);
 
   const pendingRef = useRef<Set<string>>(new Set());
@@ -80,17 +112,21 @@ export function useBookmarks(userId?: string | null) {
         if (pendingRef.current.has(id)) return;
         pendingRef.current.add(id);
 
-        // Optimistic update
         const wasBookmarked = bookmarkSet.has(id);
-        setServerIds((prev) => {
-          const set = new Set(prev);
-          if (wasBookmarked) {
-            set.delete(id);
-          } else {
-            set.add(id);
-          }
-          return [...set];
-        });
+        const applyToServer = (add: boolean) =>
+          setServerState((prev) => {
+            if (!prev) return prev;
+            const set = new Set(prev.ids);
+            if (add) {
+              set.add(id);
+            } else {
+              set.delete(id);
+            }
+            return { ...prev, ids: [...set] };
+          });
+
+        // Optimistic update
+        applyToServer(!wasBookmarked);
         // Fire API call in background — revert on failure
         fetch("/api/bookmarks", {
           method: wasBookmarked ? "DELETE" : "POST",
@@ -103,15 +139,7 @@ export function useBookmarks(userId?: string | null) {
           .catch((err) => {
             console.error("Bookmark sync error:", err);
             // Revert optimistic update
-            setServerIds((prev) => {
-              const set = new Set(prev);
-              if (wasBookmarked) {
-                set.add(id);
-              } else {
-                set.delete(id);
-              }
-              return [...set];
-            });
+            applyToServer(wasBookmarked);
           })
           .finally(() => pendingRef.current.delete(id));
       } else {
@@ -134,28 +162,37 @@ export function useBookmarks(userId?: string | null) {
 
 // ─── useTheme ───────────────────────────────────────────
 
-export function useTheme() {
-  // Always initialize as dark to match server render — prevents hydration mismatch.
-  // The blocking script in <head> already set the correct data-theme on <html>,
-  // so CSS variables are correct from first paint. This state only drives the toggle icon.
-  const [dark, setDark] = useState(true);
-  const [mounted, setMounted] = useState(false);
+// The theme lives outside React: the blocking script in <head> stamps
+// data-theme on <html> before first paint, and toggling rewrites that
+// attribute plus localStorage. useSyncExternalStore reads that external
+// state; the server snapshot stays dark to match the server render.
+const themeListeners = new Set<() => void>();
 
-  // After hydration, read actual theme from the DOM (set by blocking script)
-  useEffect(() => {
-    setDark(document.documentElement.dataset.theme !== "light");
-    setMounted(true);
-  }, []);
+function subscribeTheme(cb: () => void) {
+  themeListeners.add(cb);
+  return () => {
+    themeListeners.delete(cb);
+  };
+}
+
+function readDarkFromDom(): boolean {
+  return document.documentElement.dataset.theme !== "light";
+}
+
+// Never fires — `mounted` only distinguishes server (false) from client (true).
+const subscribeMounted = () => () => {};
+
+export function useTheme() {
+  const dark = useSyncExternalStore(subscribeTheme, readDarkFromDom, () => true);
+  const mounted = useSyncExternalStore(subscribeMounted, () => true, () => false);
 
   const toggle = useCallback(() => {
-    setDark((prev) => {
-      const next = !prev;
-      document.documentElement.dataset.theme = next ? "dark" : "light";
-      try {
-        localStorage.setItem(STORAGE_KEYS.theme, JSON.stringify(next));
-      } catch {}
-      return next;
-    });
+    const next = document.documentElement.dataset.theme === "light";
+    document.documentElement.dataset.theme = next ? "dark" : "light";
+    try {
+      localStorage.setItem(STORAGE_KEYS.theme, JSON.stringify(next));
+    } catch {}
+    themeListeners.forEach((l) => l());
   }, []);
 
   return { dark, toggle, mounted };
@@ -184,11 +221,11 @@ export function useNewsLoader() {
   const fetchedRef = useRef(new Set<string>());
   const inflightRef = useRef(new Map<string, AbortController>());
 
-  // Ensure refs are the correct type (HMR can preserve stale values)
-  if (!(fetchedRef.current instanceof Set)) fetchedRef.current = new Set();
-  if (!(inflightRef.current instanceof Map)) inflightRef.current = new Map();
-
   const loadCategory = useCallback(async (category: CategoryId, force = false) => {
+    // Ensure refs are the correct type (HMR can preserve stale values)
+    if (!(fetchedRef.current instanceof Set)) fetchedRef.current = new Set();
+    if (!(inflightRef.current instanceof Map)) inflightRef.current = new Map();
+
     if (!force && fetchedRef.current.has(category)) return;
 
     const existingController = inflightRef.current.get(category);
@@ -423,40 +460,35 @@ export function useTopicSearch() {
 export function useCustomTopics(userId?: string | null) {
   const [localTopics, setLocalTopics] = useLocalStorage<CustomTopic[]>(
     STORAGE_KEYS.customTopics,
-    []
+    EMPTY_TOPICS
   );
-  const [serverTopics, setServerTopics] = useState<CustomTopic[]>([]);
-  const [synced, setSynced] = useState(false);
+  // Server truth, keyed by user — same derived-sync shape as useBookmarks.
+  const [serverState, setServerState] = useState<{ userId: string; topics: CustomTopic[] } | null>(null);
 
   const isSignedIn = !!userId;
 
   // Fetch from server on mount when signed in
   useEffect(() => {
-    if (!isSignedIn) {
-      setSynced(false);
-      return;
-    }
+    if (!userId) return;
     let cancelled = false;
     fetch("/api/topics")
       .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
       .then((data: { topics: CustomTopic[] }) => {
-        if (!cancelled) {
-          setServerTopics(data.topics);
-          setSynced(true);
-        }
+        if (!cancelled) setServerState({ userId, topics: data.topics });
       })
       .catch((err) => console.error("Failed to fetch custom topics:", err));
     return () => { cancelled = true; };
-  }, [isSignedIn]);
+  }, [userId]);
 
-  const topics = isSignedIn && synced ? serverTopics : localTopics;
+  const server = userId && serverState !== null && serverState.userId === userId ? serverState : null;
+  const topics = server ? server.topics : localTopics;
 
   const add = useCallback(
     (topic: CustomTopic) => {
       if (topics.length >= MAX_CUSTOM_TOPICS) return;
 
       if (isSignedIn) {
-        setServerTopics((prev) => [...prev, topic]);
+        setServerState((prev) => (prev ? { ...prev, topics: [...prev.topics, topic] } : prev));
         fetch("/api/topics", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -472,7 +504,7 @@ export function useCustomTopics(userId?: string | null) {
   const remove = useCallback(
     (id: string) => {
       if (isSignedIn) {
-        setServerTopics((prev) => prev.filter((t) => t.id !== id));
+        setServerState((prev) => (prev ? { ...prev, topics: prev.topics.filter((t) => t.id !== id) } : prev));
         fetch("/api/topics", {
           method: "DELETE",
           headers: { "Content-Type": "application/json" },

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { clerkMiddleware } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
+import type { NextFetchEvent, NextRequest } from "next/server";
 
 const clerkPk = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
 const clerkEnabled = !!clerkPk && clerkPk.startsWith("pk_");
@@ -10,8 +10,8 @@ const clerk = clerkEnabled ? clerkMiddleware() : undefined;
 // Paths that require auth — fail-closed if Clerk is misconfigured
 const PROTECTED_PREFIXES = ["/api/bookmarks", "/api/topics", "/api/compare"];
 
-export default function middleware(request: NextRequest) {
-  if (clerk) return clerk(request, {} as any);
+export default function middleware(request: NextRequest, event: NextFetchEvent) {
+  if (clerk) return clerk(request, event);
 
   // Fail-closed: block protected API routes when Clerk is not configured
   const path = request.nextUrl.pathname;

--- a/scripts/backfill-images.ts
+++ b/scripts/backfill-images.ts
@@ -55,7 +55,7 @@ async function extractOgImage(url: string): Promise<string | null> {
 
     if (!match) return null;
 
-    let imageUrl = match[1];
+    const imageUrl = match[1];
     // Skip tiny tracking pixels and data URIs
     if (imageUrl.startsWith("data:")) return null;
     if (imageUrl.length < 10) return null;

--- a/scripts/recategorize.ts
+++ b/scripts/recategorize.ts
@@ -87,7 +87,6 @@ async function main() {
 
   // 3. For each article, find the best-matching category
   //    Only move if the winner beats "top" by MIN_MARGIN
-  const topIdx = categories.indexOf("top");
   const moves: Record<string, string[]> = {};
   const unchanged: Record<string, number> = {};
   categories.forEach((c) => { moves[c] = []; unchanged[c] = 0; });

--- a/scripts/seed-topics.ts
+++ b/scripts/seed-topics.ts
@@ -417,7 +417,7 @@ async function main() {
                category, vectorStr, estimateReadTime(a.summary)]
             );
             inserted++;
-          } catch (err) {
+          } catch {
             // Duplicate or other DB error — skip
           }
         }


### PR DESCRIPTION
The `next lint` → ESLint CLI migration (#213, closing out the tooling work tracked in #62) made 21 pre-existing problems visible (18 errors, 3 warnings). This PR clears all of them — `npm run lint` now exits 0.

## Trivial
- `app/methodology/page.tsx` — escape `it's` in JSX text
- `scripts/backfill-images.ts` — `prefer-const`
- `scripts/recategorize.ts` — drop unused `topIdx`
- `scripts/seed-topics.ts` — optional catch binding
- `lib/hooks.ts` — drop unused `Story` type import
- `middleware.ts` — replace `{} as any` by accepting Next's real `NextFetchEvent` param and passing it to Clerk
- `eslint.config.mjs` — per-file `no-require-imports` override for `next.config.js` (CJS by design)

## react-hooks v7 compiler-rule refactors
Every pattern was validated against this repo's actual ESLint config before being applied.

- **`useLocalStorage` and `useTheme` rebuilt on `useSyncExternalStore`** — both are genuinely external stores (localStorage; the `data-theme` attribute the blocking `<head>` script stamps). Public APIs and hydration behavior unchanged (server renders the default, client corrects right after hydration — sanctioned, no mismatch error).
- **`useBookmarks` / `useCustomTopics`** — server sync state is keyed by `userId` and *derived*, replacing the synchronous `setSynced(false)` reset in the effect. Side benefit: a user switch now refetches instead of showing the previous user's data.
- **`NewsAggregator` bookmarks fetch** — the article list and loading flag derive from a fetch key (view + user + bookmark set); no synchronous setState in the effect. `bookmarkedArticles` / `loadingBookmarks` names preserved so the render code is untouched.
- **`NewsAggregator` ranking** — decays against `lastUpdated` (the snapshot's `fetchedAt`) instead of `Date.now()` during render; ranking is now a pure function of the data.
- **`CardImage`** — prop-change reset via the guarded render-time adjust pattern (React-docs recommended); the effect is gone, call sites untouched.
- **`LandingPage`** — the `sl-anim` gate is set one frame after mount via `requestAnimationFrame` (cancelled in cleanup). SSR / no-JS / reduced-motion still render fully visible.
- **`useNewsLoader`** — the HMR ref-type guard moved inside `loadCategory` (refs must not be touched during render).

## Deliberate behavior notes
- Feed ranking ages articles against the fetch timestamp, not render-time wall clock.
- `useLocalStorage` hooks sharing a key now stay in sync across components.

## Verification
- `npm run lint` → exit 0, zero warnings
- `npm test` → 29 suites, 499 tests pass
- `npx tsc --noEmit` → clean
- Browser smoke (dev server): landing hydrates, `sl-anim` applied post-mount, theme toggle flips `data-theme` dark↔light, persists `sift-theme`, and re-renders the icon/label; no hydration or update-depth errors. (A jsdom smoke of `useBookmarks` signed-out — toggle/persist/hydrate/cross-instance sync — passed and was not committed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)