### PR TITLE
Ranking v2 stage 4: opinion ranks ×0.6 and earns no spectrum credit

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -48,6 +48,7 @@ const MOCK_DB_ROWS: DbArticle[] = [
     why_it_matters: null,
     importance_score: null,
     tone: null,
+    is_opinion: false,
     context_primer: null,
     reading_levels: null,
     created_at: new Date("2026-03-28T10:00:00Z"),
@@ -65,6 +66,7 @@ const MOCK_DB_ROWS: DbArticle[] = [
     why_it_matters: null,
     importance_score: null,
     tone: null,
+    is_opinion: false,
     context_primer: null,
     reading_levels: null,
     created_at: new Date("2026-03-28T08:00:00Z"),
@@ -248,6 +250,7 @@ describe("GET /api/news", () => {
           entities: [{ people: ["Alice"], organizations: ["Acme"], locations: ["NYC"], event_description: "test event" }],
           article_count: 2,
           grim_share: null,
+          opinion_share: null,
           representative_image_url: null,
           published_date: new Date("2026-03-28T10:00:00Z"),
           synthesis_status: "complete",
@@ -285,6 +288,7 @@ describe("GET /api/news", () => {
           article_count: 2,
           // pg returns AVG() as a numeric string.
           grim_share: "0.5",
+          opinion_share: "0.5",
           representative_image_url: null,
           published_date: new Date("2026-03-28T10:00:00Z"),
           synthesis_status: "complete",
@@ -292,7 +296,7 @@ describe("GET /api/news", () => {
         storyArticles: {},
         standaloneArticles: [
           { ...MOCK_DB_ROWS[0], tone: "grim" },
-          { ...MOCK_DB_ROWS[1], tone: "invalid-value" },
+          { ...MOCK_DB_ROWS[1], tone: "invalid-value", is_opinion: true },
         ],
       });
 
@@ -304,6 +308,11 @@ describe("GET /api/news", () => {
       expect(body.articles[1].tone).toBeUndefined();
       // grim_share >= 0.5 → the story itself is grim.
       expect(body.stories[0].tone).toBe("grim");
+      // opinion_share >= 0.5 → the story is opinion (stage 4).
+      expect(body.stories[0].isOpinion).toBe(true);
+      // reported articles carry no isOpinion key at all.
+      expect(body.articles[0].isOpinion).toBeUndefined();
+      expect(body.articles[1].isOpinion).toBe(true);
     });
   });
 

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -102,6 +102,7 @@ export async function GET(request: NextRequest) {
         ...(row.why_it_matters ? { whyItMatters: row.why_it_matters } : {}),
         ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
         ...(isArticleTone(row.tone) ? { tone: row.tone } : {}),
+        ...(row.is_opinion ? { isOpinion: true } : {}),
         ...(primer ? { contextPrimer: primer } : {}),
         ...(outlet ? { outlet } : {}),
         ...(entityLinks.length > 0 ? { entityLinks } : {}),
@@ -169,7 +170,16 @@ export async function GET(request: NextRequest) {
       // framings (0-3). The client re-rank applies a small corroboration
       // bonus per bucket beyond the first — cross-spectrum coverage is
       // stronger evidence a story matters than three same-lane outlets.
-      const spectrumBuckets = countOccupiedBuckets(framings);
+      // Stage 4: opinion-backed framings don't count toward the spectrum
+      // bonus. A framing counts only when its outlet contributed at least
+      // one REPORTED member article — op-eds across lanes are disagreement,
+      // not corroboration (sift-api#200, overrule pattern one).
+      const reportedSources = new Set(
+        childRows.filter((r) => !r.is_opinion).map((r) => r.source_name)
+      );
+      const spectrumBuckets = countOccupiedBuckets(
+        framings.filter((f) => reportedSources.has(f.sourceName))
+      );
 
       return {
         id: s.id,
@@ -184,6 +194,7 @@ export async function GET(request: NextRequest) {
         articles: childArticles,
         // A story is grim when at least half its live members are (D48).
         ...(Number(s.grim_share ?? 0) >= 0.5 ? { tone: "grim" as const } : {}),
+        ...(Number(s.opinion_share ?? 0) >= 0.5 ? { isOpinion: true } : {}),
         ...(spectrumBuckets > 0 ? { spectrumBuckets } : {}),
       };
     });

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -353,6 +353,9 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     // derived at the API boundary from framings' AllSides ratings).
     const STORY_BOOST = 0.8;
     const SPECTRUM_BOOST = 0.1;
+    // Stage 4 (mirrors OPINION_DAMPENER in lib/db.ts): outlet-declared
+    // opinion ranks x0.6 at any importance - op-eds are not top stories.
+    const OPINION_DAMPENER = 0.6;
     // Age against the fetch timestamp, not wall clock — ranking must be a pure
     // function of the data snapshot, and the snapshot carries its own "now".
     const now = lastUpdated ? lastUpdated.getTime() : 0;
@@ -370,17 +373,19 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
         // Corroboration is the story-level analog of importance: a
         // two-outlet grim story dampens, a five-outlet disaster does not.
         const damp = item.data.tone === "grim" && item.data.articleCount <= 2 ? GRIM_DAMPENER : 1;
+        const opDamp = item.data.isOpinion ? OPINION_DAMPENER : 1;
         // Stage 2: a story is as decision-relevant as its most
         // civic-entity-dense member (mirrors CIVIC_BOOST_SQL layering).
         const civic = civicBoost(
           Math.max(0, ...item.data.articles.map((a) => weightedCivicLinks(a.entityLinks)))
         );
-        return sourceScore * decay * spectrum * damp * civic;
+        return sourceScore * decay * spectrum * damp * civic * opDamp;
       }
       const importance = item.data.importanceScore ?? 3;
       const damp = item.data.tone === "grim" && importance <= 3 ? GRIM_DAMPENER : 1;
+      const opDamp = item.data.isOpinion ? OPINION_DAMPENER : 1;
       const civic = civicBoost(weightedCivicLinks(item.data.entityLinks));
-      return importance * decay * damp * civic;
+      return importance * decay * damp * civic * opDamp;
     }
 
     items.sort((a, b) => rankScore(b) - rankScore(a));

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -54,6 +54,7 @@
 | D46 | Android paused; launch re-planned around evidence | Pause Android v1 for 90 days; replace the feature roadmap with a ~10-hr week-one evidence test; re-baseline budget to 6 hrs/wk | $0 to decide | SETTLED (Jul 2026); **feature-work pause LIFTED 2026-08-05** — Android stays paused, the week-one test stays the next action, but building is no longer prohibited |
 | D47 | Q8 closed: global civic content | Sift covers non-US civic institutions. Entry point is IGOs sourced to founding treaties, not more foreign heads of state | $0 to decide | SETTLED (Aug 2026) |
 | D48 | Feed balance: cap and dampen, never hide | One outlet caps at 6 of the 50-article pool; low-importance grim items (tone=grim, importance ≤3) rank ×0.6 (≈12h older); importance 4–5 somber news ranks untouched. Answer to the doom-stacked 'top' feed (NYP held 23/50) | ~$0.05/day (tone tag rides the existing Haiku call) | SETTLED (Aug 2026); fully live 2026-08-10 — cap, dampener, non-grim hero, tone backfilled (sift#211/#212, sift-api#186/#187/#188) |
+| D49 | Opinion is not news ranking | Outlet-declared opinion (URL/title markers, deterministic) ranks ×0.6 at any importance, never takes the hero, and doesn't count toward the cross-spectrum bonus. Evidence: first labeled ranking eval (sift-api#200) — half the overrules rejected op-eds ranked as news | $0 (no LLM) | SETTLED (Aug 2026) |
 
 **Total estimated monthly cost: ~$30-50/mo**
 

--- a/docs/RANKING_SIGNALS.md
+++ b/docs/RANKING_SIGNALS.md
@@ -5,8 +5,35 @@ corroboration + cross-spectrum bonus) and 2 (civic-entity-density boost)
 implemented 2026-08-10; stage 3 implemented 2026-08-11 — the drift tripwire
 lives in sift-api's `services/feed_balance.py` (daily snapshots to the
 `feed_balance` table, migration 022) and the blind-pairs eval in
-`scripts/eval_ranking_pairs.py` (first 25-pair sheet committed; labeling
-pending).
+`scripts/eval_ranking_pairs.py`; first labeling session scored 2026-08-11
+(sift-api#200: pre-v2 13/25, v2 13/25 — a tie by the harness's own banding);
+stage 4 (opinion genre) implemented 2026-08-11 from that session's overrule
+patterns.
+
+## Stage 4 — opinion is not a top story (added from eval evidence)
+
+The first labeling session's clearest pattern: in half the overrules the
+labeler rejected op-eds and horse-race commentary the formulas had ranked
+as news, and the spectrum bonus actively *rewarded* opinion roundups
+(op-eds across lanes trivially span L/C/R buckets — disagreement, not
+corroboration). The response, deterministic and $0:
+
+- `articles.is_opinion` (migration 023), set at store time by sift-api's
+  `services/genre.py` from **outlet-declared markers only** — URL path
+  segments (`/opinion/`, `/commentary/`, `/editorial(s)/`, `/op-ed/`,
+  `/commentisfree/`) and title prefixes ("Opinion:", "Editorial |").
+  Precision-first: "Analysis:" is deliberately unflagged, and the flag is
+  `NOT NULL DEFAULT FALSE` — no marker IS the reported verdict.
+  Retroactive via `scripts/backfill_opinion.py` (lockstep SQL patterns).
+- Ranking: opinion ranks × `OPINION_DAMPENER` (0.6) at any importance, in
+  the SQL pools and the client re-rank; stories inherit it when ≥ half
+  their members are opinion; opinion never takes the landing hero.
+- Spectrum bonus counts only framings whose outlet contributed at least
+  one *reported* member article.
+- `feed_balance.opinion_share_top10` records the policy's effect, untripped.
+- Known residual: opinion not declared in URL/title. An LLM genre key on
+  the context call is the named follow-up if the residual matters; the
+  second labeling session will say.
 **Owns:** what the feed ranking is allowed to value, and why. Companion to
 [`DECISIONS.md`](./DECISIONS.md) D45 (rank by civic impact) and D48 (cap and
 dampen, never hide).

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -75,6 +75,17 @@ const CIVIC_WEIGHT_SQL = `COALESCE((
 ), 0)`;
 const CIVIC_BOOST_SQL = `(1 + ${CIVIC_BOOST} * LEAST(${CIVIC_WEIGHT_SQL}, 3))`;
 
+// Ranking v2 stage 4 (docs/RANKING_SIGNALS.md): opinion is not a top story.
+// Evidence: the first hand-labeled ranking eval (sift-api#200) — half the
+// overrules rejected op-eds the formulas ranked as news. Outlet-declared
+// opinion (articles.is_opinion, set at ingest from URL/title markers) ranks
+// ×0.6, and the API layer excludes opinion-backed framings from the
+// cross-spectrum bonus (op-eds across lanes are disagreement, not
+// corroboration). Flat, no importance gate: an op-ed is opinion at any
+// importance. Set to 1.0 to revert. Mirrored in NewsAggregator.tsx.
+const OPINION_DAMPENER = 0.6;
+const OPINION_DAMPENER_SQL = `CASE WHEN is_opinion THEN ${OPINION_DAMPENER} ELSE 1.0 END`;
+
 // Ranking v2 stage 1 (docs/RANKING_SIGNALS.md): stories rank on a SATURATING
 // corroboration curve, 3 + STORY_BOOST × ln(1 + sources), in both the SQL
 // pool and the client re-rank — previously the pool used raw count × decay
@@ -101,6 +112,7 @@ export interface DbArticle {
   why_it_matters: string | null;
   importance_score: number | null;
   tone: string | null; // grim | neutral | light | NULL (migrations/020); NULL = neutral
+  is_opinion: boolean; // outlet-declared opinion marker (migrations/023)
   created_at: Date;
   // Civic-literacy MVP additions. Both columns added in
   // sift-api/migrations/005_context_primer_and_reading_levels.sql.
@@ -126,7 +138,7 @@ export async function getArticlesByCategory(
 ): Promise<DbArticle[]> {
   const result = await pool.query<DbArticle>(
     `SELECT id, title, summary, source_url, source_name, image_url,
-            category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at
+            category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at
      FROM articles
      WHERE category = $1 AND from_search = false
        AND summary IS NOT NULL AND summary != ''
@@ -137,7 +149,8 @@ export async function getArticlesByCategory(
        COALESCE(importance_score, 3)::float *
        EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700)) *
        ${GRIM_DAMPENER_SQL} *
-       ${CIVIC_BOOST_SQL}
+       ${CIVIC_BOOST_SQL} *
+       ${OPINION_DAMPENER_SQL}
      DESC NULLS LAST
      LIMIT $2`,
     [category, limit]
@@ -161,6 +174,9 @@ export interface DbStory {
   // Fraction of live member articles tagged tone='grim' (0..1); the API
   // boundary derives Story.tone = 'grim' when >= 0.5. NULL tones count as 0.
   grim_share: string | number | null;
+  // Fraction of live member articles flagged is_opinion (0..1); the API
+  // boundary derives Story.isOpinion when >= 0.5.
+  opinion_share: string | number | null;
 }
 
 export interface DbStoryArticle extends DbArticle {
@@ -184,6 +200,7 @@ export async function getStoriesWithArticles(
       `SELECT s.id, s.headline, s.summary, s.category, s.framings, s.entities,
               COUNT(a.id)::int AS article_count,
               AVG(CASE WHEN a.tone = 'grim' THEN 1.0 ELSE 0 END) AS grim_share,
+              AVG(CASE WHEN a.is_opinion THEN 1.0 ELSE 0 END) AS opinion_share,
               s.representative_image_url, s.published_date, s.synthesis_status
        FROM stories s
        LEFT JOIN articles a
@@ -219,7 +236,7 @@ export async function getStoriesWithArticles(
     try {
       const storyArticlesResult = await pool.query<DbStoryArticle>(
         `SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at, story_id
+                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at, story_id
          FROM articles
          WHERE story_id = ANY($1::text[])
            AND from_search = false
@@ -254,11 +271,12 @@ export async function getStoriesWithArticles(
     const standaloneResult = await pool.query<DbArticle>(
       `WITH scored AS (
          SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at,
+                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at,
                 COALESCE(importance_score, 3)::float *
                 EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700)) *
                 ${GRIM_DAMPENER_SQL} *
-                ${CIVIC_BOOST_SQL}
+                ${CIVIC_BOOST_SQL} *
+                ${OPINION_DAMPENER_SQL}
                 AS rank_score
          FROM articles
          WHERE category = $1 AND from_search = false
@@ -276,7 +294,7 @@ export async function getStoriesWithArticles(
          FROM scored
        )
        SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at
+              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at
        FROM capped
        WHERE source_rank <= ${MAX_ARTICLES_PER_SOURCE}
        ORDER BY rank_score DESC
@@ -290,11 +308,12 @@ export async function getStoriesWithArticles(
     const fallback = await pool.query<DbArticle>(
       `WITH scored AS (
          SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at,
+                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at,
                 COALESCE(importance_score, 3)::float *
                 EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700)) *
                 ${GRIM_DAMPENER_SQL} *
-                ${CIVIC_BOOST_SQL}
+                ${CIVIC_BOOST_SQL} *
+                ${OPINION_DAMPENER_SQL}
                 AS rank_score
          FROM articles
          WHERE category = $1 AND from_search = false
@@ -311,7 +330,7 @@ export async function getStoriesWithArticles(
          FROM scored
        )
        SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at
+              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at
        FROM capped
        WHERE source_rank <= ${MAX_ARTICLES_PER_SOURCE}
        ORDER BY rank_score DESC
@@ -343,13 +362,14 @@ export async function getTopStoryForLanding(): Promise<DbArticle | null> {
     const result = await pool.query<DbArticle>(
       `WITH ranked AS (
          SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at,
+                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at,
                 COALESCE(importance_score, 3)::float *
                 EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700))
                 AS rank_score
          FROM articles
          WHERE category = 'top'
            AND from_search = false
+           AND is_opinion = false
            AND image_url IS NOT NULL
            AND summary IS NOT NULL AND summary != ''
            AND LOWER(summary) NOT LIKE 'unable to provide%'
@@ -359,7 +379,7 @@ export async function getTopStoryForLanding(): Promise<DbArticle | null> {
          LIMIT 12
        )
        SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, tone, context_primer, reading_levels, created_at
+              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at
        FROM ranked
        ORDER BY
          CASE WHEN tone IS DISTINCT FROM 'grim'

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -41,6 +41,8 @@ export interface Article {
   whyItMatters?: string;
   importanceScore?: number;
   tone?: ArticleTone;
+  /** Outlet-declared opinion piece (migrations/023); absent = reported. */
+  isOpinion?: boolean;
   /**
    * AI-generated "What you should know first" panel — civic-literacy MVP.
    * Populated by sift-api's primer_generator. Null/undefined when the article
@@ -661,6 +663,8 @@ export interface Story {
    * Feeds the D48 dampener for thinly-corroborated grim stories.
    */
   tone?: ArticleTone;
+  /** Derived at the API boundary: >= half the members are opinion pieces. */
+  isOpinion?: boolean;
   /**
    * Distinct L/C/R AllSides buckets occupied by this story's framings (1-3;
    * absent when none are bucketable). Derived at the API boundary via


### PR DESCRIPTION
Consume side of [sift-api#201](https://github.com/kristenmartino/sift-api/pull/201) (D49). **Merge after #201's migration is live in prod** — the queries reference `is_opinion` unguarded.

Evidence base: the first labeled ranking eval ([sift-api#200](https://github.com/kristenmartino/sift-api/pull/200)) — half the overrules rejected op-eds the formulas ranked as news, and the spectrum bonus actively *rewarded* opinion roundups.

- `OPINION_DAMPENER = 0.6` on outlet-declared opinion at any importance, in the SQL pools and the client re-rank; stories inherit it at ≥½ opinion members; opinion never takes the landing hero.
- The cross-spectrum bonus counts only framings backed by at least one *reported* member article — op-eds across lanes are disagreement, not corroboration.
- Docs: RANKING_SIGNALS stage-4 section + D49 row.

tsc clean; 30 suites / 508 tests pass. The two eslint errors in NewsAggregator are pre-existing (#223/#226 lines, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)