### PR TITLE
Floor story significance at its best member's importance, gated at 4

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -257,6 +257,7 @@ describe("GET /api/news", () => {
           grim_share: null,
           opinion_share: null,
           avg_importance: 3,
+          max_importance: 5,
           representative_image_url: null,
           published_date: new Date("2026-03-28T10:00:00Z"),
           synthesis_status: "complete",
@@ -300,6 +301,7 @@ describe("GET /api/news", () => {
           grim_share: null,
           opinion_share: null,
           avg_importance: 3,
+          max_importance: 5,
           representative_image_url: null,
           published_date: new Date("2026-03-28T10:00:00Z"),
           synthesis_status: "complete",
@@ -313,6 +315,40 @@ describe("GET /api/news", () => {
 
       expect(body.stories[0].articleCount).toBe(7);
       expect(body.stories[0].outletCount).toBe(2);
+    });
+
+    it("exposes maxImportance alongside avgImportance for the stage-7 floor", async () => {
+      // The floor needs the MAX, and the mean is what dilutes it — so the two
+      // must arrive separately. A story whose best member is a 5 but whose
+      // mean is 2.8 is exactly the case the floor exists for: measured over
+      // 523 prod stories, 5 looked like this.
+      mockGetStoriesWithArticles.mockResolvedValue({
+        stories: [{
+          id: "story1",
+          headline: "One important article, minor company",
+          summary: "A synthesized summary.",
+          category: "technology",
+          framings: [],
+          entities: [],
+          article_count: 3,
+          outlet_count: 3,
+          grim_share: null,
+          opinion_share: null,
+          avg_importance: "2.8",
+          max_importance: 5,
+          representative_image_url: null,
+          published_date: new Date("2026-03-28T10:00:00Z"),
+          synthesis_status: "complete",
+        }],
+        storyArticles: { story1: [] },
+        standaloneArticles: [],
+      });
+
+      const res = await GET(makeRequest("technology"));
+      const body = await res.json();
+
+      expect(body.stories[0].avgImportance).toBeCloseTo(2.8);
+      expect(body.stories[0].maxImportance).toBe(5);
     });
 
     it("passes article tone through and derives story tone from grim_share", async () => {
@@ -330,6 +366,7 @@ describe("GET /api/news", () => {
           grim_share: "0.5",
           opinion_share: "0.5",
           avg_importance: "1.9",
+          max_importance: 2,
           representative_image_url: null,
           published_date: new Date("2026-03-28T10:00:00Z"),
           synthesis_status: "complete",

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -198,6 +198,7 @@ export async function GET(request: NextRequest) {
         // A story is grim when at least half its live members are (D48).
         ...(Number(s.grim_share ?? 0) >= 0.5 ? { tone: "grim" as const } : {}),
         avgImportance: Number(s.avg_importance ?? 3),
+        maxImportance: Number(s.max_importance ?? 3),
         ...(Number(s.opinion_share ?? 0) >= 0.5 ? { isOpinion: true } : {}),
         ...(spectrumBuckets > 0 ? { spectrumBuckets } : {}),
       };

--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -364,6 +364,9 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     // rather than replacing it. Centered on the observed mean story
     // importance (2.50) so the story/article mix #231 tuned is unchanged.
     const STORY_IMPORTANCE_CENTER = 2.5;
+    // Stage 7 floor (mirrors STORY_FLOOR_MIN_IMPORTANCE in lib/db.ts): a
+    // story never ranks below a member this important or better.
+    const STORY_FLOOR_MIN_IMPORTANCE = 4;
     const STORY_BOOST = 2.0;
     const SPECTRUM_BOOST = 0.1;
     // Stage 4 (mirrors OPINION_DAMPENER in lib/db.ts): outlet-declared
@@ -401,6 +404,17 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
         // "major". Absent on an older payload → 1.0 (pre-stage-7 behavior).
         const storyImportance =
           (item.data.avgImportance ?? STORY_IMPORTANCE_CENTER) / STORY_IMPORTANCE_CENTER;
+        // Floor (mirrors STORY_SIGNIFICANCE_SQL): the mean is right against
+        // wire pickup but averages a single important article down, so a real
+        // story diluted by minor co-members never ranks below that member.
+        // Gated at 4 — an unconditional floor restores the single-outlet
+        // leverage stage 7 removed. Applied to significance only, so the
+        // dampeners below still bite.
+        const maxImp = item.data.maxImportance ?? 0;
+        const significance =
+          maxImp >= STORY_FLOOR_MIN_IMPORTANCE
+            ? Math.max(sourceScore * storyImportance, maxImp)
+            : sourceScore * storyImportance;
         const spectrum = 1 + SPECTRUM_BOOST * Math.max(0, (item.data.spectrumBuckets ?? 1) - 1);
         // Corroboration is the story-level analog of importance: a
         // two-outlet grim story dampens, a five-outlet disaster does not.
@@ -414,7 +428,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
         const civic = civicBoost(
           Math.max(0, ...item.data.articles.map((a) => weightedCivicLinks(a.entityLinks)))
         );
-        return sourceScore * decay * spectrum * damp * civic * opDamp * storyImportance;
+        return significance * decay * spectrum * damp * civic * opDamp;
       }
       const importance = item.data.importanceScore ?? 3;
       const damp = item.data.tone === "grim" && importance <= 3 ? GRIM_DAMPENER : 1;

--- a/docs/RANKING_SIGNALS.md
+++ b/docs/RANKING_SIGNALS.md
@@ -95,6 +95,49 @@ continuous factor fixes the mid-range too — a 7-outlet wildfire evacuation at
 mean 3.7 now separates from a 6-outlet trial at mean 2.3, which a cliff
 leaves tied.
 
+### The floor: real news is never averaged into invisibility
+
+*"Will breaking news that's genuinely important but thinly covered end up
+buried?"* Mostly no — and stage 7 is why. Before it, an importance-5 article
+**dropped** from 5.00 to 3.20 the moment a second outlet picked it up, because
+the story score replaced the article score. With stage 7 it *rises* to 6.39.
+A heavily-covered but minor story now outranks fresh important news for
+**1.1 hours** rather than 7.7.
+
+One residual: the mean that defends against wire pickup also **averages a
+single important article down**. Measured over 523 prod stories in 48h, 98
+(19%) rank below their best member — but only **5** have a best member at
+importance 4–5, which is the case that matters:
+
+```
+health    3 outlets  mean 2.8  max 5  ->  4.15
+politics  4 outlets  mean 1.8  max 4  ->  3.09
+business  2 outlets  mean 2.5  max 4  ->  3.20
+```
+
+So significance is floored at the best member's importance, **gated at ≥4**:
+
+```
+significance = max(coverage × mean/CENTER, max_member_importance)   if max ≥ 4
+             =     coverage × mean/CENTER                           otherwise
+```
+
+**The gate is the whole design.** An unconditional floor would undo stage 7 —
+it lets one outlet's importance score set the story's rank, which is exactly
+the single-outlet leverage the mean was chosen to remove. Above 4 that leverage
+is worth paying: an importance-5 article is what the publication most wants
+surfaced, and burying it because its co-members were fluff is a worse error
+than over-ranking one story.
+
+Applied to **significance only**, before the dampeners — D48 (grim), opinion
+and the spectrum bonus still multiply on top. Those are deliberate policy, and
+a floor that outran them would silently revert them.
+
+Replayed against prod across eight categories: **top-20 churn 0–1, two stories
+lifted, 21–34 ms either way.** A safety net that is inert in normal conditions
+and fires only on the case it exists for. Set `STORY_FLOOR_MIN_IMPORTANCE`
+above 5 to disable.
+
 ## Stage 6 — the front page is for news (added from product direction)
 
 *"Sift should be showing important news, not so much entertainment."*

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -191,6 +191,43 @@ const STORY_BOOST = 2.0;
 const STORY_IMPORTANCE_CENTER = 2.5;
 const STORY_IMPORTANCE_SQL = `(COALESCE(AVG(a.importance_score), 3) / ${STORY_IMPORTANCE_CENTER})`;
 
+// Stage 7's floor: a story may never rank below a genuinely important member.
+//
+// Stage 7 scores a story on the MEAN importance of its members, which is the
+// right call against wire pickup — but it also means one important article
+// clustered with minor ones is averaged down. Measured over 523 stories in
+// 48h: 98 (19%) rank below their best member, but only **5** have a best
+// member at importance 4-5. Those 5 are the case worth catching — a real
+// story diluted by its company:
+//
+//   health    3 outlets  mean 2.8  max 5  ->  4.15
+//   politics  4 outlets  mean 1.8  max 4  ->  3.09
+//   business  2 outlets  mean 2.5  max 4  ->  3.20
+//
+// GATED AT 4 ON PURPOSE. An unconditional floor would undo what stage 7 is
+// for: it lets a single outlet's importance score set the story's rank, which
+// is the single-outlet leverage the mean was chosen to remove. Above 4 that
+// leverage is worth it — an importance-5 article is the thing the publication
+// most wants surfaced, and burying it because its co-members were fluff is a
+// worse error than over-ranking one story. Below 4 the mean stands unqualified.
+//
+// Applied to SIGNIFICANCE ONLY — coverage x importance — before the dampeners.
+// D48 (grim), opinion and the spectrum bonus still multiply on top: those are
+// deliberate policy, and a floor that outran them would silently revert them.
+// Set STORY_FLOOR_MIN_IMPORTANCE above 5 to disable.
+const STORY_FLOOR_MIN_IMPORTANCE = 4;
+const STORY_MAX_IMPORTANCE_SQL = `MAX(COALESCE(a.importance_score, 3))`;
+const STORY_SIGNIFICANCE_SQL = `
+         CASE WHEN ${STORY_MAX_IMPORTANCE_SQL} >= ${STORY_FLOOR_MIN_IMPORTANCE}
+              THEN GREATEST(
+                (${STORY_BASE} + ${STORY_BOOST} * LN(1 + COUNT(DISTINCT a.source_name)))::float
+                  * ${STORY_IMPORTANCE_SQL},
+                ${STORY_MAX_IMPORTANCE_SQL}::float)
+              ELSE
+                (${STORY_BASE} + ${STORY_BOOST} * LN(1 + COUNT(DISTINCT a.source_name)))::float
+                  * ${STORY_IMPORTANCE_SQL}
+         END`;
+
 // "sources" in that curve means DISTINCT OUTLETS, not article rows. It counted
 // COUNT(a.id) until 2026-08-11, which is a different thing: measured over 7
 // days of complete stories, 29% had more articles than outlets and 18% were at
@@ -303,6 +340,10 @@ export interface DbStory {
   // Mean importance of the live member articles (stage 7): the story's
   // base significance, which corroboration multiplies rather than replaces.
   avg_importance: string | number | null;
+  // Highest member importance. Only used as the stage-7 floor, so a single
+  // genuinely important article is not averaged into invisibility by minor
+  // co-members. See STORY_FLOOR_MIN_IMPORTANCE.
+  max_importance: string | number | null;
   // Fraction of live member articles flagged is_opinion (0..1); the API
   // boundary derives Story.isOpinion when >= 0.5.
   opinion_share: string | number | null;
@@ -331,6 +372,7 @@ export async function getStoriesWithArticles(
               COUNT(DISTINCT a.source_name)::int AS outlet_count,
               AVG(CASE WHEN a.tone = 'grim' THEN 1.0 ELSE 0 END) AS grim_share,
               COALESCE(AVG(a.importance_score), 3) AS avg_importance,
+              ${STORY_MAX_IMPORTANCE_SQL} AS max_importance,
               AVG(CASE WHEN a.is_opinion THEN 1.0 ELSE 0 END) AS opinion_share,
               s.representative_image_url, s.published_date, s.synthesis_status
        FROM stories s
@@ -343,9 +385,8 @@ export async function getStoriesWithArticles(
        GROUP BY s.id
        HAVING COUNT(a.id) >= 2
        ORDER BY
-         (${STORY_BASE} + ${STORY_BOOST} * LN(1 + COUNT(DISTINCT a.source_name)))::float *
-         EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(s.published_date, s.created_at))), 0) / 86400.0, 700)) *
-         ${STORY_IMPORTANCE_SQL}
+         ${STORY_SIGNIFICANCE_SQL} *
+         EXP(-LEAST(GREATEST(EXTRACT(EPOCH FROM (NOW() - COALESCE(s.published_date, s.created_at))), 0) / 86400.0, 700))
        DESC NULLS LAST
        LIMIT 20`,
       [category]

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -690,6 +690,14 @@ export interface Story {
    */
   avgImportance?: number;
   /**
+   * Highest member importance (1-5). Floors the stage-7 significance so one
+   * genuinely important article is not averaged into invisibility by minor
+   * co-members — gated at 4, because an unconditional floor would restore the
+   * single-outlet leverage the mean was chosen to remove. See
+   * STORY_FLOOR_MIN_IMPORTANCE in lib/db.ts.
+   */
+  maxImportance?: number;
+  /**
    * Distinct L/C/R AllSides buckets occupied by this story's framings (1-3;
    * absent when none are bucketable). Derived at the API boundary via
    * countOccupiedBuckets. Ranking v2 stage 1: the client re-rank applies a


### PR DESCRIPTION
Answering *"will breaking news that's genuinely important but thinly covered end up buried?"*

**Mostly no — and stage 7 (#232) is why.** Before it, an importance-5 article **dropped** from 5.00 → 3.20 the moment a second outlet picked it up, because the story score *replaced* the article score instead of building on it. With stage 7 it rises to 6.39.

| article importance | alone | in a 2-outlet story (pre-#232 → now) |
|---:|---:|---|
| 5 | 5.00 | 3.20 ⚠️ → **6.39** ✓ |
| 4 | 4.00 | 3.20 ⚠️ → **5.12** ✓ |

And a heavily-covered but *minor* story (18 outlets, mean importance 1.9) now outranks fresh important news for **1.1 hours** instead of 7.7.

## The residual this fixes

The mean that defends against wire pickup also **averages a single important article down**. Over 523 prod stories in 48h, 98 (19%) rank below their best member — but only **5** have a best member at importance 4–5, and those are the case that matters:

```
health    3 outlets  mean 2.8  max 5  ->  4.15
politics  4 outlets  mean 1.8  max 4  ->  3.09
business  2 outlets  mean 2.5  max 4  ->  3.20
```

```
significance = max(coverage × mean/CENTER, max_member_importance)   if max >= 4
             =     coverage × mean/CENTER                           otherwise
```

## The gate is the design, not a tuning detail

An **unconditional** floor would undo stage 7 — it lets one outlet's importance score set the story's rank, which is precisely the single-outlet leverage the mean was chosen to remove.

Above 4 that leverage is worth paying for: an importance-5 article is what the publication most wants surfaced, and burying it because its co-members were fluff is a worse error than over-ranking one story. Below 4 the mean stands unqualified.

Applied to **significance only**, before the dampeners — D48 (grim), opinion and the spectrum bonus still multiply on top. Those are deliberate policy, and a floor that outran them would silently revert them.

## Verification

Prod replay across eight categories:

| | |
|---|---|
| top-20 churn | **0–1** |
| stories lifted by the floor | **2** |
| query time | 21–34ms either way |

Inert in normal conditions; fires only on the case it exists for. `STORY_FLOOR_MIN_IMPORTANCE` above 5 disables it.

`tsc` clean, **515 tests**.

Paired with kristenmartino/sift-api#224 (feed-perf mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)