### PR TITLE
Halve the ISR wake rate: revalidate 600 → 1800

### DIFF
--- a/app/agencies/page.tsx
+++ b/app/agencies/page.tsx
@@ -4,9 +4,9 @@ import AgenciesGovernance from "@/components/agencies/AgenciesGovernance";
 import { listAllOrgsLite, listCitedAgencies } from "@/lib/db";
 
 // ISR — statutory governance changes on the order of decades, not days. The
-// only thing that moves here is Sift citing another agency, so a 10-minute
+// only thing that moves here is Sift citing another agency, so a 30-minute
 // window matches the rest of the civic surface without staleness mattering.
-export const revalidate = 600;
+export const revalidate = 1800;
 
 const TITLE = "Who controls a federal agency — Sift";
 const DESC =

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -183,11 +183,11 @@ export async function GET(request: NextRequest) {
         // between pipeline runs — an uncached feed is what would quietly put it
         // back to 24/7 the moment traffic arrives.
         //
-        // 600s matches the `revalidate` every page already carries, so the
+        // 1800s matches the `revalidate` every page already carries, so the
         // freshness contract is unchanged; the pipeline only writes every
         // 1800s anyway. Same pattern as app/api/compare/daily/route.ts.
         headers: {
-          "Cache-Control": "public, s-maxage=600, stale-while-revalidate=3600",
+          "Cache-Control": "public, s-maxage=1800, stale-while-revalidate=3600",
         },
       }
     );

--- a/app/bill/[id]/opengraph-image.tsx
+++ b/app/bill/[id]/opengraph-image.tsx
@@ -4,7 +4,7 @@ import { clampOgTitle, OG_SIZE } from "@/lib/og";
 import { createDossierOgImage } from "@/lib/ogImage";
 
 // Same heartbeat as the page — the unfurl should never outlive the dossier.
-export const revalidate = 600;
+export const revalidate = 1800;
 export const size = OG_SIZE;
 export const contentType = "image/png";
 export const alt = "Bill dossier on Sift — the news, with footnotes";

--- a/app/bill/[id]/page.tsx
+++ b/app/bill/[id]/page.tsx
@@ -10,7 +10,7 @@ import { isPublishableBill } from "@/lib/publishFloor";
 import { billJsonLd } from "@/lib/structuredData";
 
 // ISR — same heartbeat as the other dossier routes.
-export const revalidate = 600;
+export const revalidate = 1800;
 
 interface BillRouteProps {
   params: Promise<{ id: string }>;

--- a/app/civic/page.tsx
+++ b/app/civic/page.tsx
@@ -9,9 +9,9 @@ import {
 import type { PoliticianChamber } from "@/lib/types";
 
 // ISR — committee/dossier metadata changes slowly (politician roster ~6mo,
-// org curation ~quarterly, bills as we add them). 10-minute cache keeps the
+// org curation ~quarterly, bills as we add them). 30-minute cache keeps the
 // page snappy without staleness mattering at this cadence.
-export const revalidate = 600;
+export const revalidate = 1800;
 
 // Per-route metadata override so shared /civic links carry the index's
 // own title/description in unfurl cards (not the homepage default).

--- a/app/colophon/page.tsx
+++ b/app/colophon/page.tsx
@@ -11,8 +11,8 @@ export const metadata: Metadata = {
 };
 
 // ISR — the architecture note carries the live curated-outlet count, read from
-// outlet_profiles. Same 10-minute heartbeat as the landing + methodology.
-export const revalidate = 600;
+// outlet_profiles. Same 30-minute heartbeat as the landing + methodology.
+export const revalidate = 1800;
 
 const STACK = [
   { name: "Next.js 15", role: "Frontend & App Router on Vercel" },

--- a/app/methodology/page.tsx
+++ b/app/methodology/page.tsx
@@ -15,9 +15,9 @@ export const metadata: Metadata = {
 
 // ISR — methodology copy itself is static, but the live outlet list reads
 // from outlet_profiles which changes when new outlets are curated. Same
-// 10-minute heartbeat as the landing keeps the list fresh without paying
+// 30-minute heartbeat as the landing keeps the list fresh without paying
 // the DB cost on every visit.
-export const revalidate = 600;
+export const revalidate = 1800;
 
 type BucketKey = CrossSpectrumBucket | "unrated";
 

--- a/app/org/[slug]/opengraph-image.tsx
+++ b/app/org/[slug]/opengraph-image.tsx
@@ -4,7 +4,7 @@ import { createDossierOgImage } from "@/lib/ogImage";
 import { formatOrgTypeLabel } from "@/lib/org";
 
 // Same heartbeat as the page — the unfurl should never outlive the dossier.
-export const revalidate = 600;
+export const revalidate = 1800;
 export const size = OG_SIZE;
 export const contentType = "image/png";
 export const alt = "Organization dossier on Sift — the news, with footnotes";

--- a/app/org/[slug]/page.tsx
+++ b/app/org/[slug]/page.tsx
@@ -12,8 +12,8 @@ import { orgJsonLd } from "@/lib/structuredData";
 
 // ISR — same heartbeat as the landing + outlet/politician dossiers.
 // Org metadata changes slowly (annual budgets refresh on 990 cycles,
-// FARA registrations are sporadic), so 600s is well-matched.
-export const revalidate = 600;
+// FARA registrations are sporadic), so 1800s is well-matched.
+export const revalidate = 1800;
 
 interface OrgRouteProps {
   params: Promise<{ slug: string }>;

--- a/app/outlet/[slug]/opengraph-image.tsx
+++ b/app/outlet/[slug]/opengraph-image.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/lib/outlet";
 
 // Same heartbeat as the page — the unfurl should never outlive the dossier.
-export const revalidate = 600;
+export const revalidate = 1800;
 export const size = OG_SIZE;
 export const contentType = "image/png";
 export const alt = "Outlet dossier on Sift — the news, with footnotes";

--- a/app/outlet/[slug]/page.tsx
+++ b/app/outlet/[slug]/page.tsx
@@ -10,10 +10,10 @@ import { isPublishableOutlet } from "@/lib/publishFloor";
 import { outletJsonLd } from "@/lib/structuredData";
 import type { Article } from "@/lib/types";
 
-// ISR — same heartbeat as the landing page (10 minutes). The dossier reads
+// ISR — same heartbeat as the landing page (30 minutes). The dossier reads
 // curated metadata that changes quarterly + recent articles that change every
-// pipeline cycle, so a 600s edge cache is well-matched on both sides.
-export const revalidate = 600;
+// pipeline cycle, so a 1800s edge cache is well-matched on both sides.
+export const revalidate = 1800;
 
 interface DossierRouteProps {
   params: Promise<{ slug: string }>;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,11 +19,27 @@ export const metadata: Metadata = {
     "Sift curates outlets across the political spectrum and adds the civic context, cross-spectrum framing, and money trail the news assumes you already know. Every claim links to a public record.",
 };
 
-// ISR: re-render at most once every 10 minutes. This bounds staleness of the
+// 600 -> 1800 on 2026-08-14, and this is the page that carries the reason for
+// all of them.
+//
+// Every ISR revalidation runs lib/db.ts against Neon, and Neon's compute
+// scales to zero only after 300s with no query. A dozen pages each on their
+// own 600s timer, staggered by whenever they were last requested, produce a
+// query far more often than every 300s under nothing more than crawler
+// traffic — which is enough to hold the compute open around the clock. That
+// was measured, not assumed: after sift-api stopped polling, the compute still
+// showed 26 days of unbroken uptime, and pg_stat_activity named the waker as
+// this app via Neon's pgbouncer.
+//
+// 1800s is not arbitrary. The background pipeline writes every 1800s, so the
+// data cannot be fresher than that and a shorter window buys nothing but
+// compute time. See sift/docs/DECISIONS.md D54.
+//
+// ISR: re-render at most once every 30 minutes. This bounds staleness of the
 // server-fetched lead story + outlet list only — the masthead carries no
 // date/issue stamp (see LandingMasthead), so nothing time-sensitive freezes
 // into the ISR cache. The background pipeline refreshes content every ~30 min.
-export const revalidate = 600;
+export const revalidate = 1800;
 
 export default async function Home() {
   const [lead, outletProfiles, outletMap, dailyCompare] = await Promise.all([

--- a/app/politician/[bioguide]/opengraph-image.tsx
+++ b/app/politician/[bioguide]/opengraph-image.tsx
@@ -4,7 +4,7 @@ import { createDossierOgImage } from "@/lib/ogImage";
 import { formatChamberLabel } from "@/lib/politician";
 
 // Same heartbeat as the page — the unfurl should never outlive the dossier.
-export const revalidate = 600;
+export const revalidate = 1800;
 export const size = OG_SIZE;
 export const contentType = "image/png";
 export const alt = "Politician dossier on Sift — the news, with footnotes";

--- a/app/politician/[bioguide]/page.tsx
+++ b/app/politician/[bioguide]/page.tsx
@@ -8,11 +8,11 @@ import { dossierMetadata } from "@/lib/metadata";
 import { isPublishablePolitician } from "@/lib/publishFloor";
 import { politicianJsonLd } from "@/lib/structuredData";
 
-// ISR — same heartbeat as the landing + outlet dossier (10 minutes).
+// ISR — same heartbeat as the landing + outlet dossier (30 minutes).
 // Politician metadata changes slowly (committees shift quarterly,
 // donor/voting data updates daily via the Phase 3.E refresh job), so a
-// 600s edge cache is well-matched on both sides.
-export const revalidate = 600;
+// 1800s edge cache is well-matched on both sides.
+export const revalidate = 1800;
 
 interface PoliticianRouteProps {
   params: Promise<{ bioguide: string }>;

--- a/app/think-tanks/page.tsx
+++ b/app/think-tanks/page.tsx
@@ -5,7 +5,7 @@ import { listSelfDescribedOrgs } from "@/lib/db";
 
 // ISR — a self-description changes when an organization rewrites its About
 // page, which is rare. Matches the rest of the civic surface.
-export const revalidate = 600;
+export const revalidate = 1800;
 
 const TITLE = "How policy organizations describe themselves — Sift";
 const DESC =


### PR DESCRIPTION
Every ISR revalidation runs `lib/db.ts` against Neon, and Neon's compute scales to zero only after **300s with no query**. Twelve pages each on their own 600s timer, staggered by whenever each was last requested, produce a query far more often than every 300s under nothing but crawler traffic.

## Measured, not assumed

After [sift-api#236](https://github.com/kristenmartino/sift-api/pull/236) stopped the backend polling, the compute *still* showed **26 days of unbroken uptime** with 13 minutes of quiet behind it. `pg_stat_activity` named the waker:

```
application_name: pgbouncer   state: idle   backend_start: 14:12:57
last query 14:15:13: SELECT slug, name, type, founded_year, annual_budget_usd, …
```

That's `org_profiles` — **this app**, through Neon's pooler. sift-api was one cause of the 24/7 compute, not the only one, and I had presented it as the whole story.

## Why 1800 specifically

Not arbitrary: **the background pipeline writes every 1800s.** The data cannot be fresher than that, so a shorter window buys nothing but compute time.

Each file already stated its cadence in prose ("10-minute cache", "600s edge cache"), so every comment was updated alongside its constant rather than left to contradict the number beneath it. `app/page.tsx` carries the full reasoning; the rest carry the number. `/api/news`'s `s-maxage` moves to 1800 too — its comment claims to match what the pages carry, and now does. `sitemap.ts` stays at 3600.

## Confirmed working

The compute **suspended for the first time** at 15:57 UTC on 2026-08-14 — `pg_postmaster_start_time()` moved off `2026-07-19 09:00:52` after 26 days. So the wake sources are now sporadic rather than continuous; this change reduces how often the remaining one fires.

## Incidental correction

`application_name=pgbouncer` means Vercel **is** on Neon's pooled endpoint. The D18 note in `docs/DECISIONS.md` claiming no client uses `-pooler` was inferred from the local `.env` and is wrong for production — correcting separately.

## Verification

`tsc` clean, `807 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)