### PR TITLE
fix(csp): allow 'unsafe-eval' in script-src during development only

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -96,10 +96,15 @@ const nextConfig = {
     minimumCacheTTL: 60 * 60 * 24 * 7,
   },
   async headers() {
+    // 'unsafe-eval' in development only: Turbopack's dev-mode chunks and
+    // React's dev tooling need eval(), and a strictly CSP-enforcing browser
+    // can otherwise leave a route un-hydrated (#217). Production stays
+    // eval-free — this branch must never widen the deployed header.
+    const devEval = process.env.NODE_ENV === "development" ? " 'unsafe-eval'" : "";
     const csp = [
       "default-src 'self'",
       // 'unsafe-inline' required for: theme init script (layout.tsx), Tailwind styles, Clerk UI
-      "script-src 'self' 'unsafe-inline' https://*.clerk.accounts.dev https://*.clerk.services https://clerk.siftnews.kristenmartino.ai https://challenges.cloudflare.com",
+      `script-src 'self' 'unsafe-inline'${devEval} https://*.clerk.accounts.dev https://*.clerk.services https://clerk.siftnews.kristenmartino.ai https://challenges.cloudflare.com`,
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       // font-src: Google Fonts CDN
       "font-src 'self' https://fonts.gstatic.com data:",


### PR DESCRIPTION
Fixes #217.

One-line mechanical change in `next.config.js` `headers()`: `script-src` gains `'unsafe-eval'` **only when `NODE_ENV === "development"`**. Turbopack's dev chunks and React's dev tooling need eval(), and the strict CSP applies in dev too — React logged `eval() is not supported in this environment` on every dev page load.

## Verification

- **Production header byte-identical:** evaluated `headers()` from both the old (`git show HEAD:next.config.js`) and new config under `NODE_ENV=production` — full header sets compare equal (`JSON.stringify` match), not just the CSP line.
- **Dev header correct:** `curl -sI localhost:3000/news` against the running dev server shows `script-src 'self' 'unsafe-inline' 'unsafe-eval' …`.
- **Eval error eliminated:** after restarting the dev server on this branch, React's `eval() is not supported` console error no longer appears on any page load.
- **No regression:** landing page hydrates and the theme toggle works end-to-end under the new header; `npm test` → 29 suites, 499 tests pass.

## Honest scope note

In the embedded browser pane where #217 was found, `/news` *still* doesn't hydrate after this fix — the Suspense fallback and the streamed content coexist in the DOM, pointing at an unresolved streaming boundary in that DB-less/half-configured-Clerk local environment. That's a second, separate cause, unrelated to CSP, and this session's earlier hook verification already routes around it via jsdom. The eval-blocking defect #217 describes (and its proposed fix) is what this PR resolves; a comment on #217 records the residual observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)