### PR TITLE
Ranking v2 stage 6: the front page is for news

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -50,6 +50,7 @@ const MOCK_DB_ROWS: DbArticle[] = [
     tone: null,
     is_opinion: false,
     is_roundup: false,
+    genre: null,
     context_primer: null,
     reading_levels: null,
     created_at: new Date("2026-03-28T10:00:00Z"),
@@ -69,6 +70,7 @@ const MOCK_DB_ROWS: DbArticle[] = [
     tone: null,
     is_opinion: false,
     is_roundup: false,
+    genre: null,
     context_primer: null,
     reading_levels: null,
     created_at: new Date("2026-03-28T08:00:00Z"),
@@ -298,7 +300,7 @@ describe("GET /api/news", () => {
         storyArticles: {},
         standaloneArticles: [
           { ...MOCK_DB_ROWS[0], tone: "grim" },
-          { ...MOCK_DB_ROWS[1], tone: "invalid-value", is_opinion: true, is_roundup: true },
+          { ...MOCK_DB_ROWS[1], tone: "invalid-value", is_opinion: true, is_roundup: true, genre: "soft" },
         ],
       });
 
@@ -317,6 +319,9 @@ describe("GET /api/news", () => {
       expect(body.articles[1].isOpinion).toBe(true);
       expect(body.articles[1].isRoundup).toBe(true);
       expect(body.articles[0].isRoundup).toBeUndefined();
+      expect(body.articles[1].genre).toBe("soft");
+      // "news" is the default and never travels on the wire.
+      expect(body.articles[0].genre).toBeUndefined();
     });
   });
 

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -104,6 +104,7 @@ export async function GET(request: NextRequest) {
         ...(isArticleTone(row.tone) ? { tone: row.tone } : {}),
         ...(row.is_opinion ? { isOpinion: true } : {}),
         ...(row.is_roundup ? { isRoundup: true } : {}),
+        ...(row.genre && row.genre !== "news" ? { genre: row.genre as "feature" | "soft" } : {}),
         ...(primer ? { contextPrimer: primer } : {}),
         ...(outlet ? { outlet } : {}),
         ...(entityLinks.length > 0 ? { entityLinks } : {}),

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -358,6 +358,14 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     const OPINION_DAMPENER = 0.6;
     // Stage 5: program episodes and briefs are containers, not stories.
     const ROUNDUP_DAMPENER = 0.4;
+    // Stage 6 (mirrors lib/db.ts): 'top' is the front page, so
+    // low-consequence items are held back there and nowhere else; and
+    // non-news genres rank lower as standalone articles. Neither applies
+    // to stories — corroboration is the story-level judgment, so a
+    // feature or tabloid piece inside a multi-outlet story still shows
+    // under "how this was covered".
+    const LOW_IMPORTANCE_DAMPENER = 0.35;
+    const NON_NEWS_DAMPENER = 0.5;
     // Age against the fetch timestamp, not wall clock — ranking must be a pure
     // function of the data snapshot, and the snapshot carries its own "now".
     const now = lastUpdated ? lastUpdated.getTime() : 0;
@@ -387,8 +395,11 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
       const damp = item.data.tone === "grim" && importance <= 3 ? GRIM_DAMPENER : 1;
       const opDamp = item.data.isOpinion ? OPINION_DAMPENER : 1;
       const roundDamp = item.data.isRoundup ? ROUNDUP_DAMPENER : 1;
+      const lowDamp =
+        activeCategory === "top" && importance <= 2 ? LOW_IMPORTANCE_DAMPENER : 1;
+      const genreDamp = item.data.genre ? NON_NEWS_DAMPENER : 1;
       const civic = civicBoost(weightedCivicLinks(item.data.entityLinks));
-      return importance * decay * damp * civic * opDamp * roundDamp;
+      return importance * decay * damp * civic * opDamp * roundDamp * lowDamp * genreDamp;
     }
 
     items.sort((a, b) => rankScore(b) - rankScore(a));

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -56,6 +56,7 @@
 | D48 | Feed balance: cap and dampen, never hide | One outlet caps at 6 of the 50-article pool; low-importance grim items (tone=grim, importance ≤3) rank ×0.6 (≈12h older); importance 4–5 somber news ranks untouched. Answer to the doom-stacked 'top' feed (NYP held 23/50) | ~$0.05/day (tone tag rides the existing Haiku call) | SETTLED (Aug 2026); fully live 2026-08-10 — cap, dampener, non-grim hero, tone backfilled (sift#211/#212, sift-api#186/#187/#188) |
 | D49 | Opinion is not news ranking | Outlet-declared opinion (URL/title markers, deterministic) ranks ×0.6 at any importance, never takes the hero, and doesn't count toward the cross-spectrum bonus. Evidence: first labeled ranking eval (sift-api#200) — half the overrules rejected op-eds ranked as news | $0 (no LLM) | SETTLED (Aug 2026) |
 | D50 | Roundup containers are not stories | Program episodes and daily briefs (title-pattern detected, deterministic) rank ×0.4 and never take the hero — they inherit importance from events they only mention. Evidence: labeled eval session 2 (sift-api#204) | $0 (no LLM) | SETTLED (Aug 2026) |
+| D51 | The front page is for news | 'top' holds a higher bar than topical tabs: importance ≤2 ranks ×0.35 there (0 = hard floor), and non-news genres (feature/soft, LLM-tagged on the existing call) rank ×0.5 as standalone articles. Story ranking untouched — corroborated coverage keeps tabloid members visible under "how this was covered" | ~$0 (fourth key on an existing call) | SETTLED (Aug 2026) |
 
 **Total estimated monthly cost: ~$30-50/mo**
 

--- a/docs/RANKING_SIGNALS.md
+++ b/docs/RANKING_SIGNALS.md
@@ -56,6 +56,39 @@ Murder | Case by Case", was the same defect wearing a crime headline.
   is also in the feed, reported directly.
 - Not applied to stories: clustering works on articles, and a container
   rarely clusters. Revisit if one ever leads a story.
+
+## Stage 6 — the front page is for news (added from product direction)
+
+*"Sift should be showing important news, not so much entertainment."*
+Measured 2026-08-11 before building: **303 of 489 'top' articles in a week
+scored importance ≤ 2**, and only 8 carried `tone='light'`. The front page
+was not filling with celebrity content — it was filling with **crime
+spectacle** ("Naked champion swimmer accused of killing security guard",
+"Penthouse Pet calls ex-hubby from jail"), *correctly* scored 1–2 and
+surfacing purely on freshness. Two layers, because two different things
+were wrong:
+
+| Layer | Catches | Mechanism |
+|---|---|---|
+| Low-importance weight | Spectacle that importance already scores 1–2 | `category='top' AND importance ≤ 2` → × `LOW_IMPORTANCE_DAMPENER` (0.35) |
+| Genre | Non-news that legitimately scores 3+ | `genre IN ('feature','soft')` → × `NON_NEWS_DAMPENER` (0.5) |
+
+- **Scoped to 'top'.** An importance-2 sports result belongs in Sports; the
+  topical tabs remain complete coverage. Only the front page holds the bar.
+- **Set `LOW_IMPORTANCE_DAMPENER` to 0 for a hard floor** (importance ≤ 2
+  never appears in 'top'). 0.35 is the graceful version: the 2/3 boundary
+  is exactly where a mis-scored article would be silently lost, and
+  non-grim importance scores have not been re-scored under the
+  scope-of-consequence rubric.
+- **Genre applies to standalone articles only** — deliberately absent from
+  the stories query. Stories rank on corroboration, so a feature or
+  tabloid piece inside a multi-outlet story does not drag the story down
+  and still appears in its source list ("how this was covered"). A lone
+  soft article standing on its own is what gets demoted, never coverage of
+  a real event. Neither weight touches story ranking.
+- Genre is stored as three values (`news | feature | soft`) while the
+  policy treats feature and soft alike, so the two can be split later
+  without a re-backfill.
 **Owns:** what the feed ranking is allowed to value, and why. Companion to
 [`DECISIONS.md`](./DECISIONS.md) D45 (rank by civic impact) and D48 (cap and
 dampen, never hide).

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -97,6 +97,33 @@ const OPINION_DAMPENER_SQL = `CASE WHEN is_opinion THEN ${OPINION_DAMPENER} ELSE
 const ROUNDUP_DAMPENER = 0.4;
 const ROUNDUP_DAMPENER_SQL = `CASE WHEN is_roundup THEN ${ROUNDUP_DAMPENER} ELSE 1.0 END`;
 
+// Ranking v2 stage 6 (docs/RANKING_SIGNALS.md): 'top' is the front page,
+// so it holds a higher bar than the topical tabs. Measured 2026-08-11:
+// 303 of 489 'top' articles in a week scored importance <= 2, and only 8
+// were tone='light' — the front page was filling with crime spectacle
+// ("Naked champion swimmer accused of killing security guard"), correctly
+// scored 1-2 and surfacing purely on freshness.
+//
+// Scoped to 'top' by design: an importance-2 sports result belongs in
+// Sports, and the topical tabs are complete coverage. Set to 0 to turn
+// this into a hard floor (importance <= 2 never appears in 'top'); 0.35
+// is the graceful version, because the 2/3 boundary is exactly where a
+// mis-scored article would be silently lost.
+const LOW_IMPORTANCE_DAMPENER = 0.35;
+const LOW_IMPORTANCE_SQL = `CASE WHEN category = 'top' AND COALESCE(importance_score, 3) <= 2 THEN ${LOW_IMPORTANCE_DAMPENER} ELSE 1.0 END`;
+
+// Stage 6, second half: genre (articles.genre, migrations/025). Magazine
+// features and soft/curiosity pieces are not the front page's job even
+// when they score importance 3+. NULL/'news' is untouched.
+//
+// STANDALONE ARTICLES ONLY — deliberately absent from the stories query.
+// Stories rank on corroboration, so a feature or tabloid piece inside a
+// multi-outlet story does not drag the story down and still appears in
+// its source list ("how this was covered"). A lone soft article standing
+// on its own is the thing being demoted, not coverage of a real event.
+const NON_NEWS_DAMPENER = 0.5;
+const NON_NEWS_SQL = `CASE WHEN genre IN ('feature', 'soft') THEN ${NON_NEWS_DAMPENER} ELSE 1.0 END`;
+
 // Ranking v2 stage 1 (docs/RANKING_SIGNALS.md): stories rank on a SATURATING
 // corroboration curve, 3 + STORY_BOOST × ln(1 + sources), in both the SQL
 // pool and the client re-rank — previously the pool used raw count × decay
@@ -125,6 +152,7 @@ export interface DbArticle {
   tone: string | null; // grim | neutral | light | NULL (migrations/020); NULL = neutral
   is_opinion: boolean; // outlet-declared opinion marker (migrations/023)
   is_roundup: boolean; // program-episode/brief container (migrations/024)
+  genre: string | null; // news | feature | soft | NULL (migrations/025); NULL = news
   created_at: Date;
   // Civic-literacy MVP additions. Both columns added in
   // sift-api/migrations/005_context_primer_and_reading_levels.sql.
@@ -150,7 +178,7 @@ export async function getArticlesByCategory(
 ): Promise<DbArticle[]> {
   const result = await pool.query<DbArticle>(
     `SELECT id, title, summary, source_url, source_name, image_url,
-            category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at
+            category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, genre, context_primer, reading_levels, created_at
      FROM articles
      WHERE category = $1 AND from_search = false
        AND summary IS NOT NULL AND summary != ''
@@ -163,7 +191,9 @@ export async function getArticlesByCategory(
        ${GRIM_DAMPENER_SQL} *
        ${CIVIC_BOOST_SQL} *
        ${OPINION_DAMPENER_SQL} *
-       ${ROUNDUP_DAMPENER_SQL}
+       ${ROUNDUP_DAMPENER_SQL} *
+       ${LOW_IMPORTANCE_SQL} *
+       ${NON_NEWS_SQL}
      DESC NULLS LAST
      LIMIT $2`,
     [category, limit]
@@ -249,7 +279,7 @@ export async function getStoriesWithArticles(
     try {
       const storyArticlesResult = await pool.query<DbStoryArticle>(
         `SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at, story_id
+                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, genre, context_primer, reading_levels, created_at, story_id
          FROM articles
          WHERE story_id = ANY($1::text[])
            AND from_search = false
@@ -284,13 +314,15 @@ export async function getStoriesWithArticles(
     const standaloneResult = await pool.query<DbArticle>(
       `WITH scored AS (
          SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at,
+                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, genre, context_primer, reading_levels, created_at,
                 COALESCE(importance_score, 3)::float *
                 EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700)) *
                 ${GRIM_DAMPENER_SQL} *
                 ${CIVIC_BOOST_SQL} *
                 ${OPINION_DAMPENER_SQL} *
-                ${ROUNDUP_DAMPENER_SQL}
+                ${ROUNDUP_DAMPENER_SQL} *
+                ${LOW_IMPORTANCE_SQL} *
+                ${NON_NEWS_SQL}
                 AS rank_score
          FROM articles
          WHERE category = $1 AND from_search = false
@@ -308,7 +340,7 @@ export async function getStoriesWithArticles(
          FROM scored
        )
        SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at
+              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, genre, context_primer, reading_levels, created_at
        FROM capped
        WHERE source_rank <= ${MAX_ARTICLES_PER_SOURCE}
        ORDER BY rank_score DESC
@@ -322,13 +354,15 @@ export async function getStoriesWithArticles(
     const fallback = await pool.query<DbArticle>(
       `WITH scored AS (
          SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at,
+                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, genre, context_primer, reading_levels, created_at,
                 COALESCE(importance_score, 3)::float *
                 EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700)) *
                 ${GRIM_DAMPENER_SQL} *
                 ${CIVIC_BOOST_SQL} *
                 ${OPINION_DAMPENER_SQL} *
-                ${ROUNDUP_DAMPENER_SQL}
+                ${ROUNDUP_DAMPENER_SQL} *
+                ${LOW_IMPORTANCE_SQL} *
+                ${NON_NEWS_SQL}
                 AS rank_score
          FROM articles
          WHERE category = $1 AND from_search = false
@@ -345,7 +379,7 @@ export async function getStoriesWithArticles(
          FROM scored
        )
        SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at
+              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, genre, context_primer, reading_levels, created_at
        FROM capped
        WHERE source_rank <= ${MAX_ARTICLES_PER_SOURCE}
        ORDER BY rank_score DESC
@@ -377,7 +411,7 @@ export async function getTopStoryForLanding(): Promise<DbArticle | null> {
     const result = await pool.query<DbArticle>(
       `WITH ranked AS (
          SELECT id, title, summary, source_url, source_name, image_url,
-                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at,
+                category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, genre, context_primer, reading_levels, created_at,
                 COALESCE(importance_score, 3)::float *
                 EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(published_date, created_at))), 0) / 86400.0, 700))
                 AS rank_score
@@ -386,6 +420,7 @@ export async function getTopStoryForLanding(): Promise<DbArticle | null> {
            AND from_search = false
            AND is_opinion = false
            AND is_roundup = false
+           AND (genre IS NULL OR genre = 'news')
            AND image_url IS NOT NULL
            AND summary IS NOT NULL AND summary != ''
            AND LOWER(summary) NOT LIKE 'unable to provide%'
@@ -395,7 +430,7 @@ export async function getTopStoryForLanding(): Promise<DbArticle | null> {
          LIMIT 12
        )
        SELECT id, title, summary, source_url, source_name, image_url,
-              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, context_primer, reading_levels, created_at
+              category, published_date, read_time, why_it_matters, importance_score, tone, is_opinion, is_roundup, genre, context_primer, reading_levels, created_at
        FROM ranked
        ORDER BY
          CASE WHEN tone IS DISTINCT FROM 'grim'

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -46,6 +46,13 @@ export interface Article {
   /** Program-episode or daily-brief container (migrations/024). */
   isRoundup?: boolean;
   /**
+   * Kind of writing (migrations/025): "feature" = magazine-style narrative,
+   * "soft" = curiosity/lifestyle/service. Absent = news. Distinct from
+   * importance — a feature can be consequential and still not be the front
+   * page's job. Ranking uses it for standalone articles only.
+   */
+  genre?: "news" | "feature" | "soft";
+  /**
    * AI-generated "What you should know first" panel — civic-literacy MVP.
    * Populated by sift-api's primer_generator. Null/undefined when the article
    * is short enough to need no context, or when the pipeline hasn't run for it


### PR DESCRIPTION
Consume side of [sift-api#208](https://github.com/kristenmartino/sift-api/pull/208) (D51). **Merge after that migration is live.**

Measured first: **303 of 489 'top' articles in a week scored importance ≤2**, only 8 `tone='light'` — the front page was filling with crime spectacle, not celebrity content, and those scores were *already correct*. So two weights for two different problems:

| Layer | Catches | Mechanism |
|---|---|---|
| `LOW_IMPORTANCE_DAMPENER` 0.35 | spectacle importance already scores 1–2 | `category='top' AND importance ≤ 2` |
| `NON_NEWS_DAMPENER` 0.5 | non-news that legitimately scores 3+ | `genre IN ('feature','soft')` |

- **Scoped to 'top'** — an importance-2 sports result belongs in Sports; topical tabs stay complete.
- **`LOW_IMPORTANCE_DAMPENER = 0` turns it into a hard floor.** 0.35 ships first because the 2/3 boundary is exactly where a mis-scored article would vanish, and non-grim scores haven't been re-scored under the scope rubric.
- **Genre is standalone-only, absent from the stories query.** Stories rank on corroboration, so a tabloid or feature piece inside a multi-outlet story keeps its place under "how this was covered" — only a lone soft article gets demoted.

tsc clean; 30 suites / 508 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)