### PR TITLE
Ranking v2 stage 5: roundup containers rank ×0.4 and never take the hero

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -49,6 +49,7 @@ const MOCK_DB_ROWS: DbArticle[] = [
     importance_score: null,
     tone: null,
     is_opinion: false,
+    is_roundup: false,
     context_primer: null,
     reading_levels: null,
     created_at: new Date("2026-03-28T10:00:00Z"),
@@ -67,6 +68,7 @@ const MOCK_DB_ROWS: DbArticle[] = [
     importance_score: null,
     tone: null,
     is_opinion: false,
+    is_roundup: false,
     context_primer: null,
     reading_levels: null,
     created_at: new Date("2026-03-28T08:00:00Z"),
@@ -296,7 +298,7 @@ describe("GET /api/news", () => {
         storyArticles: {},
         standaloneArticles: [
           { ...MOCK_DB_ROWS[0], tone: "grim" },
-          { ...MOCK_DB_ROWS[1], tone: "invalid-value", is_opinion: true },
+          { ...MOCK_DB_ROWS[1], tone: "invalid-value", is_opinion: true, is_roundup: true },
         ],
       });
 
@@ -313,6 +315,8 @@ describe("GET /api/news", () => {
       // reported articles carry no isOpinion key at all.
       expect(body.articles[0].isOpinion).toBeUndefined();
       expect(body.articles[1].isOpinion).toBe(true);
+      expect(body.articles[1].isRoundup).toBe(true);
+      expect(body.articles[0].isRoundup).toBeUndefined();
     });
   });
 

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -103,6 +103,7 @@ export async function GET(request: NextRequest) {
         ...(row.importance_score ? { importanceScore: row.importance_score } : {}),
         ...(isArticleTone(row.tone) ? { tone: row.tone } : {}),
         ...(row.is_opinion ? { isOpinion: true } : {}),
+        ...(row.is_roundup ? { isRoundup: true } : {}),
         ...(primer ? { contextPrimer: primer } : {}),
         ...(outlet ? { outlet } : {}),
         ...(entityLinks.length > 0 ? { entityLinks } : {}),

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -356,6 +356,8 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     // Stage 4 (mirrors OPINION_DAMPENER in lib/db.ts): outlet-declared
     // opinion ranks x0.6 at any importance - op-eds are not top stories.
     const OPINION_DAMPENER = 0.6;
+    // Stage 5: program episodes and briefs are containers, not stories.
+    const ROUNDUP_DAMPENER = 0.4;
     // Age against the fetch timestamp, not wall clock — ranking must be a pure
     // function of the data snapshot, and the snapshot carries its own "now".
     const now = lastUpdated ? lastUpdated.getTime() : 0;
@@ -384,8 +386,9 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
       const importance = item.data.importanceScore ?? 3;
       const damp = item.data.tone === "grim" && importance <= 3 ? GRIM_DAMPENER : 1;
       const opDamp = item.data.isOpinion ? OPINION_DAMPENER : 1;
+      const roundDamp = item.data.isRoundup ? ROUNDUP_DAMPENER : 1;
       const civic = civicBoost(weightedCivicLinks(item.data.entityLinks));
-      return importance * decay * damp * civic * opDamp;
+      return importance * decay * damp * civic * opDamp * roundDamp;
     }
 
     items.sort((a, b) => rankScore(b) - rankScore(a));

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -55,6 +55,7 @@
 | D47 | Q8 closed: global civic content | Sift covers non-US civic institutions. Entry point is IGOs sourced to founding treaties, not more foreign heads of state | $0 to decide | SETTLED (Aug 2026) |
 | D48 | Feed balance: cap and dampen, never hide | One outlet caps at 6 of the 50-article pool; low-importance grim items (tone=grim, importance ≤3) rank ×0.6 (≈12h older); importance 4–5 somber news ranks untouched. Answer to the doom-stacked 'top' feed (NYP held 23/50) | ~$0.05/day (tone tag rides the existing Haiku call) | SETTLED (Aug 2026); fully live 2026-08-10 — cap, dampener, non-grim hero, tone backfilled (sift#211/#212, sift-api#186/#187/#188) |
 | D49 | Opinion is not news ranking | Outlet-declared opinion (URL/title markers, deterministic) ranks ×0.6 at any importance, never takes the hero, and doesn't count toward the cross-spectrum bonus. Evidence: first labeled ranking eval (sift-api#200) — half the overrules rejected op-eds ranked as news | $0 (no LLM) | SETTLED (Aug 2026) |
+| D50 | Roundup containers are not stories | Program episodes and daily briefs (title-pattern detected, deterministic) rank ×0.4 and never take the hero — they inherit importance from events they only mention. Evidence: labeled eval session 2 (sift-api#204) | $0 (no LLM) | SETTLED (Aug 2026) |
 
 **Total estimated monthly cost: ~$30-50/mo**
 

--- a/docs/RANKING_SIGNALS.md
+++ b/docs/RANKING_SIGNALS.md
@@ -34,6 +34,28 @@ corroboration). The response, deterministic and $0:
 - Known residual: opinion not declared in URL/title. An LLM genre key on
   the context call is the named follow-up if the residual matters; the
   second labeling session will say.
+
+## Stage 5 — roundup containers are not stories (added from eval evidence)
+
+Session 2 of the eval (sift-api#204, pairs drawn from the live top feed)
+found program episodes and daily briefs sitting near the top of 'top':
+"Morning news brief" at importance 4, Bloomberg show episodes, NYT's "The
+Evening". They are **containers** — their summaries recite the day's
+biggest events, so the importance model scores the events rather than the
+item. The original doom-feed session's pinned #1, "D4vd Charged with
+Murder | Case by Case", was the same defect wearing a crime headline.
+
+- `articles.is_roundup` (migration 024), set at store time by
+  `services/genre.py:detect_roundup` from title patterns measured on prod
+  first: `| <Show> M/D/YYYY` episodes, `| <Show>` segment suffixes, named
+  briefs, dated program titles, NPR's `X. And, Y` two-part brief. Fox's
+  "MORNING GLORY:" is excluded — an op-ed column, already `is_opinion`.
+- Ranking: × `ROUNDUP_DAMPENER` (0.4) in the SQL pools and the client
+  re-rank; never takes the hero. Harder than the opinion dampener because
+  a container is never the best version of a story — the underlying event
+  is also in the feed, reported directly.
+- Not applied to stories: clustering works on articles, and a container
+  rarely clusters. Revisit if one ever leads a story.
 **Owns:** what the feed ranking is allowed to value, and why. Companion to
 [`DECISIONS.md`](./DECISIONS.md) D45 (rank by civic impact) and D48 (cap and
 dampen, never hide).

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -86,6 +86,17 @@ const CIVIC_BOOST_SQL = `(1 + ${CIVIC_BOOST} * LEAST(${CIVIC_WEIGHT_SQL}, 3))`;
 const OPINION_DAMPENER = 0.6;
 const OPINION_DAMPENER_SQL = `CASE WHEN is_opinion THEN ${OPINION_DAMPENER} ELSE 1.0 END`;
 
+// Ranking v2 stage 5 (docs/RANKING_SIGNALS.md): roundup containers are not
+// stories. Program episodes and daily briefs ("Morning news brief", "| The
+// Opening Trade 8/11/2026") inherit importance from the events their
+// summaries mention — the second labeled eval (sift-api#204) caught them
+// near the top of 'top', and the original doom-feed's pinned #1 was one.
+// Harder than the opinion dampener (0.4 vs 0.6) because a container is
+// never the best version of a story: the underlying event is also in the
+// feed, reported directly. Set to 1.0 to revert.
+const ROUNDUP_DAMPENER = 0.4;
+const ROUNDUP_DAMPENER_SQL = `CASE WHEN is_roundup THEN ${ROUNDUP_DAMPENER} ELSE 1.0 END`;
+
 // Ranking v2 stage 1 (docs/RANKING_SIGNALS.md): stories rank on a SATURATING
 // corroboration curve, 3 + STORY_BOOST × ln(1 + sources), in both the SQL
 // pool and the client re-rank — previously the pool used raw count × decay
@@ -113,6 +124,7 @@ export interface DbArticle {
   importance_score: number | null;
   tone: string | null; // grim | neutral | light | NULL (migrations/020); NULL = neutral
   is_opinion: boolean; // outlet-declared opinion marker (migrations/023)
+  is_roundup: boolean; // program-episode/brief container (migrations/024)
   created_at: Date;
   // Civic-literacy MVP additions. Both columns added in
   // sift-api/migrations/005_context_primer_and_reading_levels.sql.
@@ -138,7 +150,7 @@ export async function getArticlesByCategory(
 ): Promise<DbArticle[]> {
   const result = await pool.query<DbArticle>(
     `SELECT id, title, summary, source_url, source_name, image_url,
-            category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at
+            category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at
      FROM articles
      WHERE category = $1 AND from_search = false
        AND summary IS NOT NULL AND summary != ''
@@ -150,7 +162,8 @@ export async function getArticlesByCategory(
        EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700)) *
        ${GRIM_DAMPENER_SQL} *
        ${CIVIC_BOOST_SQL} *
-       ${OPINION_DAMPENER_SQL}
+       ${OPINION_DAMPENER_SQL} *
+       ${ROUNDUP_DAMPENER_SQL}
      DESC NULLS LAST
      LIMIT $2`,
     [category, limit]
@@ -236,7 +249,7 @@ export async function getStoriesWithArticles(
     try {
       const storyArticlesResult = await pool.query<DbStoryArticle>(
         `SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at, story_id
+                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at, story_id
          FROM articles
          WHERE story_id = ANY($1::text[])
            AND from_search = false
@@ -271,12 +284,13 @@ export async function getStoriesWithArticles(
     const standaloneResult = await pool.query<DbArticle>(
       `WITH scored AS (
          SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at,
+                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at,
                 COALESCE(importance_score, 3)::float *
                 EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700)) *
                 ${GRIM_DAMPENER_SQL} *
                 ${CIVIC_BOOST_SQL} *
-                ${OPINION_DAMPENER_SQL}
+                ${OPINION_DAMPENER_SQL} *
+                ${ROUNDUP_DAMPENER_SQL}
                 AS rank_score
          FROM articles
          WHERE category = $1 AND from_search = false
@@ -294,7 +308,7 @@ export async function getStoriesWithArticles(
          FROM scored
        )
        SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at
+              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at
        FROM capped
        WHERE source_rank <= ${MAX_ARTICLES_PER_SOURCE}
        ORDER BY rank_score DESC
@@ -308,12 +322,13 @@ export async function getStoriesWithArticles(
     const fallback = await pool.query<DbArticle>(
       `WITH scored AS (
          SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at,
+                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at,
                 COALESCE(importance_score, 3)::float *
                 EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700)) *
                 ${GRIM_DAMPENER_SQL} *
                 ${CIVIC_BOOST_SQL} *
-                ${OPINION_DAMPENER_SQL}
+                ${OPINION_DAMPENER_SQL} *
+                ${ROUNDUP_DAMPENER_SQL}
                 AS rank_score
          FROM articles
          WHERE category = $1 AND from_search = false
@@ -330,7 +345,7 @@ export async function getStoriesWithArticles(
          FROM scored
        )
        SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at
+              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at
        FROM capped
        WHERE source_rank <= ${MAX_ARTICLES_PER_SOURCE}
        ORDER BY rank_score DESC
@@ -362,7 +377,7 @@ export async function getTopStoryForLanding(): Promise<DbArticle | null> {
     const result = await pool.query<DbArticle>(
       `WITH ranked AS (
          SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at,
+                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at,
                 COALESCE(importance_score, 3)::float *
                 EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700))
                 AS rank_score
@@ -370,6 +385,7 @@ export async function getTopStoryForLanding(): Promise<DbArticle | null> {
          WHERE category = 'top'
            AND from_search = false
            AND is_opinion = false
+           AND is_roundup = false
            AND image_url IS NOT NULL
            AND summary IS NOT NULL AND summary != ''
            AND LOWER(summary) NOT LIKE 'unable to provide%'
@@ -379,7 +395,7 @@ export async function getTopStoryForLanding(): Promise<DbArticle | null> {
          LIMIT 12
        )
        SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, context_primer, reading_levels, created_at
+              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at
        FROM ranked
        ORDER BY
          CASE WHEN tone IS DISTINCT FROM 'grim'

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -43,6 +43,8 @@ export interface Article {
   tone?: ArticleTone;
   /** Outlet-declared opinion piece (migrations/023); absent = reported. */
   isOpinion?: boolean;
+  /** Program-episode or daily-brief container (migrations/024). */
+  isRoundup?: boolean;
   /**
    * AI-generated "What you should know first" panel — civic-literacy MVP.
    * Populated by sift-api's primer_generator. Null/undefined when the article


### PR DESCRIPTION
Consume side of [sift-api#205](https://github.com/kristenmartino/sift-api/pull/205) (D50). **Merge after that migration is live** — the queries reference `is_roundup` unguarded.

Evidence: labeled eval session 2 ([sift-api#204](https://github.com/kristenmartino/sift-api/pull/204)) — briefs and show episodes ranked near the top of 'top' because their summaries recite the day's events. `ROUNDUP_DAMPENER = 0.4` (harder than opinion's 0.6: a container is never the best version of a story), plus hero exclusion. Not applied to stories — containers rarely cluster; documented rather than guessed.

tsc clean; 30 suites / 508 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)