### PR TITLE
Ranking v2 stage 7: corroboration multiplies significance

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -256,6 +256,7 @@ describe("GET /api/news", () => {
           outlet_count: 2,
           grim_share: null,
           opinion_share: null,
+          avg_importance: 3,
           representative_image_url: null,
           published_date: new Date("2026-03-28T10:00:00Z"),
           synthesis_status: "complete",
@@ -298,6 +299,7 @@ describe("GET /api/news", () => {
           outlet_count: 2,
           grim_share: null,
           opinion_share: null,
+          avg_importance: 3,
           representative_image_url: null,
           published_date: new Date("2026-03-28T10:00:00Z"),
           synthesis_status: "complete",
@@ -327,6 +329,7 @@ describe("GET /api/news", () => {
           // pg returns AVG() as a numeric string.
           grim_share: "0.5",
           opinion_share: "0.5",
+          avg_importance: "1.9",
           representative_image_url: null,
           published_date: new Date("2026-03-28T10:00:00Z"),
           synthesis_status: "complete",
@@ -348,6 +351,9 @@ describe("GET /api/news", () => {
       expect(body.stories[0].tone).toBe("grim");
       // opinion_share >= 0.5 → the story is opinion (stage 4).
       expect(body.stories[0].isOpinion).toBe(true);
+      // Stage 7: mean member importance reaches the client as a number, so
+      // corroboration multiplies significance instead of replacing it.
+      expect(body.stories[0].avgImportance).toBeCloseTo(1.9);
       // reported articles carry no isOpinion key at all.
       expect(body.articles[0].isOpinion).toBeUndefined();
       expect(body.articles[1].isOpinion).toBe(true);

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -197,6 +197,7 @@ export async function GET(request: NextRequest) {
         articles: childArticles,
         // A story is grim when at least half its live members are (D48).
         ...(Number(s.grim_share ?? 0) >= 0.5 ? { tone: "grim" as const } : {}),
+        avgImportance: Number(s.avg_importance ?? 3),
         ...(Number(s.opinion_share ?? 0) >= 0.5 ? { isOpinion: true } : {}),
         ...(spectrumBuckets > 0 ? { spectrumBuckets } : {}),
       };

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -360,6 +360,10 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     // which score on the 1-5 importance scale, so raising only the boost
     // crowds articles out of the feed instead of ordering stories by coverage.
     const STORY_BASE = 1;
+    // Stage 7 (mirrors lib/db.ts): corroboration multiplies significance
+    // rather than replacing it. Centered on the observed mean story
+    // importance (2.50) so the story/article mix #231 tuned is unchanged.
+    const STORY_IMPORTANCE_CENTER = 2.5;
     const STORY_BOOST = 2.0;
     const SPECTRUM_BOOST = 0.1;
     // Stage 4 (mirrors OPINION_DAMPENER in lib/db.ts): outlet-declared
@@ -392,6 +396,11 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
         // once disagreed, and the LIMIT 20 truncation then happened under an
         // order no reader ever saw.
         const sourceScore = STORY_BASE + STORY_BOOST * Math.log(1 + item.data.outletCount);
+        // What the outlets covering it judged it to be. 18 outlets each
+        // scoring a drowning a 2 is 18 votes for "minor", not one for
+        // "major". Absent on an older payload → 1.0 (pre-stage-7 behavior).
+        const storyImportance =
+          (item.data.avgImportance ?? STORY_IMPORTANCE_CENTER) / STORY_IMPORTANCE_CENTER;
         const spectrum = 1 + SPECTRUM_BOOST * Math.max(0, (item.data.spectrumBuckets ?? 1) - 1);
         // Corroboration is the story-level analog of importance: a
         // two-outlet grim story dampens, a five-outlet disaster does not.
@@ -405,7 +414,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
         const civic = civicBoost(
           Math.max(0, ...item.data.articles.map((a) => weightedCivicLinks(a.entityLinks)))
         );
-        return sourceScore * decay * spectrum * damp * civic * opDamp;
+        return sourceScore * decay * spectrum * damp * civic * opDamp * storyImportance;
       }
       const importance = item.data.importanceScore ?? 3;
       const damp = item.data.tone === "grim" && importance <= 3 ? GRIM_DAMPENER : 1;

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -57,6 +57,7 @@
 | D49 | Opinion is not news ranking | Outlet-declared opinion (URL/title markers, deterministic) ranks ×0.6 at any importance, never takes the hero, and doesn't count toward the cross-spectrum bonus. Evidence: first labeled ranking eval (sift-api#200) — half the overrules rejected op-eds ranked as news | $0 (no LLM) | SETTLED (Aug 2026) |
 | D50 | Roundup containers are not stories | Program episodes and daily briefs (title-pattern detected, deterministic) rank ×0.4 and never take the hero — they inherit importance from events they only mention. Evidence: labeled eval session 2 (sift-api#204) | $0 (no LLM) | SETTLED (Aug 2026) |
 | D51 | The front page is for news | 'top' holds a higher bar than topical tabs: importance ≤2 ranks ×0.35 there (0 = hard floor), and non-news genres (feature/soft, LLM-tagged on the existing call) rank ×0.5 as standalone articles. Story ranking untouched — corroborated coverage keeps tabloid members visible under "how this was covered" | ~$0 (fourth key on an existing call) | SETTLED (Aug 2026) |
+| D52 | Corroboration multiplies significance | A story's base is the mean importance of its members ÷ 2.5 (the observed mean), not a constant — outlet count scales significance instead of standing in for it. Evidence: an 18-outlet local drowning scored 1.05× a 169-death earthquake. Centered to hold the story/article mix #231 tuned: +89 reordering units, share unchanged | $0 (existing data) | SETTLED (Aug 2026) |
 
 **Total estimated monthly cost: ~$30-50/mo**
 

--- a/docs/RANKING_SIGNALS.md
+++ b/docs/RANKING_SIGNALS.md
@@ -57,6 +57,44 @@ Murder | Case by Case", was the same defect wearing a crime headline.
 - Not applied to stories: clustering works on articles, and a container
   rarely clusters. Revisit if one ever leads a story.
 
+## Stage 7 — corroboration multiplies significance, it does not replace it
+
+*"Still too many local news stories about deaths/tragedies."* Stories ranked
+on outlet count alone; **importance never entered the story formula at all**.
+Measured 2026-08-11 at the (1, 2.0) constants #231 tuned: a New York Harbor
+drowning with **18 outlets and mean member importance 1.9** scored 6.78
+against a 169-death Colombian earthquake's 7.09 — a **1.05× ratio**.
+System-wide, **302 of 475 stories had max member importance ≤ 2**. Wire
+pickup of a local tragedy was indistinguishable from a major event.
+
+The fix is one multiplier: a story's base significance is the **mean
+importance of its member articles** — 18 outlets each scoring a drowning a 2
+is 18 votes for "minor", not one vote for "major" — divided by
+`STORY_IMPORTANCE_CENTER`.
+
+**Centering is what keeps it honest.** Dividing every story by a constant
+cannot reorder stories among themselves; it only shifts stories against
+articles. Swept against six category pools, replaying the real query shapes:
+
+| center | avg stories in top 20 | story-vs-story reordering |
+|---:|---:|---:|
+| 2.0 | 7.5 ⚠️ floods | 89 |
+| 2.4 | 6.0 | 89 |
+| **2.5** (observed mean) | **~5.7** ✓ unchanged | **89** |
+| 2.6 | 5.5 | 89 |
+| 3.0 | 4.3 ⚠️ starves | 89 |
+
+Baseline share is 5.7. Reordering is 89 at *every* center — so the center is
+purely the mix knob, and 2.50 (the observed mean across 116 pooled stories)
+holds the mix #231 tuned while adding 89 units of reordering, against the 53
+that PR bought. The earthquake gains ×1.68, the drowning ×0.76: a 1.05 ratio
+becomes 2.3.
+
+Deliberately *not* a cliff at importance ≤2 (the article rule's shape). A
+continuous factor fixes the mid-range too — a 7-outlet wildfire evacuation at
+mean 3.7 now separates from a 6-outlet trial at mean 2.3, which a cliff
+leaves tied.
+
 ## Stage 6 — the front page is for news (added from product direction)
 
 *"Sift should be showing important news, not so much entertainment."*

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -168,6 +168,29 @@ const NON_NEWS_SQL = `CASE WHEN genre IN ('feature', 'soft') THEN ${NON_NEWS_DAM
 const STORY_BASE = 1;
 const STORY_BOOST = 2.0;
 
+// Ranking v2 stage 7: corroboration is a MULTIPLIER ON SIGNIFICANCE, not a
+// substitute for it. Until this landed, a story's score ignored importance
+// entirely — every story ranked on outlet count alone — so wire pickup of a
+// local tragedy was indistinguishable from a major event. Measured
+// 2026-08-11 at the (1, 2.0) constants: a New York Harbor drowning with 18
+// outlets and mean member importance 1.9 scored 6.78 against a 169-death
+// Colombian earthquake's 7.09. A 1.05x ratio. System-wide, 302 of 475
+// stories had max member importance <= 2.
+//
+// The story's base significance is the MEAN importance of its member
+// articles — what the outlets that covered it judged it to be, which is
+// exactly the wire-pickup counter: 18 outlets each scoring it a 2 is 18
+// votes for "minor", not one vote for "major".
+//
+// Centered on the observed mean (2.50 across six category pools, n=116) so
+// the transform is share-NEUTRAL: dividing every story by a constant cannot
+// reorder stories among themselves, it only shifts them against articles.
+// Swept 2.0/2.2/2.4/2.6/3.0 — reordering is 89 at every center, story share
+// runs 7.5/6.8/6.0/5.5/4.3 against a 5.7 baseline. 2.5 holds the mix that
+// #231 tuned while adding 89 units of story-vs-story reordering.
+const STORY_IMPORTANCE_CENTER = 2.5;
+const STORY_IMPORTANCE_SQL = `(COALESCE(AVG(a.importance_score), 3) / ${STORY_IMPORTANCE_CENTER})`;
+
 // "sources" in that curve means DISTINCT OUTLETS, not article rows. It counted
 // COUNT(a.id) until 2026-08-11, which is a different thing: measured over 7
 // days of complete stories, 29% had more articles than outlets and 18% were at
@@ -277,6 +300,9 @@ export interface DbStory {
   // Fraction of live member articles tagged tone='grim' (0..1); the API
   // boundary derives Story.tone = 'grim' when >= 0.5. NULL tones count as 0.
   grim_share: string | number | null;
+  // Mean importance of the live member articles (stage 7): the story's
+  // base significance, which corroboration multiplies rather than replaces.
+  avg_importance: string | number | null;
   // Fraction of live member articles flagged is_opinion (0..1); the API
   // boundary derives Story.isOpinion when >= 0.5.
   opinion_share: string | number | null;
@@ -304,6 +330,7 @@ export async function getStoriesWithArticles(
               COUNT(a.id)::int AS article_count,
               COUNT(DISTINCT a.source_name)::int AS outlet_count,
               AVG(CASE WHEN a.tone = 'grim' THEN 1.0 ELSE 0 END) AS grim_share,
+              COALESCE(AVG(a.importance_score), 3) AS avg_importance,
               AVG(CASE WHEN a.is_opinion THEN 1.0 ELSE 0 END) AS opinion_share,
               s.representative_image_url, s.published_date, s.synthesis_status
        FROM stories s
@@ -317,7 +344,8 @@ export async function getStoriesWithArticles(
        HAVING COUNT(a.id) >= 2
        ORDER BY
          (${STORY_BASE} + ${STORY_BOOST} * LN(1 + COUNT(DISTINCT a.source_name)))::float *
-         EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(s.published_date, s.created_at))), 0) / 86400.0, 700))
+         EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(s.published_date, s.created_at))), 0) / 86400.0, 700)) *
+         ${STORY_IMPORTANCE_SQL}
        DESC NULLS LAST
        LIMIT 20`,
       [category]

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -683,6 +683,13 @@ export interface Story {
   /** Derived at the API boundary: >= half the members are opinion pieces. */
   isOpinion?: boolean;
   /**
+   * Mean importance of the live member articles (1-5) — the story's base
+   * significance since stage 7. Corroboration multiplies this rather than
+   * standing in for it, so wire pickup of a local tragedy no longer reads
+   * as a major event.
+   */
+  avgImportance?: number;
+  /**
    * Distinct L/C/R AllSides buckets occupied by this story's framings (1-3;
    * absent when none are bucketable). Derived at the API boundary via
    * countOccupiedBuckets. Ranking v2 stage 1: the client re-rank applies a


### PR DESCRIPTION
Builds directly on [#231](https://github.com/kristenmartino/sift/pull/231) — and uses its methodology, because the pathology it leaves untouched is the one behind "still too many local stories about deaths/tragedies."

**Stories ranked on outlet count alone; importance never entered the story formula.** At the (1, 2.0) constants: a New York Harbor drowning with **18 outlets and mean member importance 1.9** scored 6.78 against a 169-death Colombian earthquake's 7.09 — a **1.05× ratio**. System-wide, **302 of 475 stories had max member importance ≤2**.

A story's base is now the **mean importance of its members** — 18 outlets each scoring a drowning a 2 is 18 votes for "minor" — divided by `STORY_IMPORTANCE_CENTER`.

**Centering holds your mix.** Dividing every story by a constant cannot reorder stories among themselves; it only shifts them against articles. Swept against six category pools, replaying the real query shapes:

| center | avg stories in top 20 | reordering |
|---:|---:|---:|
| 2.0 | 7.5 ⚠️ floods | 89 |
| 2.4 | 6.0 | 89 |
| **2.5** (observed mean) | **~5.7** ✓ unchanged | **89** |
| 3.0 | 4.3 ⚠️ starves | 89 |

Baseline 5.7. Reordering is 89 at every center, so the center is purely the mix knob — 2.50 holds what #231 tuned while adding 89 units against that PR's 53. Earthquake ×1.68, drowning ×0.76: 1.05 → 2.3.

Continuous rather than a ≤2 cliff on purpose: a cliff leaves a 7-outlet wildfire evacuation (mean 3.7) tied with a 6-outlet trial (mean 2.3).

tsc clean; 31 suites / 514 tests. Companion sift-api PR mirrors the STORIES_SQL shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)