### PR TITLE
Ranking v2 stage 1: saturating story corroboration + cross-spectrum bonus

### DIFF
--- a/__tests__/crossSpectrum.test.ts
+++ b/__tests__/crossSpectrum.test.ts
@@ -1,5 +1,6 @@
 import {
   bucketize,
+  countOccupiedBuckets,
   groupFramingsByBucket,
   shouldRenderCrossSpectrum,
   CROSS_SPECTRUM_BUCKETS,
@@ -222,5 +223,45 @@ describe("shouldRenderCrossSpectrum", () => {
         makeFraming("WSJ", "right"),
       ]),
     ).toBe(true);
+  });
+});
+
+// ─── countOccupiedBuckets (ranking v2 stage 1) ─────────────
+
+describe("countOccupiedBuckets", () => {
+  it("counts distinct buckets, not framings", () => {
+    expect(
+      countOccupiedBuckets([
+        makeFraming("Vox", "left"),
+        makeFraming("Guardian", "lean-left"),
+        makeFraming("WSJ", "right"),
+      ]),
+    ).toBe(2);
+  });
+
+  it("spans all three buckets at most", () => {
+    expect(
+      countOccupiedBuckets([
+        makeFraming("Vox", "left"),
+        makeFraming("AP", "center"),
+        makeFraming("WSJ", "right"),
+        makeFraming("Fox", "right"),
+      ]),
+    ).toBe(3);
+  });
+
+  it("unbucketable framings count toward nothing", () => {
+    // Absence of a rating is never evidence of spectrum spread — a story
+    // covered only by unrated outlets must not earn the spectrum bonus.
+    expect(
+      countOccupiedBuckets([
+        makeFraming("Unrated Blog", null),
+        makeFraming("Another", null),
+      ]),
+    ).toBe(0);
+  });
+
+  it("returns 0 for an empty array", () => {
+    expect(countOccupiedBuckets([])).toBe(0);
   });
 });

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -9,6 +9,7 @@ import {
 import { parseContextPrimer, attachPrimerTermLinks } from "@/lib/primer";
 import { parseEntityLinks } from "@/lib/entityLinks";
 import { enrichLinksWithContext } from "@/lib/civicContext";
+import { countOccupiedBuckets } from "@/lib/crossSpectrum";
 import { stripHtml, sanitizeUrl } from "@/lib/sanitize";
 import type { CategoryId, Article, ArticleTone, Story, StoryFraming, EntitySet, NewsApiResponse, NewsApiError } from "@/lib/types";
 
@@ -164,6 +165,12 @@ export async function GET(request: NextRequest) {
           eventDescription: stripHtml(String(e.event_description ?? "")),
         }));
 
+      // Ranking v2 stage 1: distinct L/C/R buckets among this story's
+      // framings (0-3). The client re-rank applies a small corroboration
+      // bonus per bucket beyond the first — cross-spectrum coverage is
+      // stronger evidence a story matters than three same-lane outlets.
+      const spectrumBuckets = countOccupiedBuckets(framings);
+
       return {
         id: s.id,
         headline: stripHtml(s.headline),
@@ -177,6 +184,7 @@ export async function GET(request: NextRequest) {
         articles: childArticles,
         // A story is grim when at least half its live members are (D48).
         ...(Number(s.grim_share ?? 0) >= 0.5 ? { tone: "grim" as const } : {}),
+        ...(spectrumBuckets > 0 ? { spectrumBuckets } : {}),
       };
     });
 

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -287,12 +287,19 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
       ...currentArticles.map((a) => ({ type: "article" as const, data: a })),
     ];
 
-    // Rank by composite score: (importance + source_boost) * recency_decay
+    // Rank by composite score: (importance | corroboration) * recency_decay
     // D48 grim dampener (mirrors GRIM_DAMPENER in lib/db.ts): low-importance
     // grim items rank as if ~12h older; importance 4-5 somber news and
     // untagged items are untouched — de-stack tabloid crime, never hide
     // major news.
     const GRIM_DAMPENER = 0.6;
+    // Ranking v2 stage 1 (docs/RANKING_SIGNALS.md; constants mirror lib/db.ts):
+    // stories score 3 + STORY_BOOST·ln(1 + sources) — the same saturating
+    // curve the SQL pool now truncates under — times a small cross-spectrum
+    // bonus per occupied L/C/R bucket beyond the first (spectrumBuckets is
+    // derived at the API boundary from framings' AllSides ratings).
+    const STORY_BOOST = 0.8;
+    const SPECTRUM_BOOST = 0.1;
     // Age against the fetch timestamp, not wall clock — ranking must be a pure
     // function of the data snapshot, and the snapshot carries its own "now".
     const now = lastUpdated ? lastUpdated.getTime() : 0;
@@ -305,11 +312,12 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
       const decay = Math.exp(-ageHours / 24);
 
       if (item.type === "story") {
-        const sourceBoost = Math.min((item.data.articleCount - 1), 4) * 0.5;
+        const sourceScore = 3 + STORY_BOOST * Math.log(1 + item.data.articleCount);
+        const spectrum = 1 + SPECTRUM_BOOST * Math.max(0, (item.data.spectrumBuckets ?? 1) - 1);
         // Corroboration is the story-level analog of importance: a
         // two-outlet grim story dampens, a five-outlet disaster does not.
         const damp = item.data.tone === "grim" && item.data.articleCount <= 2 ? GRIM_DAMPENER : 1;
-        return (3 + sourceBoost) * decay * damp;
+        return sourceScore * decay * spectrum * damp;
       }
       const importance = item.data.importanceScore ?? 3;
       const damp = item.data.tone === "grim" && importance <= 3 ? GRIM_DAMPENER : 1;

--- a/docs/RANKING_SIGNALS.md
+++ b/docs/RANKING_SIGNALS.md
@@ -1,6 +1,7 @@
 # Ranking signals — the model behind D45
 
-**Status:** signal model adopted 2026-08-10; v2 implementation planned, not started.
+**Status:** signal model adopted 2026-08-10; stage 1 (saturating corroboration
++ cross-spectrum bonus) implemented 2026-08-10; stages 2–3 planned.
 **Owns:** what the feed ranking is allowed to value, and why. Companion to
 [`DECISIONS.md`](./DECISIONS.md) D45 (rank by civic impact) and D48 (cap and
 dampen, never hide).

--- a/lib/crossSpectrum.ts
+++ b/lib/crossSpectrum.ts
@@ -82,6 +82,19 @@ export function groupFramingsByBucket(
  * never have all three by chance. Rejected unbucketed framings are still
  * surfaced via the StoryCard's flat-list fallback.
  */
+/**
+ * Number of distinct L/C/R buckets a story's framings occupy (0–3).
+ * Ranking v2 stage 1 (docs/RANKING_SIGNALS.md): coverage spanning the
+ * spectrum is stronger corroboration than three same-lane outlets, so the
+ * feed applies a small bonus per bucket beyond the first. Unbucketable
+ * framings (no outlet, or a `mixed`/null rating) count toward nothing —
+ * absence of a rating is never evidence of spectrum spread.
+ */
+export function countOccupiedBuckets(framings: StoryFraming[]): number {
+  const groups = groupFramingsByBucket(framings);
+  return CROSS_SPECTRUM_BUCKETS.filter((b) => groups[b].length > 0).length;
+}
+
 export function shouldRenderCrossSpectrum(framings: StoryFraming[]): boolean {
   const groups = groupFramingsByBucket(framings);
   const bucketed = groups.left.length + groups.center.length + groups.right.length;

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -55,6 +55,19 @@ const GRIM_DAMPENER = 0.6;
 // SQL fragment appended to the importance × recency rank product.
 const GRIM_DAMPENER_SQL = `CASE WHEN tone = 'grim' AND COALESCE(importance_score, 3) <= 3 THEN ${GRIM_DAMPENER} ELSE 1.0 END`;
 
+// Ranking v2 stage 1 (docs/RANKING_SIGNALS.md): stories rank on a SATURATING
+// corroboration curve, 3 + STORY_BOOST × ln(1 + sources), in both the SQL
+// pool and the client re-rank — previously the pool used raw count × decay
+// while the client showed readers a different formula, so the LIMIT 20
+// truncation happened under an order nobody saw. ln keeps an 18-member wire
+// pile-up from lapping a 6-outlet story 3×. The cross-spectrum bonus is
+// applied at the API/client layer only (it needs framings' outlet ratings);
+// its ≤1.2× range cannot meaningfully change a 20-deep pool truncation.
+// STORY_BOOST = 0.5/ln(2) ≈ 0.72 would reproduce the old client score for a
+// 2-source story; 0.8 sits close to that while giving big stories a little
+// more headroom (10 sources → 4.9, vs the old hard cap at 5).
+const STORY_BOOST = 0.8;
+
 export interface DbArticle {
   id: string;
   title: string;
@@ -161,7 +174,7 @@ export async function getStoriesWithArticles(
        GROUP BY s.id
        HAVING COUNT(a.id) >= 2
        ORDER BY
-         COUNT(a.id)::float *
+         (3 + ${STORY_BOOST} * LN(1 + COUNT(a.id)))::float *
          EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(s.published_date, s.created_at))), 0) / 86400.0, 700))
        DESC NULLS LAST
        LIMIT 20`,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -661,6 +661,13 @@ export interface Story {
    * Feeds the D48 dampener for thinly-corroborated grim stories.
    */
   tone?: ArticleTone;
+  /**
+   * Distinct L/C/R AllSides buckets occupied by this story's framings (1-3;
+   * absent when none are bucketable). Derived at the API boundary via
+   * countOccupiedBuckets. Ranking v2 stage 1: the client re-rank applies a
+   * small corroboration bonus per bucket beyond the first.
+   */
+  spectrumBuckets?: number;
 }
 
 export type FeedItem =


### PR DESCRIPTION
Stage 1 of [docs/RANKING_SIGNALS.md](https://github.com/kristenmartino/sift/blob/main/docs/RANKING_SIGNALS.md) (D45).

- **One story formula, both layers**: `3 + 0.8·ln(1 + sources)` in the SQL pool *and* the client re-rank. The pool previously truncated under raw `count × decay` — an order nobody saw — and raw count let an 18-member wire pile-up lap a 6-outlet story 3×.
- **Cross-spectrum bonus**: `spectrumBuckets` (distinct L/C/R buckets among framings, via the new `countOccupiedBuckets` reusing the display bucketing) earns +10% per bucket beyond the first at the API/client layer. Spectrum-spanning coverage is stronger corroboration than three same-lane outlets; unbucketable framings count toward nothing.
- Constants named and mirrored (`STORY_BOOST`, `SPECTRUM_BOOST`); the SQL side omits the spectrum bonus deliberately (needs framings' ratings; its ≤1.2× range can't meaningfully change a 20-deep truncation — noted in the code comment).

**Replay against the live feed** (the RANKING_SIGNALS gate): top-10 grim share and story count unchanged; mean top-10 story sources unchanged; the two 3-bucket stories gain the most, the 18-source single-lane pile-up the least — the intended shape. Companion sift-api PR updates the feed-perf STORIES_SQL mirror.

tsc, eslint, jest green (42 tests, 4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)