### PR TITLE
Record ranking v2 stage 3 as implemented

### DIFF
--- a/docs/RANKING_SIGNALS.md
+++ b/docs/RANKING_SIGNALS.md
@@ -2,8 +2,11 @@
 
 **Status:** signal model adopted 2026-08-10; stages 1 (saturating
 corroboration + cross-spectrum bonus) and 2 (civic-entity-density boost)
-implemented 2026-08-10; stage 3 (hand-ranked eval + feed_health tripwire)
-planned.
+implemented 2026-08-10; stage 3 implemented 2026-08-11 — the drift tripwire
+lives in sift-api's `services/feed_balance.py` (daily snapshots to the
+`feed_balance` table, migration 022) and the blind-pairs eval in
+`scripts/eval_ranking_pairs.py` (first 25-pair sheet committed; labeling
+pending).
 **Owns:** what the feed ranking is allowed to value, and why. Companion to
 [`DECISIONS.md`](./DECISIONS.md) D45 (rank by civic impact) and D48 (cap and
 dampen, never hide).


### PR DESCRIPTION
Docs only: RANKING_SIGNALS.md status now reflects [sift-api#197](https://github.com/kristenmartino/sift-api/pull/197)/[#198](https://github.com/kristenmartino/sift-api/pull/198) — the feed_balance drift tripwire and the blind-pairs eval harness are live; the first 25-pair labeling session is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)