### PR TITLE
Ranking v2 stage 2: civic-entity-density boost

### DIFF
--- a/__tests__/civicWeight.test.ts
+++ b/__tests__/civicWeight.test.ts
@@ -1,0 +1,51 @@
+import { CIVIC_BOOST, civicBoost, weightedCivicLinks } from "@/lib/civicWeight";
+import type { EntityLink, EntityLinkType } from "@/lib/types";
+
+function link(type: EntityLinkType, canonicalId: string): EntityLink {
+  return { type, canonicalId, surfaceForm: canonicalId };
+}
+
+describe("weightedCivicLinks", () => {
+  it("weights bills and politicians fully, orgs half, outlets not at all", () => {
+    expect(
+      weightedCivicLinks([
+        link("bill", "hr-1234"),
+        link("politician", "S000148"),
+        link("org", "aclu"),
+        link("outlet", "nytimes"),
+      ]),
+    ).toBe(2.5);
+  });
+
+  it("counts distinct (type, canonicalId) pairs once", () => {
+    // The linker can emit the same entity for multiple surface forms
+    // ("Schumer", "Chuck Schumer") — density means distinct entities,
+    // not mention count.
+    expect(
+      weightedCivicLinks([
+        link("politician", "S000148"),
+        link("politician", "S000148"),
+        link("politician", "P000197"),
+      ]),
+    ).toBe(2);
+  });
+
+  it("returns 0 for missing or empty links", () => {
+    expect(weightedCivicLinks(undefined)).toBe(0);
+    expect(weightedCivicLinks([])).toBe(0);
+  });
+});
+
+describe("civicBoost", () => {
+  it("is 1.0 at zero weight and caps at +30%", () => {
+    expect(civicBoost(0)).toBe(1);
+    expect(civicBoost(3)).toBeCloseTo(1 + CIVIC_BOOST * 3);
+    // The cap is the safety property: no amount of civic density may
+    // promote a routine item over a disaster.
+    expect(civicBoost(50)).toBeCloseTo(1.3);
+  });
+
+  it("scales linearly below the cap", () => {
+    expect(civicBoost(1.5)).toBeCloseTo(1.15);
+  });
+});

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import { CATEGORIES, VALID_CATEGORIES, COMPARE_SOURCES, CATEGORY_COMPARE_DEFAULTS, DEFAULT_COMPARE_SOURCES, CUSTOM_TOPIC_COLORS } from "@/lib/constants";
 import { COPY } from "@/lib/copy";
+import { civicBoost, weightedCivicLinks } from "@/lib/civicWeight";
 import { timeAgo } from "@/lib/utils";
 import { useNewsLoader, useBookmarks, useTheme, useTopicSearch, useCompare, useCustomTopics } from "@/lib/hooks";
 import ArticleCard from "./ArticleCard";
@@ -317,11 +318,17 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
         // Corroboration is the story-level analog of importance: a
         // two-outlet grim story dampens, a five-outlet disaster does not.
         const damp = item.data.tone === "grim" && item.data.articleCount <= 2 ? GRIM_DAMPENER : 1;
-        return sourceScore * decay * spectrum * damp;
+        // Stage 2: a story is as decision-relevant as its most
+        // civic-entity-dense member (mirrors CIVIC_BOOST_SQL layering).
+        const civic = civicBoost(
+          Math.max(0, ...item.data.articles.map((a) => weightedCivicLinks(a.entityLinks)))
+        );
+        return sourceScore * decay * spectrum * damp * civic;
       }
       const importance = item.data.importanceScore ?? 3;
       const damp = item.data.tone === "grim" && importance <= 3 ? GRIM_DAMPENER : 1;
-      return importance * decay * damp;
+      const civic = civicBoost(weightedCivicLinks(item.data.entityLinks));
+      return importance * decay * damp * civic;
     }
 
     items.sort((a, b) => rankScore(b) - rankScore(a));

--- a/docs/RANKING_SIGNALS.md
+++ b/docs/RANKING_SIGNALS.md
@@ -1,7 +1,9 @@
 # Ranking signals — the model behind D45
 
-**Status:** signal model adopted 2026-08-10; stage 1 (saturating corroboration
-+ cross-spectrum bonus) implemented 2026-08-10; stages 2–3 planned.
+**Status:** signal model adopted 2026-08-10; stages 1 (saturating
+corroboration + cross-spectrum bonus) and 2 (civic-entity-density boost)
+implemented 2026-08-10; stage 3 (hand-ranked eval + feed_health tripwire)
+planned.
 **Owns:** what the feed ranking is allowed to value, and why. Companion to
 [`DECISIONS.md`](./DECISIONS.md) D45 (rank by civic impact) and D48 (cap and
 dampen, never hide).

--- a/lib/civicWeight.ts
+++ b/lib/civicWeight.ts
@@ -1,0 +1,44 @@
+// Ranking v2 stage 2 (docs/RANKING_SIGNALS.md): civic-entity density — the
+// D45 decision-relevance signal. An article whose entity links resolve to
+// curated dossiers (bills, members of Congress, orgs) is decision-relevant
+// to a reader-as-citizen in a way a wire curiosity is not.
+//
+// Weighted DISTINCT count: bills and politicians carry full weight, orgs
+// half, outlets nothing (an outlet link says who wrote it, not what a
+// citizen can act on). Capped at 3 before boosting so civic density
+// re-orders within a tier but can never promote a routine item over a
+// disaster: max effect is 1 + CIVIC_BOOST × 3 = +30%.
+//
+// Mirrored in SQL by CIVIC_BOOST_SQL in lib/db.ts — keep the weights, the
+// cap, and the constant in lockstep with it.
+
+import type { EntityLink } from "./types";
+
+export const CIVIC_BOOST = 0.1;
+export const CIVIC_WEIGHT_CAP = 3;
+
+const TYPE_WEIGHTS: Record<string, number> = {
+  bill: 1,
+  politician: 1,
+  org: 0.5,
+  outlet: 0,
+};
+
+/** Weighted count of distinct (type, canonicalId) civic links. */
+export function weightedCivicLinks(links: EntityLink[] | undefined): number {
+  if (!links?.length) return 0;
+  const seen = new Set<string>();
+  let sum = 0;
+  for (const link of links) {
+    const key = `${link.type}:${link.canonicalId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    sum += TYPE_WEIGHTS[link.type] ?? 0;
+  }
+  return sum;
+}
+
+/** The rank multiplier for a given weighted civic-link count (1.0–1.3). */
+export function civicBoost(weight: number): number {
+  return 1 + CIVIC_BOOST * Math.min(Math.max(weight, 0), CIVIC_WEIGHT_CAP);
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -55,6 +55,24 @@ const GRIM_DAMPENER = 0.6;
 // SQL fragment appended to the importance × recency rank product.
 const GRIM_DAMPENER_SQL = `CASE WHEN tone = 'grim' AND COALESCE(importance_score, 3) <= 3 THEN ${GRIM_DAMPENER} ELSE 1.0 END`;
 
+// Ranking v2 stage 2 (docs/RANKING_SIGNALS.md): civic-entity-density boost —
+// the D45 decision-relevance signal. Weighted DISTINCT dossier links (bill
+// and politician 1.0, org 0.5, outlet 0), capped at 3, ×0.1 per point:
+// civic density re-orders within a tier but tops out at +30%, so it can
+// never promote a routine item over a disaster. Weights, cap, and constant
+// mirror lib/civicWeight.ts (the client re-rank) — keep them in lockstep.
+// Applied to the three article pool queries; the hero query keeps its own
+// tone-preference mechanic, and stories derive their boost client-side from
+// member articles (same layering as the stage-1 spectrum bonus). Verified
+// against prod before shipping: worst pool shape 163 ms, unchanged.
+const CIVIC_BOOST = 0.1;
+const CIVIC_WEIGHT_SQL = `COALESCE((
+  SELECT SUM(CASE t WHEN 'bill' THEN 1.0 WHEN 'politician' THEN 1.0 WHEN 'org' THEN 0.5 ELSE 0 END)
+  FROM (SELECT DISTINCT el->>'type' AS t, el->>'canonical_id' AS cid
+        FROM jsonb_array_elements(CASE WHEN jsonb_typeof(entity_links) = 'array' THEN entity_links ELSE '[]'::jsonb END) el) links
+), 0)`;
+const CIVIC_BOOST_SQL = `(1 + ${CIVIC_BOOST} * LEAST(${CIVIC_WEIGHT_SQL}, 3))`;
+
 // Ranking v2 stage 1 (docs/RANKING_SIGNALS.md): stories rank on a SATURATING
 // corroboration curve, 3 + STORY_BOOST × ln(1 + sources), in both the SQL
 // pool and the client re-rank — previously the pool used raw count × decay
@@ -116,7 +134,8 @@ export async function getArticlesByCategory(
      ORDER BY
        COALESCE(importance_score, 3)::float *
        EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700)) *
-       ${GRIM_DAMPENER_SQL}
+       ${GRIM_DAMPENER_SQL} *
+       ${CIVIC_BOOST_SQL}
      DESC NULLS LAST
      LIMIT $2`,
     [category, limit]
@@ -236,7 +255,8 @@ export async function getStoriesWithArticles(
                 category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at,
                 COALESCE(importance_score, 3)::float *
                 EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700)) *
-                ${GRIM_DAMPENER_SQL}
+                ${GRIM_DAMPENER_SQL} *
+                ${CIVIC_BOOST_SQL}
                 AS rank_score
          FROM articles
          WHERE category = $1 AND from_search = false
@@ -271,7 +291,8 @@ export async function getStoriesWithArticles(
                 category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at,
                 COALESCE(importance_score, 3)::float *
                 EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700)) *
-                ${GRIM_DAMPENER_SQL}
+                ${GRIM_DAMPENER_SQL} *
+                ${CIVIC_BOOST_SQL}
                 AS rank_score
          FROM articles
          WHERE category = $1 AND from_search = false


### PR DESCRIPTION
Stage 2 of [docs/RANKING_SIGNALS.md](https://github.com/kristenmartino/sift/blob/main/docs/RANKING_SIGNALS.md) — the D45 decision-relevance signal, from the entity links Sift already resolves to its civic dossiers.

- **Weighted distinct dossier links** per article: bill/politician 1.0, org 0.5, outlet 0. Capped at 3, ×0.1 per point → **max +30%**: civic density re-orders within a tier, structurally incapable of promoting a routine item over a disaster.
- Applied in all three SQL article pool queries (`CIVIC_BOOST_SQL`) and the client re-rank (new `lib/civicWeight.ts`, shared by article + story branches — a story is as decision-relevant as its most-linked member). Hero unchanged.
- `CIVIC_BOOST = 0` reverts; weights/cap mirrored SQL↔client with lockstep comments.

**Validated against prod first**: worst pool shape 163 ms (unchanged); the 7-day weight distribution discriminates (85% of articles at zero, 93 at the cap). **Replay on the live feed**: 'top' unchanged (grim 7→7); in politics the risers are a congressional investigation (w=3, +4 places) and the vaccine-schedule executive order (w=2, +2) while the catering-truck gossip item holds still.

Companion sift-api PR mirrors the fragment into feed-perf. tsc, eslint, jest green (24 tests, 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)