### PR TITLE
Count a term's coverage by the primer too, not just the headline

### DIFF
--- a/__tests__/copyFormatters.test.ts
+++ b/__tests__/copyFormatters.test.ts
@@ -338,3 +338,21 @@ describe("term.definitionCitation", () => {
     );
   });
 });
+
+describe("term.coverageMethod", () => {
+  it("tells the reader the count includes stories that never print the term", () => {
+    // Not decoration. Once the primer counts, the story list contains pieces
+    // whose headline and summary never use the term — a reader who clicks
+    // through and finds one would otherwise conclude the count is wrong.
+    const m = COPY.term.coverageMethod;
+    expect(m).toContain("headline or summary");
+    expect(m).toContain("reading notes");
+    expect(m).toMatch(/never spell out|never print/);
+  });
+
+  it("does not describe the reading notes as a source or a definition", () => {
+    // The primer is a coverage signal only. Every primer term in the corpus
+    // carries source: null, which is the entire reason term_profiles exists.
+    expect(COPY.term.coverageMethod).not.toMatch(/\bsource\b|\bcited\b|\bdefines\b/i);
+  });
+});

--- a/components/term/TermDossier.tsx
+++ b/components/term/TermDossier.tsx
@@ -147,6 +147,13 @@ export default function TermDossier({
                   {COPY.term.dateSpan(coverage.firstSeen, coverage.lastSeen)}
                 </p>
               )}
+              {/* How the count was reached. The list below contains stories
+                  that never print the term — they were matched by the primer
+                  — so a reader who clicks through would otherwise think the
+                  count was wrong. */}
+              <p className="font-body text-[12px] text-(--text-tertiary) leading-relaxed mt-4 max-w-[60ch]">
+                {COPY.term.coverageMethod}
+              </p>
             </>
           )}
         </section>

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -619,6 +619,14 @@ export const COPY = {
       `${outlets.toLocaleString()} ${outlets === 1 ? "outlet" : "outlets"}.`,
     dateSpan: (first: string, last: string) =>
       first === last ? `Filed ${first}.` : `Filed ${first} — ${last}.`,
+    // How the count was arrived at. Worth saying plainly on a page whose
+    // whole argument is that Sift shows its working: the number counts two
+    // different things, and a reader who clicks through will notice that some
+    // stories never print the term.
+    coverageMethod:
+      "Counts stories whose headline or summary uses the term, plus stories " +
+      "where Sift's own reading notes flagged it — many pieces turn on a term " +
+      "they never spell out in the headline.",
     // Shown when the corpus has nothing. Says what it means, and does not
     // pretend the term is unimportant.
     noCoverage:

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1339,17 +1339,27 @@ const SITEMAP_TERM_BRANCH = String.raw`
               WHERE a.from_search = false
                 AND a.summary IS NOT NULL AND a.summary <> ''
                 AND LOWER(a.summary) NOT LIKE 'unable to provide%'
-                AND to_tsvector('english', COALESCE(a.title,'') || ' ' || COALESCE(a.summary,''))
-                    @@ phraseto_tsquery('english', f.s)
-                -- Prefilter above, exact predicate below — both load-bearing.
-                -- See termMatchSql for why. All-caps forms match
-                -- case-sensitively, mirroring isAcronym in lib/term.ts.
-                AND CASE WHEN f.s = UPPER(f.s)
-                         THEN (COALESCE(a.title,'') || ' ' || COALESCE(a.summary,'')) ~
-                              ('\m' || regexp_replace(f.s, '([.*+?^$(){}|\[\]\\])', '\\\1', 'g') || '\M')
-                         ELSE (COALESCE(a.title,'') || ' ' || COALESCE(a.summary,'')) ~*
-                              ('\m' || regexp_replace(f.s, '([.*+?^$(){}|\[\]\\])', '\\\1', 'g') || '\M')
-                    END
+                -- Same two halves as termMatchSql, and they must stay the
+                -- same: this decides the sitemap, that decides the page, and
+                -- a disagreement means a page says noindex while the sitemap
+                -- lists it.
+                AND (
+                     (to_tsvector('english', COALESCE(a.title,'') || ' ' || COALESCE(a.summary,''))
+                        @@ phraseto_tsquery('english', f.s)
+                      -- Prefilter above, exact predicate below — both
+                      -- load-bearing. All-caps forms match case-sensitively,
+                      -- mirroring isAcronym in lib/term.ts.
+                      AND CASE WHEN f.s = UPPER(f.s)
+                               THEN (COALESCE(a.title,'') || ' ' || COALESCE(a.summary,'')) ~
+                                    ('\m' || regexp_replace(f.s, '([.*+?^$(){}|\[\]\\])', '\\\1', 'g') || '\M')
+                               ELSE (COALESCE(a.title,'') || ' ' || COALESCE(a.summary,'')) ~*
+                                    ('\m' || regexp_replace(f.s, '([.*+?^$(){}|\[\]\\])', '\\\1', 'g') || '\M')
+                          END)
+                     -- The primer half (migration 033). An article counts
+                     -- when Sift's reading-aid layer defined the term for it,
+                     -- even if the headline never says it.
+                     OR primer_term_keys(a.context_primer) && ARRAY[lower(btrim(f.s))]
+                    )
            ) m ON TRUE
           WHERE t.definition IS NOT NULL AND t.definition_source IS NOT NULL
           GROUP BY t.slug, t.updated_at
@@ -1407,7 +1417,10 @@ const SITEMAP_TERM_BRANCH = String.raw`
  *   coverage is not stored, so the SQL recomputes it. Without the coverage
  *   half a term page is a definition Cornell wrote and we cited — strictly
  *   worse than Cornell, and the "one row poured into a template" shape this
- *   whole function exists to keep out of the index.
+ *   whole function exists to keep out of the index. Coverage counts a title/
+ *   summary match **or** a primer definition; counting only the former
+ *   withheld `prior-restraint` for having "no coverage" while 128 articles
+ *   were about it.
  */
 export async function listSitemapEntries(): Promise<SitemapEntry[]> {
   try {
@@ -1550,10 +1563,20 @@ const TERM_MATCH_TSV =
 const TERM_MATCH_TEXT = "(COALESCE(a.title,'') || ' ' || COALESCE(a.summary,''))";
 
 /**
- * SQL for "this article mentions the term", as `(prefilter AND exact) OR ...`
- * over every surface form.
+ * SQL for "this article involves the term".
  *
- * **Both halves are load-bearing; do not simplify to either one alone.**
+ * Two independent signals, OR'd: the term appears in the title or summary, or
+ * the article's own context primer defined it. The second is the subject of
+ * the long note inside the function — it is what makes the page work for
+ * terms that live in article bodies rather than headlines.
+ *
+ * Note the shift from "mentions" to "involves". Once the primer counts, an
+ * article can be covered by a term it never literally prints, which is the
+ * point — and it is why the copy says "stories in Sift's index" rather than
+ * "stories mentioning".
+ *
+ * **The text half's two parts are both load-bearing; do not simplify to
+ * either one alone.**
  *
  * - The `@@ phraseto_tsquery` half is only there for speed. It rides the GIN
  *   index and cuts 305k rows to a few hundred: measured 1,030 ms and ~52,000
@@ -1583,6 +1606,46 @@ function termMatchSql(
     return `(${TERM_MATCH_TSV} @@ phraseto_tsquery('english', $${phraseIdx})
              AND ${TERM_MATCH_TEXT} ${op} $${regexIdx})`;
   });
+
+  // ── The primer half ──
+  //
+  // An article also counts when Sift's own reading-aid layer defined the term
+  // for it, even if the term never reaches the headline. Without this the
+  // coverage signal misses exactly the terms most worth a page, because they
+  // are what a journalist writes in paragraph nine — measured against the
+  // corpus: prior restraint 0 title/summary matches against 128 primer
+  // definitions, certiorari 5 vs 83, qualified immunity 6 vs 75, cloture 0 vs
+  // 45. `/term/prior-restraint` was withheld from the sitemap for "no
+  // coverage" while 128 articles were about it.
+  //
+  // This does not weaken what the page claims, for two reasons:
+  //
+  // 1. It is still reportage about Sift's own index, not a claim about the
+  //    world — the same footing the text half stands on, and why neither
+  //    needs a citation beyond the articles it links.
+  // 2. It is the *higher-precision* half. The primer generator read the
+  //    article; the regex only sees a string. #40 is the standing reminder of
+  //    what a context-free matcher does to a corpus, and it argues for this
+  //    signal rather than against it.
+  //
+  // What the primer still cannot do is define anything: all 72,689 primer
+  // terms in the corpus carry `source: null`, which is why term_profiles is
+  // hand-written. Coverage, yes; definition, never.
+  //
+  // Case is folded on both sides — inside `primer_term_keys` (migration 033)
+  // and here — because the generator is not consistent ('redistricting' 483,
+  // 'Redistricting' 2).
+  const primerIdx = firstParam + params.length;
+  params.push(
+    // Postgres text[] literal. Surface forms are curated and validated by
+    // seed_term_profiles.py, but quote-escape anyway — this is string-built
+    // SQL touching user-visible counts.
+    `{${patterns
+      .map((p) => `"${p.phrase.toLowerCase().replace(/(["\\])/g, "\\$1")}"`)
+      .join(",")}}`,
+  );
+  clauses.push(`primer_term_keys(a.context_primer) && $${primerIdx}::text[]`);
+
   return { sql: `(${clauses.join(" OR ")})`, params };
 }
 
@@ -1620,7 +1683,10 @@ async function getTermBySlugUncached(slug: string): Promise<TermProfile | null> 
  * Nothing here is stored, and nothing here needs a citation — it is a count of
  * articles Sift holds, not a claim about the world. Which is the whole reason
  * this half of the page can be generated while the definition half has to be
- * hand-sourced.
+ * hand-sourced. That holds for the primer half of the match too: "our own
+ * reading-aid layer flagged this term for this article" is a fact about the
+ * index. What the primer cannot do is *define* the term — every primer term
+ * in the corpus has `source: null`.
  *
  * Outlet identity resolves the same way `getRecentArticlesByOutletSlug` does
  * (explicit `source_name_aliases`, else `outlet_profiles.name`), so an outlet


### PR DESCRIPTION
**Depends on [sift-api#252](https://github.com/kristenmartino/sift-api/pull/252)** (migration 033 adds `primer_term_keys` + the GIN index). Merge that first.

## The gap

The coverage query searched title + summary only. That misses the terms most worth a page, because they are what a journalist writes in paragraph nine rather than the headline — so `/term/prior-restraint` was withheld from the sitemap for having "no coverage" while **128 articles were about it**.

An article now counts when the term appears in the title or summary, **or** when the article's own context primer defined it.

## Replay across all 24 curated terms

| term | before | after | |
|---|---|---|---|
| prior-restraint | 0 | **128** | newly publishes |
| certiorari | 5 | **84** | newly publishes |
| qualified-immunity | 6 | **75** | newly publishes |
| cloture | 0 | **45** | newly publishes |
| injunction | 139 | 284 | |
| subpoena | 118 | 227 | |
| gerrymandering | 198 | 292 | |
| appropriations | 107 | 178 | |
| redistricting | 806 | 844 | |

**20/24 above the floor → 24/24.** Not one term lost coverage; the signal is purely additive.

## Why this doesn't weaken what the page claims

Both halves are **reportage about Sift's own index**, not claims about the world — the same footing that lets the coverage half be generated while the definition half must be hand-sourced.

And the primer is the *higher-precision* half. Its generator read the article; the regex only sees a string. #40 — where a context-free matcher put `the-nation` on 1,523 articles about "the nation's fuel" — argues **for** this signal, not against it.

What the primer still cannot do is define anything. All **72,689** primer terms in the corpus carry `source: null`. Coverage, yes; definition, never. That distinction is asserted in a test.

## The reader is told, because the page would otherwise look wrong

The story list now contains pieces whose headline never prints the term. On `/term/prior-restraint`: a publisher refusing a retraction demand, a French social-media ban struck down, press groups suing over Truth Social access. Someone clicking through would reasonably conclude the count was padded.

`COPY.term.coverageMethod` now says plainly that the count includes stories flagged by Sift's own reading notes — and a test asserts that string never describes those notes as a *source* or a *definition*.

## Verification

- All 24 pages render against prod data; the four formerly-withheld ones emit `index, follow` with `max-image-preview:large` still inherited.
- Sitemap carries 24 `/term/` entries — SQL floor and TS predicate agree, as the invariant requires.
- 849 tests pass; `tsc --noEmit` clean.
- **No feed impact**: `getTermCoverage` is read only by the term route and the sitemap. Unlike the alias fix, nothing here touches `spectrumBuckets` or ranking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)