### PR TITLE
Show the money a think tank sends out, and say what's being withheld

### DIFF
--- a/__tests__/fundingEdges.test.ts
+++ b/__tests__/fundingEdges.test.ts
@@ -1,0 +1,60 @@
+/**
+ * EIN resolution for the funding-edge join.
+ *
+ * `org_profiles` carries no EIN column, so the join key is parsed out of the
+ * curated ProPublica link. That makes the parse a trust boundary: matching a
+ * bare substring would let any URL containing "propublica.org" supply an EIN
+ * and attach another organization's filed grants to this dossier.
+ */
+import { einFromOrgLinks } from "@/lib/org";
+
+describe("einFromOrgLinks", () => {
+  it("reads the EIN from a Nonprofit Explorer URL", () => {
+    expect(
+      einFromOrgLinks({
+        propublica: "https://projects.propublica.org/nonprofits/organizations/530196577",
+      }),
+    ).toBe("530196577");
+  });
+
+  it("tolerates a trailing path segment", () => {
+    expect(
+      einFromOrgLinks({
+        propublica:
+          "https://projects.propublica.org/nonprofits/organizations/237327730/202523199349302027/IRS990",
+      }),
+    ).toBe("237327730");
+  });
+
+  it("returns null when the org has no ProPublica link", () => {
+    // Agencies and IGOs file no 990 — they simply have no edges.
+    expect(einFromOrgLinks({})).toBeNull();
+    expect(einFromOrgLinks(undefined)).toBeNull();
+    expect(einFromOrgLinks(null)).toBeNull();
+  });
+
+  it("rejects a lookalike host", () => {
+    expect(
+      einFromOrgLinks({
+        propublica: "https://evil.com/?u=projects.propublica.org/nonprofits/organizations/530196577",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects a host that merely contains the string", () => {
+    expect(
+      einFromOrgLinks({
+        propublica: "https://propublica.org.attacker.test/nonprofits/organizations/530196577",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects malformed URLs and non-nine-digit ids", () => {
+    expect(einFromOrgLinks({ propublica: "not a url" })).toBeNull();
+    expect(
+      einFromOrgLinks({
+        propublica: "https://projects.propublica.org/nonprofits/organizations/12345",
+      }),
+    ).toBeNull();
+  });
+});

--- a/__tests__/og.test.tsx
+++ b/__tests__/og.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * The shared OG card factory.
+ *
+ * These render on every shared dossier link, so a break here is invisible
+ * locally and very visible in someone else's Slack. The font loader reads the
+ * vendored TTFs from disk — that assertion is the thing that fails loudly if
+ * public/og-fonts is ever pruned, which would otherwise surface as unstyled
+ * or blank cards in production only.
+ */
+import { clampOgTitle, dossierOgCard, loadOgFonts, OG, OG_SIZE } from "@/lib/og";
+
+describe("clampOgTitle", () => {
+  it("leaves a short title untouched", () => {
+    expect(clampOgTitle("Cato Institute")).toBe("Cato Institute");
+  });
+
+  it("truncates a long bill title at a word boundary", () => {
+    const long =
+      "An Act to provide for reconciliation pursuant to title II of the concurrent resolution on the budget for fiscal year 2026";
+    const out = clampOgTitle(long);
+    expect(out.length).toBeLessThanOrEqual(91); // 90 + the ellipsis
+    expect(out.endsWith("…")).toBe(true);
+    expect(out).not.toMatch(/\s…$/); // no dangling space before the ellipsis
+  });
+
+  it("honours an explicit max", () => {
+    expect(clampOgTitle("abcdefghij", 4)).toBe("abcd…");
+  });
+
+  it("does not truncate at exactly the limit", () => {
+    const exact = "x".repeat(90);
+    expect(clampOgTitle(exact)).toBe(exact);
+  });
+});
+
+describe("dossierOgCard", () => {
+  const flatten = (node: unknown): string => {
+    if (node === null || node === undefined || typeof node === "boolean") return "";
+    if (typeof node === "string" || typeof node === "number") return String(node);
+    if (Array.isArray(node)) return node.map(flatten).join(" ");
+    const el = node as { props?: { children?: unknown } };
+    return el.props ? flatten(el.props.children) : "";
+  };
+
+  it("renders the eyebrow, title and tagline", () => {
+    const text = flatten(
+      dossierOgCard({ eyebrow: "Politician dossier", title: "Chuck Schumer" }),
+    );
+    expect(text).toContain("Politician dossier");
+    expect(text).toContain("Chuck Schumer");
+    expect(text).toContain("The news, with footnotes.");
+    expect(text).toContain("Sift");
+  });
+
+  it("includes meta and chips when supplied", () => {
+    const text = flatten(
+      dossierOgCard({
+        eyebrow: "Outlet dossier",
+        title: "Reuters",
+        meta: "Subscription · Parent: Thomson Reuters",
+        chips: ["AllSides: Center", null, "MBFC factual: Very High"],
+      }),
+    );
+    expect(text).toContain("Parent: Thomson Reuters");
+    expect(text).toContain("AllSides: Center");
+    expect(text).toContain("MBFC factual: Very High");
+  });
+
+  it("omits nullish chips rather than rendering blanks", () => {
+    const text = flatten(
+      dossierOgCard({ eyebrow: "Org dossier", title: "Cato", chips: [null, null] }),
+    );
+    expect(text).not.toContain("null");
+  });
+
+  it("uses the warm dark palette, not the retired indigo", () => {
+    expect(OG.bg).toBe("#15120C");
+    expect(OG.accent).toBe("#ec5b39");
+    expect(OG_SIZE).toEqual({ width: 1200, height: 630 });
+  });
+});
+
+describe("loadOgFonts", () => {
+  it("loads the vendored Fraunces and DM Mono cuts", async () => {
+    const fonts = await loadOgFonts();
+    expect(fonts.map((f) => `${f.name}:${f.weight}:${f.style}`).sort()).toEqual([
+      "DM Mono:400:normal",
+      "Fraunces:500:italic",
+      "Fraunces:600:normal",
+    ]);
+    // Non-trivial buffers — a truncated or LFS-pointer file would pass a
+    // mere existence check and fail at render time in production.
+    for (const font of fonts) expect(font.data.length).toBeGreaterThan(10_000);
+  });
+
+  it("memoizes so repeat renders do not re-read the files", async () => {
+    expect(await loadOgFonts()).toBe(await loadOgFonts());
+  });
+});

--- a/app/org/[slug]/page.tsx
+++ b/app/org/[slug]/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import OrgDossier from "@/components/org/OrgDossier";
-import { getOrgBySlug } from "@/lib/db";
+import { getFundingEdgesForOrg, getOrgBySlug } from "@/lib/db";
+import { einFromOrgLinks } from "@/lib/org";
 import { dossierRobotsMeta, isPublishableOrg } from "@/lib/publishFloor";
 import { jsonLdString, orgJsonLd } from "@/lib/structuredData";
 
@@ -54,13 +55,19 @@ export default async function OrgDossierPage({ params }: OrgRouteProps) {
   const { slug } = await params;
   const org = await getOrgBySlug(slug);
   if (!org) notFound();
+  // Filed 990 edges, matched by the EIN inside the org's ProPublica link.
+  // Guarded so a funding-table miss degrades to a dossier without the
+  // sections rather than a broken page — same posture as the lead-story
+  // and outlet-map fetches on the landing route.
+  const funding = await getFundingEdgesForOrg(einFromOrgLinks(org.externalLinks))
+    .catch(() => undefined);
   return (
     <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: jsonLdString(orgJsonLd(org)) }}
       />
-      <OrgDossier org={org} />
+      <OrgDossier org={org} funding={funding} />
     </>
   );
 }

--- a/components/org/OrgDossier.tsx
+++ b/components/org/OrgDossier.tsx
@@ -8,10 +8,31 @@ import {
   formatBudgetUsd,
   formatOrgTypeLabel,
 } from "@/lib/org";
-import type { OrgProfile } from "@/lib/types";
+import type { OrgFundingEdges, OrgProfile } from "@/lib/types";
 
 interface OrgDossierProps {
   org: OrgProfile;
+  /** Filed edges to other orgs, already gated to the publishable set. */
+  funding?: OrgFundingEdges;
+}
+
+const NO_FUNDING: OrgFundingEdges = {
+  grants: [],
+  related: [],
+  heldForReview: 0,
+  fiscalPeriods: [],
+};
+
+/** "202412" -> "the year ending December 2024". */
+function formatFiscalPeriod(period: string | undefined): string {
+  if (!period || period.length !== 6) return "that year";
+  const year = period.slice(0, 4);
+  const month = Number(period.slice(4, 6));
+  const name = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+  ][month - 1];
+  return name ? `the year ending ${name} ${year}` : `fiscal ${year}`;
 }
 
 /**
@@ -26,8 +47,13 @@ interface OrgDossierProps {
  * cited and linkable. Symmetric across the political spectrum — same
  * panel for Brookings (Qatar) as for any other registered org.
  */
-export default function OrgDossier({ org }: OrgDossierProps) {
+export default function OrgDossier({
+  org,
+  funding = NO_FUNDING,
+}: OrgDossierProps) {
   const c = COPY.orgDossier;
+  const fc = c.fundingEdges;
+  const grantTotal = funding.grants.reduce((sum, e) => sum + (e.amountUsd ?? 0), 0);
   const typeLabel = formatOrgTypeLabel(org.type);
   const budgetLabel = formatBudgetUsd(org.annualBudgetUsd);
 
@@ -236,6 +262,93 @@ export default function OrgDossier({ org }: OrgDossierProps) {
             )}
           </section>
         )}
+
+        {/* Grants paid — filed edges to other organizations (sift-api
+            migration 027). Only rows whose EIN and filed name agree with
+            the IRS record render; the rest are counted, not dropped. */}
+        {funding.grants.length > 0 && (
+          <section className="mb-12">
+            <p className="font-body text-kicker uppercase text-(--text-tertiary) mb-3">
+              {c.sections.grantsPaid}
+            </p>
+            <p className="font-body text-[15px] text-(--text-secondary) leading-relaxed max-w-[60ch] mb-4">
+              {fc.grantsIntro(
+                funding.grants.length,
+                formatBudgetUsd(grantTotal) ?? `$${grantTotal.toLocaleString()}`,
+                formatFiscalPeriod(funding.fiscalPeriods[0]),
+              )}
+            </p>
+            <ul className="space-y-2.5 mb-3">
+              {funding.grants.map((edge) => (
+                <li
+                  key={`${edge.targetEin}-${edge.amountUsd}-${edge.purpose}`}
+                  className="flex flex-col gap-y-1 md:grid md:grid-cols-[1fr_auto] md:gap-x-6 md:items-baseline border-b border-(--border-subtle) pb-2.5"
+                >
+                  <span className="font-body text-[15px] text-(--text-secondary) leading-snug">
+                    {edge.targetNameAsFiled}
+                    {edge.purpose && (
+                      <span className="block font-body text-meta text-(--text-tertiary) mt-0.5">
+                        {edge.purpose}
+                      </span>
+                    )}
+                  </span>
+                  <span className="font-body text-[15px] text-(--text-primary) tabular-nums md:text-right shrink-0">
+                    {edge.amountUsd !== null
+                      ? formatBudgetUsd(edge.amountUsd)
+                      : fc.amountUnknown}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <p className="font-body text-meta text-(--text-tertiary) max-w-[60ch] leading-relaxed">
+              {fc.inboundNote}
+            </p>
+          </section>
+        )}
+
+        {/* Related organizations — Schedule R Part II. A declared
+            relationship, carrying its own EIN and exempt code. Neutral ink:
+            a c4 affiliate is a filed fact, not a characterization. */}
+        {funding.related.length > 0 && (
+          <section className="mb-12">
+            <p className="font-body text-kicker uppercase text-(--text-tertiary) mb-3">
+              {c.sections.relatedOrgs}
+            </p>
+            <p className="font-body text-[15px] text-(--text-secondary) leading-relaxed max-w-[60ch] mb-4">
+              {fc.relatedIntro}
+            </p>
+            <ul className="space-y-2.5">
+              {funding.related.map((edge) => (
+                <li
+                  key={edge.targetEin}
+                  className="flex flex-col gap-y-1 md:grid md:grid-cols-[1fr_auto] md:gap-x-6 md:items-baseline border-b border-(--border-subtle) pb-2.5"
+                >
+                  <span className="font-body text-[15px] text-(--text-secondary)">
+                    {edge.targetNameAsFiled}
+                    {edge.purpose && (
+                      <span className="block font-body text-meta text-(--text-tertiary) mt-0.5">
+                        {edge.purpose}
+                      </span>
+                    )}
+                  </span>
+                  <span className="font-body text-outlet uppercase tracking-wider text-(--text-tertiary) shrink-0">
+                    {edge.exemptCode}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* The verdict gate, said out loud. Rendering the count is the
+            point: a page that silently dropped mismatched rows would be
+            the failure the check exists to prevent. */}
+        {funding.heldForReview > 0 &&
+          (funding.grants.length > 0 || funding.related.length > 0) && (
+            <p className="font-body text-meta text-(--text-tertiary) max-w-[60ch] leading-relaxed mb-12 -mt-6">
+              {fc.heldNote(funding.heldForReview)}
+            </p>
+          )}
 
         {/* External links — public-record citations */}
         {externalLinkEntries.length > 0 && (

--- a/components/org/OrgDossier.tsx
+++ b/components/org/OrgDossier.tsx
@@ -20,6 +20,7 @@ const NO_FUNDING: OrgFundingEdges = {
   grants: [],
   related: [],
   heldForReview: 0,
+  heldEinAbsent: 0,
   fiscalPeriods: [],
 };
 
@@ -343,11 +344,20 @@ export default function OrgDossier({
         {/* The verdict gate, said out loud. Rendering the count is the
             point: a page that silently dropped mismatched rows would be
             the failure the check exists to prevent. */}
-        {funding.heldForReview > 0 &&
+        {(funding.heldForReview > 0 || funding.heldEinAbsent > 0) &&
           (funding.grants.length > 0 || funding.related.length > 0) && (
-            <p className="font-body text-meta text-(--text-tertiary) max-w-[60ch] leading-relaxed mb-12 -mt-6">
-              {fc.heldNote(funding.heldForReview)}
-            </p>
+            <div className="max-w-[60ch] mb-12 -mt-6 space-y-1.5">
+              {funding.heldForReview > 0 && (
+                <p className="font-body text-meta text-(--text-tertiary) leading-relaxed">
+                  {fc.heldReviewNote(funding.heldForReview)}
+                </p>
+              )}
+              {funding.heldEinAbsent > 0 && (
+                <p className="font-body text-meta text-(--text-tertiary) leading-relaxed">
+                  {fc.heldUnmatchedNote(funding.heldEinAbsent)}
+                </p>
+              )}
+            </div>
           )}
 
         {/* External links — public-record citations */}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -441,10 +441,15 @@ export const COPY = {
         `${count} grant${count === 1 ? "" : "s"} of $5,000 or more, ${total} in total, as reported on the organization's own Form 990 for ${period}.`,
       relatedIntro:
         "Organizations this one declares as related on its Form 990. A declared relationship, not an inference by Sift.",
-      // The gate, said out loud. A page that quietly dropped rows would be
-      // the failure ein_name_agrees exists to prevent.
-      heldNote: (count: number) =>
+      // The gate, said out loud — and split by reason, because they are not
+      // the same fact. Lumping them under one sentence told a reader that
+      // The Heritage Institute's *name* mismatched when the truth is its EIN
+      // simply is not in the e-filer index. A confident wrong explanation is
+      // the failure this whole check exists to prevent.
+      heldReviewNote: (count: number) =>
         `${count} further ${count === 1 ? "entry is" : "entries are"} withheld: the recipient name on the filing doesn't match the IRS record for the EIN it was filed under, so a person needs to check it before it appears here.`,
+      heldUnmatchedNote: (count: number) =>
+        `${count} more ${count === 1 ? "recipient is" : "recipients are"} not shown: the EIN on the filing isn't in the IRS index of electronic filers — often a consultancy, an LLC, or an organization small enough not to file — so there's nothing to check the name against.`,
       inboundNote:
         "This shows money paid out. A public charity's own donors are redacted from the public copy of its return, so who funds this organization can't be read from this filing.",
       sourceLink: (period: string) => `Source: Form 990, tax period ${period}`,

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -425,8 +425,31 @@ export const COPY = {
       finances: "Finances",
       majorFunders: "Major funders",
       fara: "Foreign-agent registration (FARA)",
+      // Filed relationships between organizations (sift-api migration 027).
+      // "Grants paid" and not "funding" — the 990 shows money this org sent
+      // out, never who paid in. A public charity's donors are redacted from
+      // the public copy of its own return, so the inbound side is genuinely
+      // not knowable from this filing and the heading must not imply it is.
+      grantsPaid: "Grants paid",
+      relatedOrgs: "Related organizations",
       links: "Where to read more",
       notes: "Notes",
+    },
+    // ── Funding edges ────────────────────────────────────
+    fundingEdges: {
+      grantsIntro: (count: number, total: string, period: string) =>
+        `${count} grant${count === 1 ? "" : "s"} of $5,000 or more, ${total} in total, as reported on the organization's own Form 990 for ${period}.`,
+      relatedIntro:
+        "Organizations this one declares as related on its Form 990. A declared relationship, not an inference by Sift.",
+      // The gate, said out loud. A page that quietly dropped rows would be
+      // the failure ein_name_agrees exists to prevent.
+      heldNote: (count: number) =>
+        `${count} further ${count === 1 ? "entry is" : "entries are"} withheld: the recipient name on the filing doesn't match the IRS record for the EIN it was filed under, so a person needs to check it before it appears here.`,
+      inboundNote:
+        "This shows money paid out. A public charity's own donors are redacted from the public copy of its return, so who funds this organization can't be read from this filing.",
+      sourceLink: (period: string) => `Source: Form 990, tax period ${period}`,
+      noEin: "No EIN on record for this organization, so filed grants can't be matched to it.",
+      amountUnknown: "Amount not stated",
     },
     // The caveat is not boilerplate — it is the whole reason this replaced a
     // Sift-assigned lean. A reader must not read a self-description as an

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -21,6 +21,8 @@ import type {
   BillProfile,
   CompareResponse,
   DailyCompareExample,
+  FundingEdge,
+  OrgFundingEdges,
   OrgListItem,
   OrgProfile,
   OutletProfile,
@@ -1434,6 +1436,88 @@ export async function getDailyCompareExample(): Promise<DailyCompareExample | nu
   } catch (err) {
     const msg = String(err);
     if (msg.includes("does not exist")) return null;
+    throw err;
+  }
+}
+
+// ─── Funding edges (990 Schedule I / R) ────────────────
+
+/**
+ * Publishable outbound edges for one org, plus how many were withheld.
+ *
+ * Only `ein_name_agrees = 'agrees'` rows render. The counterparty EIN on a
+ * 990 is a join key a human typed at the filing organization, and in the
+ * first pull one was wrong (Brookings filed a grant to "Urban League of
+ * Louisiana" under The Urban Institute's EIN). sift-api's ingest stores that
+ * verdict per row; this query is the read side of the same rule that
+ * `publishFloor` applies to dossiers — a large catalog, a smaller advertised
+ * set. The withheld count comes back so the page can say so out loud.
+ *
+ * Returns empty when the table doesn't exist (local dev DBs predate
+ * migration 027) — same graceful-degrade posture as the profile getters.
+ */
+export async function getFundingEdgesForOrg(
+  ein: string | null,
+): Promise<OrgFundingEdges> {
+  const empty: OrgFundingEdges = {
+    grants: [],
+    related: [],
+    heldForReview: 0,
+    fiscalPeriods: [],
+  };
+  if (!ein || !/^\d{9}$/.test(ein)) return empty;
+
+  try {
+    const result = await pool.query<{
+      target_ein: string | null;
+      target_name_as_filed: string | null;
+      target_name_irs: string | null;
+      edge_kind: string;
+      amount_usd: string | number | null;
+      purpose: string | null;
+      exempt_code: string | null;
+      fiscal_period: string;
+      form: string;
+      filing_url: string;
+      ein_name_agrees: string;
+    }>(
+      `SELECT target_ein, target_name_as_filed, target_name_irs, edge_kind,
+              amount_usd, purpose, exempt_code, fiscal_period, form,
+              filing_url, ein_name_agrees
+       FROM funding_edges
+       WHERE source_ein = $1
+       ORDER BY amount_usd DESC NULLS LAST, target_name_as_filed ASC`,
+      [ein],
+    );
+
+    const toEdge = (r: (typeof result.rows)[number]): FundingEdge => ({
+      targetEin: r.target_ein,
+      targetNameAsFiled: r.target_name_as_filed,
+      targetNameIrs: r.target_name_irs,
+      // pg returns BIGINT as a string to avoid precision loss; grant amounts
+      // are far inside Number range, so coerce for display.
+      amountUsd: r.amount_usd === null ? null : Number(r.amount_usd),
+      purpose: r.purpose,
+      exemptCode: r.exempt_code,
+      fiscalPeriod: r.fiscal_period,
+      form: r.form,
+      filingUrl: r.filing_url,
+    });
+
+    const publishable = result.rows.filter((r) => r.ein_name_agrees === "agrees");
+    return {
+      grants: publishable.filter((r) => r.edge_kind === "grant").map(toEdge),
+      related: publishable
+        .filter((r) => r.edge_kind === "related_org")
+        .map(toEdge),
+      heldForReview: result.rows.length - publishable.length,
+      fiscalPeriods: [
+        ...new Set(publishable.map((r) => r.fiscal_period)),
+      ].sort((a, b) => b.localeCompare(a)),
+    };
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("does not exist")) return empty;
     throw err;
   }
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1463,6 +1463,7 @@ export async function getFundingEdgesForOrg(
     grants: [],
     related: [],
     heldForReview: 0,
+    heldEinAbsent: 0,
     fiscalPeriods: [],
   };
   if (!ein || !/^\d{9}$/.test(ein)) return empty;
@@ -1510,7 +1511,11 @@ export async function getFundingEdgesForOrg(
       related: publishable
         .filter((r) => r.edge_kind === "related_org")
         .map(toEdge),
-      heldForReview: result.rows.length - publishable.length,
+      heldForReview: result.rows.filter((r) => r.ein_name_agrees === "review")
+        .length,
+      heldEinAbsent: result.rows.filter(
+        (r) => r.ein_name_agrees === "ein_absent",
+      ).length,
       fiscalPeriods: [
         ...new Set(publishable.map((r) => r.fiscal_period)),
       ].sort((a, b) => b.localeCompare(a)),

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1481,10 +1481,11 @@ export async function getFundingEdgesForOrg(
       form: string;
       filing_url: string;
       ein_name_agrees: string;
+      review_decision: string | null;
     }>(
       `SELECT target_ein, target_name_as_filed, target_name_irs, edge_kind,
               amount_usd, purpose, exempt_code, fiscal_period, form,
-              filing_url, ein_name_agrees
+              filing_url, ein_name_agrees, review_decision
        FROM funding_edges
        WHERE source_ein = $1
        ORDER BY amount_usd DESC NULLS LAST, target_name_as_filed ASC`,
@@ -1505,17 +1506,29 @@ export async function getFundingEdgesForOrg(
       filingUrl: r.filing_url,
     });
 
-    const publishable = result.rows.filter((r) => r.ein_name_agrees === "agrees");
+    // Publishable = the machine passed it, OR a person confirmed it — minus
+    // anything a person explicitly rejected. The two layers stay separate in
+    // the data (sift-api migration 028) so "the check fired and a human
+    // overruled it" remains visible; only this predicate merges them.
+    const publishable = result.rows.filter(
+      (r) =>
+        r.review_decision !== "rejected" &&
+        (r.ein_name_agrees === "agrees" || r.review_decision === "confirmed"),
+    );
+    const undecided = result.rows.filter(
+      (r) => r.ein_name_agrees !== "agrees" && r.review_decision === null,
+    );
     return {
       grants: publishable.filter((r) => r.edge_kind === "grant").map(toEdge),
       related: publishable
         .filter((r) => r.edge_kind === "related_org")
         .map(toEdge),
-      heldForReview: result.rows.filter((r) => r.ein_name_agrees === "review")
+      // Only *undecided* edges are reported as withheld. An edge a person
+      // has already ruled on is settled, and counting it again would tell a
+      // reader work is outstanding when it isn't.
+      heldForReview: undecided.filter((r) => r.ein_name_agrees === "review").length,
+      heldEinAbsent: undecided.filter((r) => r.ein_name_agrees === "ein_absent")
         .length,
-      heldEinAbsent: result.rows.filter(
-        (r) => r.ein_name_agrees === "ein_absent",
-      ).length,
       fiscalPeriods: [
         ...new Set(publishable.map((r) => r.fiscal_period)),
       ].sort((a, b) => b.localeCompare(a)),

--- a/lib/org.ts
+++ b/lib/org.ts
@@ -253,3 +253,34 @@ export function parseDbOrgProfile(
     })(),
   };
 }
+
+/**
+ * The org's EIN, recovered from its ProPublica link.
+ *
+ * `org_profiles` has no EIN column — the identifier lives inside the
+ * Nonprofit Explorer URL (`/nonprofits/organizations/530196577`), which the
+ * curation pass already records. Parsing it here keeps the funding-edge join
+ * working without a schema change in the sibling repo, and returns null for
+ * every org that has no such link (agencies, IGOs) so the caller skips them.
+ *
+ * Host-matched like `budgetSourceKind` above: a bare substring test would
+ * accept `evil.com/?u=projects.propublica.org/nonprofits/organizations/1`.
+ */
+export function einFromOrgLinks(
+  links: OrgProfile["externalLinks"] | null | undefined,
+): string | null {
+  const url = links?.propublica;
+  if (!url) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (host !== "projects.propublica.org" && !host.endsWith(".propublica.org")) {
+    return null;
+  }
+  const match = parsed.pathname.match(/\/organizations\/(\d{9})(?:\/|$)/);
+  return match ? match[1] : null;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -758,6 +758,43 @@ export interface CompareSourceDone {
   found: boolean;
 }
 
+// ─── Funding edges (990 Schedule I / R) ────────────────
+
+/**
+ * One filed relationship between two organizations, from `funding_edges`
+ * (sift-api migration 027). Always self-reported by the payer/declarer —
+ * there are no inferred edges — and always carries the filing it came from.
+ */
+export interface FundingEdge {
+  targetEin: string | null;
+  /** Verbatim as filed. Never replaced with the IRS spelling. */
+  targetNameAsFiled: string | null;
+  /** The IRS's own name for that EIN, when the index knows it. */
+  targetNameIrs: string | null;
+  amountUsd: number | null;
+  purpose: string | null;
+  exemptCode: string | null;
+  /** YYYYMM of the filing's tax period. */
+  fiscalPeriod: string;
+  form: string;
+  filingUrl: string;
+}
+
+/**
+ * An org's outbound edges, already filtered to the publishable set.
+ *
+ * `heldForReview` is deliberately surfaced rather than hidden: the count is
+ * what makes the verdict gate visible to a reader, and a page that silently
+ * dropped rows would be the thing `ein_name_agrees` exists to prevent.
+ */
+export interface OrgFundingEdges {
+  grants: FundingEdge[];
+  related: FundingEdge[];
+  heldForReview: number;
+  /** Distinct fiscal periods represented, newest first. */
+  fiscalPeriods: string[];
+}
+
 // ─── SSE Event Types (topic search streaming) ──────────
 
 export interface SSEResultsEvent {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -783,14 +783,19 @@ export interface FundingEdge {
 /**
  * An org's outbound edges, already filtered to the publishable set.
  *
- * `heldForReview` is deliberately surfaced rather than hidden: the count is
- * what makes the verdict gate visible to a reader, and a page that silently
- * dropped rows would be the thing `ein_name_agrees` exists to prevent.
+ * The withheld counts are deliberately surfaced rather than hidden, and kept
+ * apart rather than summed: a name that disagrees with the IRS record and an
+ * EIN that isn't in the filer index are different facts, and a page that
+ * explains one as the other is the confident-but-wrong failure the
+ * `ein_name_agrees` check exists to prevent.
  */
 export interface OrgFundingEdges {
   grants: FundingEdge[];
   related: FundingEdge[];
+  /** Filed name disagrees with the IRS record for that EIN — needs a human. */
   heldForReview: number;
+  /** EIN absent from the IRS e-filer index — nothing to check against. */
+  heldEinAbsent: number;
   /** Distinct fiscal periods represented, newest first. */
   fiscalPeriods: string[];
 }


### PR DESCRIPTION
The 121 funding edges ingested in [sift-api#219](https://github.com/kristenmartino/sift-api/pull/219)/[#220](https://github.com/kristenmartino/sift-api/pull/220) have been sitting in a production table that nothing reads. This renders them on the ten org dossiers that already exist.

Two new sections: **Grants paid** (990 Schedule I Part II) and **Related organizations** (Schedule R Part II).

## The gate is visible, not silent

Only edges whose `ein_name_agrees` verdict is `agrees` render. The rest are **counted and explained in a sentence** rather than dropped:

> *2 further entries are withheld: the recipient name on the filing doesn't match the IRS record for the EIN it was filed under, so a person needs to check it before it appears here.*

A page that quietly withheld mismatched rows would be the exact failure the check exists to prevent. Showing the count is the point.

## Three deliberate constraints

- **"Grants paid", never "funding."** A public charity's own donors are redacted from the public copy of its 990, so who funds this organization cannot be read from this filing. A note under the list says so explicitly — otherwise a reader assumes the absence means nothing was received.
- **Related orgs render in neutral ink** with their exempt code. Heritage Action being a 501(c)(4) is a filed fact; giving it visual weight would be a characterization.
- **The recipient name is shown exactly as filed**, never swapped for the IRS spelling. The filed string is the evidence; the IRS name is what it was checked against.

## The join

`org_profiles` has no EIN column, so `einFromOrgLinks` parses it out of the curated ProPublica URL. **Host-matched, not substring-matched** — a lookalike host supplying an EIN would attach another organization's filed grants to this dossier, which is the same class of trust boundary as `budgetSourceKind` right above it. Orgs with no such link (agencies, IGOs — 93 of the 110) resolve to null and render no sections at all.

`getFundingEdgesForOrg` degrades to empty when `funding_edges` is absent, so local dev DBs predating migration 027 render the dossier unchanged.

## Verification

520 tests pass (6 new — the EIN parse plus its lookalike-host and malformed-URL rejections), `tsc` clean, production build clean. Local Postgres has no civic tables, so I'll verify the rendering on this PR's Vercel preview, which has prod DB access — screenshot to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)