### PR TITLE
Make compare feel like the flagship: disputed-first, staged progress, a completion beat, shareable URLs

### DIFF
--- a/components/CompareView.tsx
+++ b/components/CompareView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { ShareButton } from "@/components/ShareActions";
 import { COMPARE_SOURCES } from "@/lib/constants";
 import { COPY } from "@/lib/copy";
 import type { CompareClaim } from "@/lib/types";
@@ -20,35 +21,42 @@ interface CompareViewProps {
   onToggleSource: (key: string) => void;
 }
 
-const AGREEMENT_STYLES: Record<string, { label: string; bg: string; color: string; border: string; dot: string }> = {
+// Agreement chips ride the status tokens (globals.css) so both themes hold \u2014
+// claim agreement is a different axis from political lean, so color is fine
+// here. For/Against below stays neutral ink: coloring outlets green/red on a
+// disputed claim would visually score them right/wrong, the exact move the
+// no-hue-coding rule exists to prevent.
+const AGREEMENT_STYLES: Record<string, { label: string; color: string; dot: string }> = {
   unanimous: {
-    label: "All agree",
-    bg: "rgba(5,150,105,0.1)",
-    color: "#059669",
-    border: "rgba(5,150,105,0.2)",
+    label: COPY.compare.agreement.unanimous,
+    color: "var(--success)",
     dot: "\u25CF",
   },
   majority: {
-    label: "Mostly agree",
-    bg: "rgba(37,99,235,0.1)",
-    color: "#2563eb",
-    border: "rgba(37,99,235,0.2)",
+    label: COPY.compare.agreement.majority,
+    color: "var(--info)",
     dot: "\u25D2",
   },
   disputed: {
-    label: "Disputed",
-    bg: "rgba(217,119,6,0.1)",
-    color: "#d97706",
-    border: "rgba(217,119,6,0.2)",
+    label: COPY.compare.agreement.disputed,
+    color: "var(--warning)",
     dot: "\u25C6",
   },
   unique: {
-    label: "Unique angle",
-    bg: "rgba(107,114,128,0.1)",
-    color: "#6b7280",
-    border: "rgba(107,114,128,0.2)",
+    label: COPY.compare.agreement.unique,
+    color: "var(--text-tertiary)",
     dot: "\u25CB",
   },
+};
+
+// Disputed first \u2014 the cross-spectrum disagreement is the whole point of the
+// feature, so it leads. The backend sorts the same way; this is the defensive
+// mirror for cached or older responses.
+const AGREEMENT_ORDER: Record<string, number> = {
+  disputed: 0,
+  majority: 1,
+  unanimous: 2,
+  unique: 3,
 };
 
 export default function CompareView({
@@ -75,6 +83,10 @@ export default function CompareView({
     .map((key) => COMPARE_SOURCES.find((s) => s.key === key)?.label ?? key)
     .join(", ");
 
+  const sortedClaims = [...claims].sort(
+    (a, b) => (AGREEMENT_ORDER[a.agreement] ?? 4) - (AGREEMENT_ORDER[b.agreement] ?? 4)
+  );
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = inputValue.trim();
@@ -90,35 +102,43 @@ export default function CompareView({
       <div className="flex items-start justify-between gap-4 mb-6">
         <div>
           <div className="flex items-center gap-2 mb-2">
+            {/* bookmark-pop is the completion moment — the user just waited
+                ~20 seconds; the badge landing with a spring is the "done". */}
             <span
-              className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wide"
+              className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wide animate-bookmark-pop"
               style={{
-                background: "rgba(99,102,241,0.1)",
+                background: "color-mix(in srgb, var(--accent) 10%, transparent)",
                 color: "var(--accent)",
-                border: "1px solid rgba(99,102,241,0.2)",
+                border: "1px solid color-mix(in srgb, var(--accent) 25%, transparent)",
               }}
             >
-              {COPY.compare.emptyTitle}
+              {COPY.compare.badge}
             </span>
           </div>
           <h2 className="font-heading text-[22px] font-bold text-(--text-primary) tracking-tight">
             {topic}
           </h2>
           <div className="flex items-center gap-3 mt-1.5 text-xs text-(--text-tertiary)">
-            <span>{sourcesChecked.length} sources checked</span>
+            <span>{COPY.compare.metaSources(sourcesChecked.length)}</span>
             <span className="opacity-30">&middot;</span>
             <span>{(durationMs / 1000).toFixed(1)}s</span>
             <span className="opacity-30">&middot;</span>
-            <span>{claims.length} claims analyzed</span>
+            <span>{COPY.compare.metaClaims(claims.length)}</span>
           </div>
+          <p className="text-[11px] text-(--text-tertiary) mt-1.5 italic">
+            {COPY.compare.liveNote}
+          </p>
         </div>
-        <button
-          onClick={onClose}
-          aria-label="Close comparison"
-          className="flex items-center justify-center w-9 h-9 rounded-full border border-(--border) bg-transparent text-(--text-secondary) text-base cursor-pointer transition-all duration-200 shrink-0 mt-1"
-        >
-          &times;
-        </button>
+        <div className="flex items-center gap-2 shrink-0 mt-1">
+          <ShareButton title={topic} />
+          <button
+            onClick={onClose}
+            aria-label="Close comparison"
+            className="flex items-center justify-center w-9 h-9 rounded-full border border-(--border) bg-transparent text-(--text-secondary) text-base cursor-pointer transition-all duration-200 shrink-0"
+          >
+            &times;
+          </button>
+        </div>
       </div>
 
       {/* Sources */}
@@ -147,7 +167,7 @@ export default function CompareView({
         }}
       >
         <h3 className="text-xs font-bold uppercase tracking-widest text-(--text-tertiary) mb-3">
-          Summary
+          {COPY.compare.summary}
         </h3>
         <p className="text-[15px] leading-relaxed text-(--text-secondary)">
           {comparison}
@@ -157,9 +177,9 @@ export default function CompareView({
       {/* Claims */}
       <div className="space-y-3 mb-8">
         <h3 className="text-xs font-bold uppercase tracking-widest text-(--text-tertiary) mb-1">
-          Key Claims
+          {COPY.compare.keyClaims}
         </h3>
-        {claims.map((claim, i) => {
+        {sortedClaims.map((claim, i) => {
           const style = AGREEMENT_STYLES[claim.agreement] || AGREEMENT_STYLES.unique;
           const isDisputed = claim.agreement === "disputed";
           const isExpanded = expandedClaim === i;
@@ -173,6 +193,10 @@ export default function CompareView({
                 background: "var(--surface-raised)",
                 border: "1px solid var(--border)",
                 cursor: hasDetails ? "pointer" : "default",
+                // Staggered entrance — the claims land one after another,
+                // the earned payoff after a 20-second wait.
+                animation: "fade-slide-in 0.5s var(--ease-out-expo) both",
+                animationDelay: `${i * 60}ms`,
               }}
               onClick={() => hasDetails && setExpandedClaim(isExpanded ? null : i)}
             >
@@ -181,9 +205,9 @@ export default function CompareView({
                   className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full font-semibold uppercase tracking-wide shrink-0 mt-0.5"
                   style={{
                     fontSize: "10px",
-                    background: style.bg,
+                    background: `color-mix(in srgb, ${style.color} 10%, transparent)`,
                     color: style.color,
-                    border: `1px solid ${style.border}`,
+                    border: `1px solid color-mix(in srgb, ${style.color} 22%, transparent)`,
                   }}
                 >
                   {style.dot} {style.label}
@@ -210,9 +234,15 @@ export default function CompareView({
                     overflow: "hidden",
                   }}
                 >
+                  {/* Neutral ink on both labels — green-For/red-Against
+                      visually scored outlets right/wrong on a disputed
+                      claim. Label + position carry the difference, same
+                      rule as LeanGlyph. */}
                   {claim.sources_for && claim.sources_for.length > 0 && (
                     <div className="flex items-start gap-2">
-                      <span className="font-semibold" style={{ color: "#059669" }}>For:</span>
+                      <span className="font-semibold text-(--text-primary)">
+                        {COPY.compare.for}
+                      </span>
                       <span className="text-(--text-secondary)">
                         {claim.sources_for.join(", ")}
                       </span>
@@ -220,7 +250,9 @@ export default function CompareView({
                   )}
                   {claim.sources_against && claim.sources_against.length > 0 && (
                     <div className="flex items-start gap-2">
-                      <span className="font-semibold" style={{ color: "#dc2626" }}>Against:</span>
+                      <span className="font-semibold text-(--text-primary)">
+                        {COPY.compare.against}
+                      </span>
                       <span className="text-(--text-secondary)">
                         {claim.sources_against.join(", ")}
                       </span>

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -37,6 +37,10 @@ function useInitialParams() {
       return param && VALID_CATEGORIES.has(param as CategoryId) ? param as CategoryId : "top";
     })(),
     view: searchParams.get("view"),
+    // Shared compare links: ?compare=<topic>&sources=<key,key>. Read once —
+    // the URL-sync effect below owns the address bar from then on.
+    compare: searchParams.get("compare"),
+    compareSources: searchParams.get("sources"),
   }));
   return initial;
 }
@@ -91,6 +95,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     loading: compareLoading,
     error: compareError,
     slow: compareSlow,
+    stage: compareStage,
     compare: runCompare,
     clear: clearCompare,
   } = useCompare();
@@ -99,10 +104,37 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     loadCategory(activeCategory);
   }, [activeCategory, loadCategory]);
 
-  // Sync state to URL (shallow replace, no scroll)
+  // Run a shared ?compare= link on arrival. Once only — after this, compare
+  // state belongs to the user's own clicks. Signed-out visitors land on the
+  // sign-in empty state via the 401 path, which is the funnel until the
+  // anonymous daily example covers them.
+  const compareFromUrlRan = useRef(false);
+  useEffect(() => {
+    if (compareFromUrlRan.current) return;
+    compareFromUrlRan.current = true;
+    const topic = initialParams.compare?.trim();
+    if (!topic || topic.length < 3) return;
+    const validKeys = (initialParams.compareSources ?? "")
+      .split(",")
+      .filter((key) => COMPARE_SOURCES.some((s) => s.key === key));
+    const sources =
+      validKeys.length >= 2 ? validKeys.slice(0, 5) : [...DEFAULT_COMPARE_SOURCES];
+    setSelectedSources(sources);
+    setCompareMode(true);
+    setShowBookmarks(false);
+    setSearchMode(false);
+    runCompare(topic, sources);
+  }, [initialParams, runCompare]);
+
+  // Sync state to URL (shallow replace, no scroll). Compare wins the address
+  // bar while active so the result screen is linkable — the single most
+  // impressive artifact the product makes should be able to leave it.
   useEffect(() => {
     const params = new URLSearchParams();
-    if (showBookmarks) {
+    if (compareMode && compareTopic) {
+      params.set("compare", compareTopic);
+      if (selectedSources.length > 0) params.set("sources", selectedSources.join(","));
+    } else if (showBookmarks) {
       params.set("view", "bookmarks");
     } else if (activeCategory !== "top") {
       params.set("category", activeCategory);
@@ -110,7 +142,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     const newUrl = params.toString() ? `/news?${params.toString()}` : "/news";
     // Use history API directly to avoid triggering re-renders from router
     window.history.replaceState(null, "", newUrl);
-  }, [activeCategory, showBookmarks]);
+  }, [activeCategory, showBookmarks, compareMode, compareTopic, selectedSources]);
 
   // Category switch with fade-out/fade-in
   const switchCategory = useCallback((catId: CategoryId) => {
@@ -640,7 +672,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
                 className="text-xs text-(--text-tertiary) cursor-pointer bg-transparent border-none p-0 transition-colors duration-200"
                 style={{ color: sourcesExpanded ? "var(--accent)" : undefined }}
               >
-                Comparing: {selectedLabels} {sourcesExpanded ? "▴" : "▾"}
+                {COPY.compare.comparing(selectedLabels)} {sourcesExpanded ? "▴" : "▾"}
               </button>
               {sourcesExpanded && (
                 <div className="flex flex-wrap gap-1.5 mt-2 animate-fade-slide-in">
@@ -694,15 +726,32 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
         {/* Compare mode */}
         {compareMode ? (
           <>
-            {/* Compare loading */}
+            {/* Compare loading — staged progress instead of a bare spinner.
+                The stage lines track the workflow's real shape on elapsed
+                time; the source chips shimmer as a set (no per-source
+                checkmarks until the streaming path can make them true). */}
             {compareLoading && (
               <div className="text-center py-20 px-5 animate-fade-slide-in">
                 <div className="text-4xl mb-5 animate-sift-refresh inline-block text-(--accent)">◆</div>
-                <p className="text-base font-semibold text-(--text-secondary)">
-                  {COPY.compare.loading}
+                <p className="text-base font-semibold text-(--text-secondary)" aria-live="polite">
+                  {compareStage === 0
+                    ? COPY.compare.stageSearch(selectedSources.length)
+                    : compareStage === 1
+                      ? COPY.compare.stageClaims
+                      : COPY.compare.stageSummary}
                 </p>
+                <div className="flex flex-wrap justify-center gap-1.5 mt-5 max-w-[560px] mx-auto">
+                  {selectedSources.map((key) => (
+                    <span
+                      key={key}
+                      className="px-2.5 py-1 rounded-full text-[11px] font-medium border border-(--border) text-(--text-tertiary) animate-shimmer"
+                    >
+                      {COMPARE_SOURCES.find((s) => s.key === key)?.label ?? key}
+                    </span>
+                  ))}
+                </div>
                 {compareSlow && (
-                  <p className="text-sm mt-3 text-(--text-tertiary) animate-fade-slide-in">
+                  <p className="text-sm mt-4 text-(--text-tertiary) animate-fade-slide-in">
                     {COPY.compare.slow}
                   </p>
                 )}
@@ -713,8 +762,8 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
             {compareError && !compareLoading && (
               compareError === "Unauthorized" ? (
                 <EmptyState
-                  title="Sign in to compare"
-                  body="Source comparison uses AI to cross-reference multiple outlets. Sign in to access this feature."
+                  title={COPY.compare.signInTitle}
+                  body={COPY.compare.signInBody}
                 />
               ) : (
                 <ErrorState

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -116,12 +116,46 @@ export const COPY = {
     entry: "Compare",
     loading: "Comparing coverage across sources\u2026",
     slow: "Searching multiple outlets \u2014 this takes 10\u201320 seconds",
-    emptyTitle: "Multi-Source Comparison",
-    emptyBody: "Enter a topic above to compare how different outlets cover it",
+    // Stage lines mirror the real pipeline (search each outlet \u2192 extract
+    // claims \u2192 write the summary) on typical timings. Honesty rule: they say
+    // what the pipeline is doing, never which outlet has finished \u2014 the
+    // client can't see that until the streaming path lands.
+    stageSearch: (n: number) => `Searching ${n} outlet${n !== 1 ? "s" : ""}\u2026`,
+    stageClaims: "Lining up the claims\u2026",
+    stageSummary: "Writing the summary\u2026",
+    // Results-header badge. Was reusing emptyTitle ("Multi-Source
+    // Comparison"), which read like a menu item on the payoff screen.
+    badge: "Multi-source compare",
+    emptyTitle: "Compare the coverage",
+    emptyBody:
+      "Pick a topic and up to five outlets \u2014 Sift lines up where they agree, where they split, and what only one of them reports.",
     placeholder: "Compare coverage across sources\u2026 e.g. \u201cFederal Reserve rate decision\u201d",
     another: "Compare Another Topic",
     anotherPlaceholder: "Enter a topic to compare across sources\u2026",
     button: "Compare coverage",
+    comparing: (labels: string) => `Comparing: ${labels}`,
+    summary: "Summary",
+    keyClaims: "Key Claims",
+    // Agreement labels for claim chips. Rendered with status tokens
+    // (success/info/warning + neutral) \u2014 claim agreement is a different axis
+    // from political lean, but For/Against below stays neutral ink because
+    // coloring outlets green/red visually scores them right/wrong.
+    agreement: {
+      unanimous: "All agree",
+      majority: "Mostly agree",
+      disputed: "Disputed",
+      unique: "Unique angle",
+    },
+    for: "For:",
+    against: "Against:",
+    metaSources: (n: number) => `${n} source${n !== 1 ? "s" : ""} checked`,
+    metaClaims: (n: number) => `${n} claim${n !== 1 ? "s" : ""} analyzed`,
+    // Honesty caption for shared links \u2014 a ?compare= URL reruns the
+    // comparison live rather than replaying a stored result.
+    liveNote: "Generated live \u2014 opening a shared link runs the comparison fresh, so results can differ slightly.",
+    signInTitle: "Sign in to compare",
+    signInBody:
+      "Source comparison uses AI to cross-reference multiple outlets. Sign in to run your own.",
   },
   search: {
     // Visible label on the /news header pill, matching compare.entry.

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -568,6 +568,12 @@ export function useCustomTopics(userId?: string | null) {
 // by ~55s. Compare runs ~20–30s, up to ~55s before the proxy gives up.
 const COMPARE_TIMEOUT_MS = 65_000;
 const COMPARE_SLOW_MS = 8_000;
+// Elapsed-time stage cuts matched to the workflow's typical shape: per-source
+// search fans out first (~20s), claim extraction next, response formatting
+// last. The lines describe what the pipeline does at that point — they never
+// claim a specific outlet finished, which the client can't know pre-SSE.
+const COMPARE_STAGE_CLAIMS_MS = 22_000;
+const COMPARE_STAGE_SUMMARY_MS = 38_000;
 
 interface CompareState {
   topic: string | null;
@@ -578,6 +584,8 @@ interface CompareState {
   loading: boolean;
   error: string | null;
   slow: boolean;
+  /** 0 = searching sources, 1 = extracting claims, 2 = writing the summary. */
+  stage: 0 | 1 | 2;
 }
 
 export function useCompare() {
@@ -590,6 +598,7 @@ export function useCompare() {
     loading: false,
     error: null,
     slow: false,
+    stage: 0,
   });
   const controllerRef = useRef<AbortController | null>(null);
 
@@ -608,11 +617,20 @@ export function useCompare() {
       loading: true,
       error: null,
       slow: false,
+      stage: 0,
     });
 
     const slowTimer = setTimeout(
       () => setState((s) => ({ ...s, slow: true })),
       COMPARE_SLOW_MS
+    );
+    const stageClaimsTimer = setTimeout(
+      () => setState((s) => (s.loading ? { ...s, stage: 1 } : s)),
+      COMPARE_STAGE_CLAIMS_MS
+    );
+    const stageSummaryTimer = setTimeout(
+      () => setState((s) => (s.loading ? { ...s, stage: 2 } : s)),
+      COMPARE_STAGE_SUMMARY_MS
     );
     const timeoutTimer = setTimeout(() => controller.abort(), COMPARE_TIMEOUT_MS);
 
@@ -640,6 +658,7 @@ export function useCompare() {
         loading: false,
         error: null,
         slow: false,
+        stage: 0,
       });
     } catch (err: unknown) {
       if (err instanceof DOMException && err.name === "AbortError") {
@@ -655,6 +674,8 @@ export function useCompare() {
       setState((s) => ({ ...s, loading: false, error: message, slow: false }));
     } finally {
       clearTimeout(slowTimer);
+      clearTimeout(stageClaimsTimer);
+      clearTimeout(stageSummaryTimer);
       clearTimeout(timeoutTimer);
       controllerRef.current = null;
     }
@@ -672,6 +693,7 @@ export function useCompare() {
       loading: false,
       error: null,
       slow: false,
+      stage: 0,
     });
   }, []);
 


### PR DESCRIPTION
**Slice 2 of 3** of the human-touch design pass — stacked on #221; merge that first (GitHub will retarget this to main when the base merges).

The review's sharpest finding: the most impressive thing the product does was the hardest to find and the least rewarding to wait for — a bare spinner for up to 55 seconds, then a payoff screen of hardcoded strings and leftover indigo.

## What's here

- **Disputed-first claims** — defensive client sort mirroring the sift-api change (`sift-api` PR of the same date); cross-spectrum disagreement is the feature's point, so it leads instead of sitting mid-list.
- **Staged progress**: stage lines mirror the real pipeline (search → claims → summary) on elapsed-time cuts, with the selected outlets shimmering as a set. Honesty rule, drawn deliberately: no per-source checkmarks yet, because the client can't know them — slice 3's SSE path makes them true.
- **A completion beat**: results land with `bookmark-pop` on the header badge and staggered claim entrances — the one earned flourish, after a 20-second wait. Reduced-motion safe via the existing global override.
- **Shareable compare URLs**: `?compare=<topic>&sources=…` read on mount, written while active. Live-rerun semantics with an in-voice caption saying so — result persistence stays rejected (sift-mcp BACKLOG).
- **Voice + token cleanup**: every CompareView string moved into `COPY.compare`; agreement chips ride the status tokens in both themes; the last indigo `rgba(99,102,241,…)` is gone; **For/Against is neutral ink** — green-For/red-Against visually scored outlets right/wrong on disputed claims, the exact move the no-hue-coding rule exists to prevent, extended from lean to claim sides.

## Verification

- `tsc --noEmit` clean, all 503 jest tests pass at this commit.
- Full flow (staged loading → disputed-first results → URL round-trip through a fresh window) verified against a local prod build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)