### PR TITLE
Make coverage actually order the feed: STORY_BOOST 0.8 → 2.0, STORY_BASE 3 → 1

### DIFF
--- a/__tests__/rankingConstants.test.ts
+++ b/__tests__/rankingConstants.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The story corroboration constants live in two places and must agree.
+ *
+ * `lib/db.ts` truncates the pool to 20 under one formula; `NewsAggregator.tsx`
+ * re-ranks what survives under another. Ranking v2 stage 1 exists *because*
+ * they once disagreed — the pool was cut under an order no reader ever saw.
+ * Nothing in the type system stops that recurring, and it fails silently:
+ * both files compile, both run, and the only symptom is a feed ordered
+ * differently than it was selected.
+ *
+ * A third copy lives in `sift-api/scripts/explain_feed_queries.py`, which
+ * mirrors the deployed SQL byte for byte so the perf diagnostic measures the
+ * query that actually runs. It is in another repo and cannot be checked from
+ * here; it is named in both files' comments instead.
+ *
+ * These read source text rather than importing, because both constants are
+ * module-private — and exporting them purely to be testable would widen the
+ * API to prove a point about copy-paste.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const root = join(__dirname, "..");
+const dbSrc = readFileSync(join(root, "lib/db.ts"), "utf8");
+const clientSrc = readFileSync(join(root, "components/NewsAggregator.tsx"), "utf8");
+
+function constant(src: string, name: string): number {
+  const m = src.match(new RegExp(`const\\s+${name}\\s*=\\s*([0-9.]+)\\s*;`));
+  if (!m) throw new Error(`${name} not found — was it renamed or inlined?`);
+  return Number(m[1]);
+}
+
+describe("story corroboration constants", () => {
+  it("STORY_BASE matches between the SQL pool and the client re-rank", () => {
+    expect(constant(clientSrc, "STORY_BASE")).toBe(constant(dbSrc, "STORY_BASE"));
+  });
+
+  it("STORY_BOOST matches between the SQL pool and the client re-rank", () => {
+    expect(constant(clientSrc, "STORY_BOOST")).toBe(constant(dbSrc, "STORY_BOOST"));
+  });
+
+  it("both formulas use the constants rather than an inlined number", () => {
+    // The base was a literal `3` inside both expressions until 2026-08-11,
+    // which is how it stayed unexamined while being 77% of the score.
+    expect(dbSrc).toContain("${STORY_BASE} + ${STORY_BOOST} * LN(1 + COUNT(DISTINCT a.source_name))");
+    expect(clientSrc).toContain("STORY_BASE + STORY_BOOST * Math.log(1 + item.data.outletCount)");
+  });
+
+  it("ranks on distinct outlets, not article rows", () => {
+    // One high-volume outlet filing four pieces is not four-outlet
+    // corroboration. 29% of stories had more articles than outlets.
+    expect(dbSrc).toContain("LN(1 + COUNT(DISTINCT a.source_name))");
+    expect(clientSrc).toContain("item.data.outletCount");
+  });
+
+  it("keeps corroboration a meaningful share of the story score", () => {
+    // The failure this guards is a base large enough to flatten the curve:
+    // at (3, 0.8) the whole 2→18-outlet range was worth 7.7h of freshness
+    // against EXP(-age_days), so recency was the only real signal.
+    const base = constant(dbSrc, "STORY_BASE");
+    const boost = constant(dbSrc, "STORY_BOOST");
+    const hours = 24 * Math.log(
+      (base + boost * Math.log(19)) / (base + boost * Math.log(3))
+    );
+    expect(hours).toBeGreaterThan(12);
+  });
+});

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -347,11 +347,20 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     // major news.
     const GRIM_DAMPENER = 0.6;
     // Ranking v2 stage 1 (docs/RANKING_SIGNALS.md; constants mirror lib/db.ts):
-    // stories score 3 + STORY_BOOST·ln(1 + sources) — the same saturating
-    // curve the SQL pool now truncates under — times a small cross-spectrum
-    // bonus per occupied L/C/R bucket beyond the first (spectrumBuckets is
-    // derived at the API boundary from framings' AllSides ratings).
-    const STORY_BOOST = 0.8;
+    // stories score STORY_BASE + STORY_BOOST·ln(1 + outlets) — the same
+    // saturating curve the SQL pool truncates under — times a small
+    // cross-spectrum bonus per occupied L/C/R bucket beyond the first
+    // (spectrumBuckets is derived at the API boundary from framings' AllSides
+    // ratings).
+    //
+    // BOTH constants must match lib/db.ts exactly. They were (3, 0.8) until
+    // 2026-08-11; the reasoning for (1, 2.0) — and why the base had to move
+    // with the boost rather than the boost alone — is documented there.
+    // Short version: STORY_BASE sets stories against standalone articles,
+    // which score on the 1-5 importance scale, so raising only the boost
+    // crowds articles out of the feed instead of ordering stories by coverage.
+    const STORY_BASE = 1;
+    const STORY_BOOST = 2.0;
     const SPECTRUM_BOOST = 0.1;
     // Stage 4 (mirrors OPINION_DAMPENER in lib/db.ts): outlet-declared
     // opinion ranks x0.6 at any importance - op-eds are not top stories.
@@ -382,7 +391,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
         // two formulas must move together — v2 stage 1 exists because they
         // once disagreed, and the LIMIT 20 truncation then happened under an
         // order no reader ever saw.
-        const sourceScore = 3 + STORY_BOOST * Math.log(1 + item.data.outletCount);
+        const sourceScore = STORY_BASE + STORY_BOOST * Math.log(1 + item.data.outletCount);
         const spectrum = 1 + SPECTRUM_BOOST * Math.max(0, (item.data.spectrumBuckets ?? 1) - 1);
         // Corroboration is the story-level analog of importance: a
         // two-outlet grim story dampens, a five-outlet disaster does not.

--- a/docs/RANKING_SIGNALS.md
+++ b/docs/RANKING_SIGNALS.md
@@ -168,29 +168,49 @@ same wire pile-up the `ln` was chosen to damp, arriving through the variable
 rather than the shape. `articleCount` is still what the card displays; the two
 are separate fields end to end now.
 
-**Corroboration is currently a very weak ranking signal, and that is the open
-question this raised.** The term spans only 3.88 (2 sources) to 5.36 (18) — a
-1.38× range — against `decay = EXP(-age_days)`. So **the entire 2 → 18 range is
-worth 7.7 hours of freshness**, and the base constant `3` is 77% of the score at
-n = 2. Replaying the switch to distinct outlets against prod moved 0 of 20 in
-every category except politics, which moved one story — not because the variable
-was wrong, but because the term barely orders anything.
+**Corroboration was a very weak ranking signal until 2026-08-11.** At the
+original `(base 3, boost 0.8)` the term spanned only 3.88 (2 outlets) to 5.36
+(18) — a 1.38× range — against `decay = EXP(-age_days)`. So **the entire 2 → 18
+range was worth 7.7 hours of freshness**, and the base constant was 77% of the
+score at n = 2. Replaying the switch to distinct outlets moved 0 of 20 in every
+category except politics, which moved one story — not because the variable was
+wrong, but because the term barely ordered anything.
 
-Making well-covered stories actually surface is therefore a **weighting**
-decision, not a variable one. Measured options, as "how many hours older an
-18-outlet story can be and still outrank a 2-outlet one":
+### The weighting: `(1, 2.0)`, and why the base had to move too
 
-| base | boost | hours |
-|---:|---:|---:|
-| 3 | 0.8 | 7.7 *(today)* |
-| 3 | 1.6 | 11.6 |
-| 1 | 0.8 | 13.9 |
-| 1 | 1.6 | 17.5 |
-| 0 | 1.0 | 23.7 |
+**These two constants do different jobs, and only one of them is about
+coverage.** `STORY_BASE` sets where stories sit against **standalone articles**,
+which score `importance × decay` on a 1–5 scale — so raising `STORY_BOOST`
+alone lifts every story against every article at once. That reorders the feed,
+but mostly by crowding articles out, not by ranking stories on coverage.
 
-For scale, decay halves a score every 16.6 hours. This is a product call about
-how much corroboration should outweigh recency — deliberately left unmade here.
-See `sift-api/docs/SOURCE_SCALING.md`.
+Replayed against prod over six categories (`top`, `politics`, `world`,
+`business`, `technology`, `sports`), scoring stories and standalone articles in
+one list exactly as `NewsAggregator.rankScore` does:
+
+| base | boost | avg stories in top 20 | story-vs-story reordering | 2 → 18 |
+|---:|---:|---:|---:|---:|
+| 3 | 0.8 | 5.8 | — | 7.7h |
+| 3 | 1.6 | **8.5** | 32 | 11.6h |
+| 2.5 | 1.6 | 7.5 | 36 | 12.6h |
+| 2 | 1.6 | 6.8 | 42 | 13.9h |
+| 2 | 2.0 | 7.7 | 46 | 15.1h |
+| 1.5 | 2.0 | 7.2 | 50 | 16.6h |
+| **1** | **2.0** | **5.8** | **53** | **18.4h** |
+
+Boost-only at 1.6 buys 32 units of reordering by pushing the story share from
+5.8 to 8.5 per top-20 — sports went 9 → 14, and 19 of 20 at boost 2.5. `(1, 2.0)`
+buys **53** at a story share **identical to today's**. Coverage moves the feed;
+the story/article mix does not move at all.
+
+Sanity at the shipped constants: a 2-outlet story scores 3.20 (just over an
+importance-3 article), an 18-outlet story 6.89 (above the importance-5 ceiling),
+and a thinly-covered grim story lands at 1.92 under D48's dampener. The `ln`
+still saturates, so a wire pile-up cannot lap a 6-outlet story — that guard was
+never what was wrong.
+
+For scale, decay halves a score every 16.6 hours. See
+`sift-api/docs/SOURCE_SCALING.md`.
 
 ### Stage 2 — civic-entity density (the D45 signal)
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -133,9 +133,40 @@ const NON_NEWS_SQL = `CASE WHEN genre IN ('feature', 'soft') THEN ${NON_NEWS_DAM
 // applied at the API/client layer only (it needs framings' outlet ratings);
 // its ≤1.2× range cannot meaningfully change a 20-deep pool truncation.
 // STORY_BOOST = 0.5/ln(2) ≈ 0.72 would reproduce the old client score for a
-// 2-source story; 0.8 sits close to that while giving big stories a little
+// 2-source story; 0.8 sat close to that while giving big stories a little
 // more headroom (10 sources → 4.9, vs the old hard cap at 5).
-const STORY_BOOST = 0.8;
+//
+// RAISED 0.8 → 2.0 AND THE BASE DROPPED 3 → 1 ON 2026-08-11, TOGETHER.
+//
+// At (3, 0.8) corroboration barely ordered anything: the term spanned 3.88 (2
+// outlets) to 5.36 (18) — a 1.38× range — against decay = EXP(-age_days), so
+// the entire 2 → 18 range was worth **7.7 hours of freshness** and the base
+// constant was 77% of the score at n=2. Recency was the ranking signal;
+// coverage was rounding error.
+//
+// The base has to move with the boost, because these two numbers do different
+// jobs and only one of them is about coverage. `STORY_BASE` sets where stories
+// sit against STANDALONE ARTICLES, which score `importance × decay` on a 1-5
+// scale — so raising the boost alone lifts every story against every article
+// at once. Replayed against prod over six categories:
+//
+//   base boost | avg stories in top-20 | story-vs-story reordering | 2→18
+//   3    0.8   | 5.8                   | —                         |  7.7h
+//   3    1.6   | 8.5  ← floods         | 32                        | 11.6h
+//   1    2.0   | 5.8  ← unchanged      | 53                        | 18.4h
+//
+// Bumping the boost alone bought reordering by crowding articles out (sports
+// went 9 → 14 of 20, and 19 of 20 at 2.5). Lowering the base in step buys
+// *more* reordering at an identical story/article mix. Coverage now moves the
+// feed; the mix does not move at all, which is the point.
+//
+// Sanity at the new constants: a 2-outlet story scores 3.20 (just over an
+// importance-3 article), an 18-outlet story 6.89 (over the importance-5
+// ceiling). A thinly-covered grim story still lands under D48's dampener at
+// 1.92. The `ln` still saturates, so a wire pile-up cannot lap a 6-outlet
+// story — that guard was never the problem.
+const STORY_BASE = 1;
+const STORY_BOOST = 2.0;
 
 // "sources" in that curve means DISTINCT OUTLETS, not article rows. It counted
 // COUNT(a.id) until 2026-08-11, which is a different thing: measured over 7
@@ -285,7 +316,7 @@ export async function getStoriesWithArticles(
        GROUP BY s.id
        HAVING COUNT(a.id) >= 2
        ORDER BY
-         (3 + ${STORY_BOOST} * LN(1 + COUNT(DISTINCT a.source_name)))::float *
+         (${STORY_BASE} + ${STORY_BOOST} * LN(1 + COUNT(DISTINCT a.source_name)))::float *
          EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(s.published_date, s.created_at))), 0) / 86400.0, 700))
        DESC NULLS LAST
        LIMIT 20`,


### PR DESCRIPTION
Corroboration was very nearly not a ranking signal. At `(base 3, boost 0.8)` the term spanned 3.88 (2 outlets) to 5.36 (18) — a **1.38× range** — against `decay = EXP(-age_days)`.

> The entire 2 → 18 outlet range was worth **7.7 hours of freshness**, and the base constant was **77% of the score** at n=2.

Recency ordered the feed. Coverage was rounding error.

## Why the base had to move with the boost

**These two constants do different jobs, and only one is about coverage.** `STORY_BASE` sets where stories sit against **standalone articles**, which score `importance × decay` on a 1–5 scale — so raising `STORY_BOOST` alone lifts every story against every article at once. That reorders the feed by *crowding articles out*, not by ranking stories on how well covered they are.

Replayed against prod across six categories, scoring stories and standalone articles in one list exactly as `NewsAggregator.rankScore` does:

| base | boost | avg stories in top 20 | story-vs-story reordering | 2 → 18 |
|---:|---:|---:|---:|---:|
| 3 | 0.8 | 5.8 | — | 7.7h |
| 3 | **1.6** | **8.5** ⚠️ floods | 32 | 11.6h |
| 2 | 1.6 | 6.8 | 42 | 13.9h |
| **1** | **2.0** | **5.8** ✓ unchanged | **53** | **18.4h** |

Boost-only at 1.6 buys 32 units of reordering by pushing story share from 5.8 → 8.5 per top-20 — **sports went 9 → 14, and 19 of 20 at boost 2.5**. `(1, 2.0)` buys **53** at a story share *identical to today's*.

Coverage moves the feed; the story/article mix does not move at all. That's the result worth having.

## Sanity at the new constants

| | score |
|---|---:|
| 2-outlet story | 3.20 (just over an importance-3 article) |
| 18-outlet story | 6.89 (above the importance-5 ceiling) |
| thinly-covered grim story | 1.92 (under D48's dampener) |

The `ln` still saturates, so a wire pile-up cannot lap a 6-outlet story — **that guard was never what was wrong.**

The base was a literal `3` inside both expressions, which is how it stayed unexamined while being most of the score. It's a named constant now.

## Drift guard

`__tests__/rankingConstants.test.ts` pins the failure Ranking v2 stage 1 exists because of: the pool truncates to 20 under `lib/db.ts`'s formula while the client re-ranks under `NewsAggregator`'s, and nothing in the type system stops those diverging — both compile, both run, and the only symptom is a feed ordered differently than it was selected.

**Verified by mutation:** changing either constant in one file fails the suite.

## Verification

- Prod A/B of both `ORDER BY`s across eight categories: **20–22ms either way**, pool top-20 churn 0–3 rows. (The pool only picks which 20 stories are candidates; the visible change is in the client re-rank.)
- `tsc` clean, **514 tests**.

Paired with kristenmartino/sift-api#218, which mirrors the constants into the feed-perf shape — a stale mirror doesn't fail, it silently measures a query nobody runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
