### PR TITLE
Add /glossary — the index over the term pages

### DIFF
--- a/__tests__/copyFormatters.test.ts
+++ b/__tests__/copyFormatters.test.ts
@@ -356,3 +356,53 @@ describe("term.coverageMethod", () => {
     expect(COPY.term.coverageMethod).not.toMatch(/\bsource\b|\bcited\b|\bdefines\b/i);
   });
 });
+
+describe("termIndex formatters", () => {
+  const c = COPY.termIndex;
+
+  it("does not shadow COPY.glossary, which is the entity-chip layer", () => {
+    // The first draft of this page used `glossary` for both. It type-checked
+    // as a duplicate object key, silently shadowed the chip namespace, and
+    // broke EntityChipTooltip and EntityLinksList. Pinning both shapes so a
+    // future rename cannot quietly do it again.
+    expect(COPY.glossary.eyebrow).toBe("Mentioned in this story");
+    expect(COPY.glossary.typeGlyphs).toBeDefined();
+    expect(c.eyebrow).toBe("Civic glossary");
+  });
+
+  it("states the finding with real numbers and names the starkest term", () => {
+    const f = c.finding(1030, 4828, "Prior Restraint");
+    expect(f).toContain("1,030");
+    expect(f).toContain("4,828");
+    expect(f).toContain("21 in every 100");
+    expect(f).toContain("Prior Restraint");
+  });
+
+  it("says nothing about held-back terms when none are held back", () => {
+    // A "0 further terms are held back" sentence is noise, and the negative
+    // case would read as an error.
+    expect(c.gapNote(24, 24)).toBe("");
+    expect(c.gapNote(24, 20)).toBe("");
+  });
+
+  it("pluralizes the held-back note", () => {
+    expect(c.gapNote(24, 25)).toContain("1 further term is");
+    expect(c.gapNote(24, 27)).toContain("3 further terms are");
+  });
+
+  it("pluralizes the per-row coverage line", () => {
+    expect(c.rowCoverage(1, 1)).toBe("1 story · 1 outlet");
+    expect(c.rowCoverage(1234, 23)).toBe("1,234 stories · 23 outlets");
+  });
+
+  it("omits the never-named share when every story names the term", () => {
+    expect(c.rowUnnamed(0, 100)).toBe("");
+    expect(c.rowUnnamed(128, 128)).toBe("100% never name it");
+    expect(c.rowUnnamed(69, 75)).toBe("92% never name it");
+  });
+
+  it("pluralizes the term count", () => {
+    expect(c.countLabel(1)).toContain("1 term,");
+    expect(c.countLabel(24)).toContain("24 terms,");
+  });
+});

--- a/app/agencies/page.tsx
+++ b/app/agencies/page.tsx
@@ -8,7 +8,15 @@ import { listAllOrgsLite, listCitedAgencies } from "@/lib/db";
 // window matches the rest of the civic surface without staleness mattering.
 export const revalidate = 1800;
 
-const TITLE = "Who controls a federal agency — Sift";
+// The page title carries NO brand: app/layout.tsx sets
+// `template: "%s | Sift"`, so hardcoding "— Sift" here rendered
+// "... — Sift | Sift" — live on /agencies and /think-tanks until 2026-08-17.
+// Wasted characters matter on a page built for search: Google truncates
+// around 60. The unfurl title keeps the brand, because openGraph/twitter get
+// no template — the same split `dossierMetadata` already makes for /outlet
+// and friends.
+const TITLE = "Who controls a federal agency";
+const TITLE_UNFURL = `${TITLE} — Sift`;
 const DESC =
   "Appointment, terms, and the partisan-balance limits Congress wrote into statute. Every line cited to the section it came from. No AI-generated text.";
 
@@ -16,8 +24,8 @@ export const metadata: Metadata = {
   title: TITLE,
   description: DESC,
   alternates: { canonical: "/agencies" },
-  openGraph: { title: TITLE, description: DESC, type: "website" },
-  twitter: { card: "summary_large_image", title: TITLE, description: DESC },
+  openGraph: { title: TITLE_UNFURL, description: DESC, type: "website" },
+  twitter: { card: "summary_large_image", title: TITLE_UNFURL, description: DESC },
 };
 
 export default async function AgenciesPage() {

--- a/app/civic/page.tsx
+++ b/app/civic/page.tsx
@@ -15,7 +15,15 @@ export const revalidate = 1800;
 
 // Per-route metadata override so shared /civic links carry the index's
 // own title/description in unfurl cards (not the homepage default).
-const CIVIC_TITLE = "Civic dossiers — Sift";
+// The page title carries NO brand: app/layout.tsx sets
+// `template: "%s | Sift"`, so hardcoding "— Sift" here rendered
+// "... — Sift | Sift" — live on /agencies and /think-tanks until 2026-08-17.
+// Wasted characters matter on a page built for search: Google truncates
+// around 60. The unfurl title keeps the brand, because openGraph/twitter get
+// no template — the same split `dossierMetadata` already makes for /outlet
+// and friends.
+const CIVIC_TITLE = "Civic dossiers";
+const CIVIC_TITLE_UNFURL = `${CIVIC_TITLE} — Sift`;
 // Count-free on purpose: the hardcoded "536 sitting members" froze stale
 // while the corpus grew past 600 (executives, foreign leaders, SCOTUS).
 // Same rule as the outlet count — quote a number only where it's derived.
@@ -26,13 +34,13 @@ export const metadata: Metadata = {
   title: CIVIC_TITLE,
   description: CIVIC_DESC,
   openGraph: {
-    title: CIVIC_TITLE,
+    title: CIVIC_TITLE_UNFURL,
     description: CIVIC_DESC,
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: CIVIC_TITLE,
+    title: CIVIC_TITLE_UNFURL,
     description: CIVIC_DESC,
   },
 };

--- a/app/glossary/page.tsx
+++ b/app/glossary/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+
+import TermIndex from "@/components/term/TermIndex";
+import { countDefinedTerms, listPublishedTerms } from "@/lib/db";
+
+// ISR — the definitions change when a human edits the CSV, but the coverage
+// counts move every pipeline cycle, and they are what the page argues from.
+// 30 minutes matches the rest of the civic surface.
+export const revalidate = 1800;
+
+// The page title carries NO brand: app/layout.tsx sets
+// `template: "%s | Sift"`, so hardcoding "— Sift" here rendered
+// "... — Sift | Sift" — live on /agencies and /think-tanks until 2026-08-17.
+// Wasted characters matter on a page built for search: Google truncates
+// around 60. The unfurl title keeps the brand, because openGraph/twitter get
+// no template — the same split `dossierMetadata` already makes for /outlet
+// and friends.
+const TITLE = "The words the news assumes you already know";
+const TITLE_UNFURL = `${TITLE} — Sift`;
+const DESC =
+  "Civic terms defined from the primary record — statute, constitutional clause, regulation — and shown as they are actually being covered. Roughly one story in five turns on a term the coverage never names.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESC,
+  alternates: { canonical: "/glossary" },
+  openGraph: { title: TITLE_UNFURL, description: DESC, type: "website" },
+  twitter: { card: "summary_large_image", title: TITLE_UNFURL, description: DESC },
+};
+
+export default async function GlossaryPage() {
+  const [terms, definedCount] = await Promise.all([
+    listPublishedTerms(),
+    countDefinedTerms(),
+  ]);
+
+  // Terms defined but below the floor. Clamped at 0 because the two queries
+  // are independent: a term seeded between them would otherwise render as a
+  // negative count in the gap note.
+  const heldCount = Math.max(0, definedCount - terms.length);
+
+  return <TermIndex terms={terms} heldCount={heldCount} />;
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -32,6 +32,9 @@ const STATIC_ROUTES: Array<{
   { path: "/civic", changeFrequency: "weekly", priority: 0.8 },
   { path: "/agencies", changeFrequency: "monthly", priority: 0.7 },
   { path: "/think-tanks", changeFrequency: "monthly", priority: 0.7 },
+  // Weekly, not monthly: the coverage counts this page argues from move
+  // every pipeline cycle, unlike the statutory text on /agencies.
+  { path: "/glossary", changeFrequency: "weekly", priority: 0.7 },
   { path: "/methodology", changeFrequency: "monthly", priority: 0.5 },
   { path: "/colophon", changeFrequency: "monthly", priority: 0.3 },
   { path: "/privacy", changeFrequency: "yearly", priority: 0.2 },

--- a/app/think-tanks/page.tsx
+++ b/app/think-tanks/page.tsx
@@ -7,7 +7,15 @@ import { listSelfDescribedOrgs } from "@/lib/db";
 // page, which is rare. Matches the rest of the civic surface.
 export const revalidate = 1800;
 
-const TITLE = "How policy organizations describe themselves — Sift";
+// The page title carries NO brand: app/layout.tsx sets
+// `template: "%s | Sift"`, so hardcoding "— Sift" here rendered
+// "... — Sift | Sift" — live on /agencies and /think-tanks until 2026-08-17.
+// Wasted characters matter on a page built for search: Google truncates
+// around 60. The unfurl title keeps the brand, because openGraph/twitter get
+// no template — the same split `dossierMetadata` already makes for /outlet
+// and friends.
+const TITLE = "How policy organizations describe themselves";
+const TITLE_UNFURL = `${TITLE} — Sift`;
 const DESC =
   "Think tanks and advocacy organizations quoted from their own sites — not summarized, not rated, not characterized. Every quote linked to its source. No AI-generated text.";
 
@@ -15,8 +23,8 @@ export const metadata: Metadata = {
   title: TITLE,
   description: DESC,
   alternates: { canonical: "/think-tanks" },
-  openGraph: { title: TITLE, description: DESC, type: "website" },
-  twitter: { card: "summary_large_image", title: TITLE, description: DESC },
+  openGraph: { title: TITLE_UNFURL, description: DESC, type: "website" },
+  twitter: { card: "summary_large_image", title: TITLE_UNFURL, description: DESC },
 };
 
 export default async function ThinkTanksPage() {

--- a/components/civic/CivicIndex.tsx
+++ b/components/civic/CivicIndex.tsx
@@ -215,6 +215,17 @@ export default function CivicIndex({
                 {c.thinkTanksCrossLink}
               </Link>
             </p>
+            {/* Third cut of the same corpus. A term page is the one dossier
+                type that is not an entity, so it belongs beside these rather
+                than in the politician/org lists above. */}
+            <p className="font-body text-[14px] mt-2 leading-relaxed">
+              <Link
+                href="/glossary"
+                className="text-(--accent) no-underline hover:underline"
+              >
+                {c.termIndexCrossLink}
+              </Link>
+            </p>
           </header>
 
           {orgTypeGroups.length === 0 ? (

--- a/components/term/TermIndex.tsx
+++ b/components/term/TermIndex.tsx
@@ -1,0 +1,194 @@
+import Link from "next/link";
+
+import CorrectionPath from "@/components/CorrectionPath";
+import LandingMasthead from "@/components/landing/LandingMasthead";
+import { COPY } from "@/lib/copy";
+import type { TermListItem } from "@/lib/types";
+
+interface TermIndexProps {
+  terms: TermListItem[];
+  /** Terms defined but below the floor — for the honest gap note. */
+  heldCount: number;
+}
+
+/** Section headings for `term_profiles.category`. */
+const CATEGORY_LABELS: Record<string, string> = {
+  congress: "Congress",
+  courts: "Courts",
+  executive: "The executive",
+  elections: "Elections",
+  constitution: "Constitution",
+  immigration: "Immigration",
+  "first-amendment": "Speech and the press",
+  business: "Business and markets",
+};
+
+/** Stable order — the branches first, then the areas they act on. */
+const CATEGORY_ORDER = [
+  "constitution",
+  "congress",
+  "executive",
+  "courts",
+  "elections",
+  "first-amendment",
+  "immigration",
+  "business",
+];
+
+function categoryRank(c: string | null): number {
+  const i = CATEGORY_ORDER.indexOf(c ?? "");
+  // Unknown or uncategorised sorts last rather than disappearing — a term
+  // added with a new category still shows up, under its own raw label.
+  return i === -1 ? CATEGORY_ORDER.length : i;
+}
+
+/**
+ * `/glossary` — the index over `/term/<slug>`.
+ *
+ * Lives in components/term/ beside TermDossier rather than in
+ * components/glossary/, which belongs to the inline entity-chip layer.
+ *
+ * Named `/glossary` rather than `/terms` for two reasons: `/terms` is the
+ * Terms of Service, and `/agencies` and `/think-tanks` already establish that
+ * a collection page takes a plain-English name rather than the route segment
+ * its children live under.
+ *
+ * The page leads with a finding rather than the list, following `/agencies`:
+ * a reader who stops after the first screen should still leave with the one
+ * fact that makes it worth sending on. Here that fact is that roughly one
+ * story in five turns on a term the coverage never names — which is precisely
+ * why a reader cannot look the term up, and so precisely why these pages
+ * exist. Every number in it is computed from the live corpus.
+ */
+export default function TermIndex({ terms, heldCount }: TermIndexProps) {
+  const c = COPY.termIndex;
+
+  const totalArticles = terms.reduce((n, t) => n + t.articleCount, 0);
+  const totalUnnamed = terms.reduce((n, t) => n + t.unnamedCount, 0);
+  // The starkest example, for the finding sentence. Ties broken by volume so
+  // the named term is one a reader plausibly recognises.
+  const worst = [...terms].sort(
+    (a, b) =>
+      b.unnamedCount / b.articleCount - a.unnamedCount / a.articleCount ||
+      b.articleCount - a.articleCount,
+  )[0];
+
+  const groups = [...new Set(terms.map((t) => t.category))]
+    .sort((a, b) => categoryRank(a) - categoryRank(b))
+    .map((cat) => ({
+      key: cat ?? "other",
+      label: cat ? (CATEGORY_LABELS[cat] ?? cat) : "Other",
+      items: terms.filter((t) => t.category === cat),
+    }))
+    .filter((g) => g.items.length > 0);
+
+  const gapNote = c.gapNote(terms.length, terms.length + heldCount);
+
+  return (
+    <div className="min-h-screen bg-(--surface-base) text-(--text-primary)">
+      <LandingMasthead />
+
+      <main id="main-content" className="max-w-[800px] mx-auto px-6 pt-12 pb-24">
+        <header className="mb-9">
+          <p className="font-body text-kicker uppercase text-(--text-tertiary) mb-3 flex items-center">
+            <span aria-hidden className="inline-block w-7 h-px bg-(--border) mr-3" />
+            {c.eyebrow}
+          </p>
+          <h1 className="font-heading text-[36px] md:text-[44px] font-bold leading-[1.05] tracking-tight text-(--text-primary)">
+            {c.headline}
+          </h1>
+          <p className="font-body text-[16px] text-(--text-secondary) mt-3 max-w-[62ch] leading-relaxed">
+            {c.dek}
+          </p>
+          <p className="font-body text-[15px] text-(--text-tertiary) mt-4 max-w-[62ch] leading-relaxed">
+            {c.contextNote}
+          </p>
+        </header>
+
+        <hr className="border-0 border-t border-(--border) mb-10" />
+
+        {terms.length === 0 ? (
+          <p className="font-body text-[15px] text-(--text-tertiary) italic leading-relaxed">
+            {c.empty}
+          </p>
+        ) : (
+          <>
+            {/* The finding, before the list. Only rendered when there is one
+                to state — a corpus where every term is named in its own
+                coverage would make this paragraph a lie. */}
+            {totalUnnamed > 0 && worst && (
+              <section className="mb-12 border-l-2 border-(--accent) pl-5">
+                <p className="font-body text-kicker uppercase text-(--text-tertiary) mb-3">
+                  {c.findingHeading}
+                </p>
+                <p className="font-body text-[16px] text-(--text-secondary) leading-relaxed max-w-[62ch]">
+                  {c.finding(totalUnnamed, totalArticles, worst.term)}
+                </p>
+              </section>
+            )}
+
+            <p className="font-body text-[14px] text-(--text-tertiary) mb-1.5 leading-relaxed">
+              {c.countLabel(terms.length)}
+            </p>
+            {gapNote && (
+              <p className="font-body text-[14px] text-(--text-tertiary) mb-8 max-w-[62ch] leading-relaxed">
+                {gapNote}
+              </p>
+            )}
+
+            <div className={gapNote ? "" : "mt-8"}>
+              {groups.map((g) => (
+                <section key={g.key} className="mb-10">
+                  <p className="font-mono text-[12px] uppercase tracking-[0.14em] text-(--text-tertiary) mb-3">
+                    {g.label}
+                  </p>
+                  <ul className="space-y-0">
+                    {g.items.map((t) => {
+                      const unnamed = c.rowUnnamed(t.unnamedCount, t.articleCount);
+                      return (
+                        <li
+                          key={t.slug}
+                          className="border-b border-(--border-subtle) last:border-b-0 py-3"
+                        >
+                          <Link
+                            href={`/term/${t.slug}`}
+                            className="group no-underline flex flex-wrap items-baseline gap-x-3 gap-y-1"
+                          >
+                            <span className="font-heading text-[17px] text-(--text-primary) group-hover:text-(--accent) transition-colors flex-1 min-w-[160px]">
+                              {t.term}
+                            </span>
+                            <span className="font-body text-[13px] text-(--text-tertiary) tabular-nums">
+                              {c.rowCoverage(t.articleCount, t.outletCount)}
+                            </span>
+                            {unnamed && (
+                              <span className="font-body text-[12px] text-(--text-secondary) tabular-nums">
+                                {unnamed}
+                              </span>
+                            )}
+                          </Link>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          </>
+        )}
+
+        <hr className="border-0 border-t border-(--border) my-10" />
+
+        <CorrectionPath />
+
+        <p className="font-body text-[14px] mt-8">
+          <Link
+            href="/"
+            className="text-(--text-tertiary) no-underline hover:underline hover:text-(--accent)"
+          >
+            {c.backLink}
+          </Link>
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -67,6 +67,7 @@ export const COPY = {
       { label: "Civic dossiers", href: "/civic" },
       { label: "Agencies", href: "/agencies" },
       { label: "Think tanks", href: "/think-tanks" },
+      { label: "Glossary", href: "/glossary" },
       { label: "Methodology", href: "/methodology" },
       { label: "Colophon", href: "/colophon" },
     ] as const,
@@ -596,6 +597,63 @@ export const COPY = {
     noRecent:
       "No recent stories from this outlet on Sift. The pipeline reads from this outlet \u2014 nothing has surfaced in the last day or two.",
   },
+  // ─── Term index (route `/glossary`) ────────────────────
+  //
+  // The index over /term/<slug>. The ROUTE is /glossary — /terms is the Terms
+  // of Service, and /agencies and /think-tanks already establish that a
+  // collection page takes a plain-English name rather than the route segment
+  // its children sit under.
+  //
+  // The KEY is `termIndex`, not `glossary`, because COPY.glossary is already
+  // taken by the inline entity-chip layer ("Mentioned in this story") — a
+  // different feature entirely. Reusing it silently shadowed that namespace
+  // and broke EntityChipTooltip and EntityLinksList at the type level.
+  termIndex: {
+    eyebrow: "Civic glossary",
+    headline: "The words the news assumes you already know",
+    dek:
+      "Each one is defined from the primary record — the statute, the " +
+      "constitutional clause, the regulation — and then shown as it is " +
+      "actually being covered right now, and by whom.",
+    // Same job as agencies.contextNote: someone arriving cold sees a masthead
+    // saying "the news, with footnotes" and a Sports tab above this page, and
+    // has to reconcile that before reading a word.
+    contextNote:
+      "Reference, not news. Every definition here is Sift's summary of a " +
+      "cited source, never Sift's own authority on what a term means.",
+    // The finding, stated before the list — a reader who stops here should
+    // still leave with the fact that makes the page worth sending on. Both
+    // numbers are computed, never hardcoded: see listPublishedTerms.
+    findingHeading: "Most of this vocabulary is invisible",
+    finding: (unnamed: number, total: number, worstTerm: string) =>
+      `Across these terms, ${unnamed.toLocaleString()} of ${total.toLocaleString()} ` +
+      `stories in Sift's index turn on a term the coverage never names — ` +
+      `roughly ${Math.round((unnamed / total) * 100)} in every 100. For ${worstTerm} ` +
+      "it is every single story. That is the gap these pages exist to close: " +
+      "you cannot look up a word the article never used.",
+    countLabel: (terms: number) =>
+      `${terms} ${terms === 1 ? "term" : "terms"}, each with its source and its coverage.`,
+    // Says out loud what is missing, rather than showing only the flattering
+    // subset. Mirrors agencies.contextNote's honesty about omissions.
+    gapNote: (published: number, held: number) =>
+      held > published
+        ? `${held - published} further ${held - published === 1 ? "term is" : "terms are"} ` +
+          "defined but held back: below a handful of stories there is nothing " +
+          "to show about how a term is being covered, and a definition alone " +
+          "is something a law dictionary already does better."
+        : "",
+    // Per-row. The share is the point, so it is spelled out rather than
+    // left as a bare number.
+    rowCoverage: (articles: number, outlets: number) =>
+      `${articles.toLocaleString()} ${articles === 1 ? "story" : "stories"} · ` +
+      `${outlets.toLocaleString()} ${outlets === 1 ? "outlet" : "outlets"}`,
+    rowUnnamed: (unnamed: number, articles: number) =>
+      unnamed === 0
+        ? ""
+        : `${Math.round((unnamed / articles) * 100)}% never name it`,
+    empty: "No terms are curated yet.",
+    backLink: "Back to Sift",
+  },
   // ─── Term dossier (`/term/[slug]`) ─────────────────────
   //
   // Two registers on one page, and the wording keeps them apart on purpose.
@@ -974,6 +1032,11 @@ export const COPY = {
       "Who controls a federal agency \u2014 appointment, terms, and the party-balance limits written into statute \u2192",
     thinkTanksCrossLink:
       "How these organizations describe themselves \u2014 in their own words, quoted and linked \u2192",
+    // Third cross-link, same rule as the two above: state the payoff, not the
+    // destination. "See the glossary" gives nobody a reason to click; one
+    // story in five turning on an unnamed term does.
+    termIndexCrossLink:
+      "The words the news assumes you know \u2014 one story in five turns on a term it never names \u2192",
     emptyBills: "No bills curated yet.",
     billsMoreSoon: "More bills as they're curated.",
     backLink: "Back to Sift",

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -39,6 +39,7 @@ import type {
   PoliticianListItem,
   PoliticianProfile,
   TermCoverage,
+  TermListItem,
   TermOutletCoverage,
   TermProfile,
 } from "./types";
@@ -1653,6 +1654,126 @@ function termMatchSql(
 const TERM_ARTICLE_FILTER = `a.from_search = false
   AND a.summary IS NOT NULL AND a.summary <> ''
   AND LOWER(a.summary) NOT LIKE 'unable to provide%'`;
+
+/**
+ * Every term that clears the publish floor, with its coverage counts.
+ *
+ * Backs `/glossary`. Applies the same floor as `listSitemapEntries` — a
+ * sourced definition and `TERM_MIN_ARTICLES` articles — because an index that
+ * advertises pages the sitemap withholds is two different answers to one
+ * question. The precedent is `listCitedAgencies`, which has always refused to
+ * list an agency whose governance text lacks its source.
+ *
+ * `unnamed` is the column the page is built around: articles matched *only*
+ * by the primer, meaning the story turns on the term without ever printing
+ * it. `bool_or` per (term, article) is what makes that computable — an
+ * article can match several surface forms, and it counts as named if any one
+ * of them appeared in the text.
+ *
+ * Measured at 785 ms over 24 terms against the prod corpus. That is heavy for
+ * a page, and fine for this one: ISR holds it for 30 minutes, and the numbers
+ * are the argument rather than decoration.
+ */
+export async function listPublishedTerms(): Promise<TermListItem[]> {
+  try {
+    const result = await pool.query<{
+      slug: string;
+      term: string;
+      category: string | null;
+      article_count: string;
+      outlet_count: string;
+      unnamed_count: string;
+    }>(GLOSSARY_QUERY);
+    return result.rows
+      .map((r) => ({
+        slug: r.slug,
+        term: r.term,
+        category: r.category,
+        articleCount: Number(r.article_count),
+        outletCount: Number(r.outlet_count),
+        unnamedCount: Number(r.unnamed_count),
+      }))
+      .filter((t) => t.articleCount >= TERM_MIN_ARTICLES);
+  } catch (err) {
+    if (!isMissingSchemaObject(err, "term_profiles")) throw err;
+    reportError("db.listPublishedTerms", err, { level: "warning" });
+    return [];
+  }
+}
+
+/**
+ * How many terms carry a sourced definition, floor or no floor.
+ *
+ * The denominator for `/glossary`'s gap note. Split from
+ * `listPublishedTerms` rather than derived from it because that one has
+ * already applied the floor — a page that says "N held back" needs to know
+ * what was filtered out, and asking the filtered list is how a count like
+ * that silently becomes zero.
+ */
+export async function countDefinedTerms(): Promise<number> {
+  try {
+    const r = await pool.query<{ n: string }>(
+      `SELECT COUNT(*)::text AS n FROM term_profiles
+        WHERE definition IS NOT NULL AND definition_source IS NOT NULL`,
+    );
+    return Number(r.rows[0]?.n ?? 0);
+  } catch (err) {
+    if (!isMissingSchemaObject(err, "term_profiles")) throw err;
+    reportError("db.countDefinedTerms", err, { level: "warning" });
+    return 0;
+  }
+}
+
+/**
+ * `String.raw` for the same reason `SITEMAP_TERM_BRANCH` is — the POSIX
+ * word-boundary escapes `\m` and `\M` are eaten by an ordinary template
+ * literal, which would silently turn word matching into substring matching.
+ */
+const GLOSSARY_QUERY = String.raw`
+  WITH per AS (
+    SELECT t.slug, t.term, t.category, a.id, a.source_name,
+           -- Named in the text by ANY of its surface forms. Per (term,
+           -- article), so a story that says "TPS" but not "Temporary
+           -- Protected Status" still counts as named.
+           bool_or(
+             to_tsvector('english', COALESCE(a.title,'') || ' ' || COALESCE(a.summary,''))
+               @@ phraseto_tsquery('english', f.s)
+             AND CASE WHEN f.s = UPPER(f.s)
+                      THEN (COALESCE(a.title,'') || ' ' || COALESCE(a.summary,'')) ~
+                           ('\m' || regexp_replace(f.s, '([.*+?^$(){}|\[\]\\])', '\\\1', 'g') || '\M')
+                      ELSE (COALESCE(a.title,'') || ' ' || COALESCE(a.summary,'')) ~*
+                           ('\m' || regexp_replace(f.s, '([.*+?^$(){}|\[\]\\])', '\\\1', 'g') || '\M')
+                 END
+           ) AS in_text
+      FROM term_profiles t
+      CROSS JOIN LATERAL (
+        SELECT t.term AS s UNION SELECT jsonb_array_elements_text(t.aliases)
+      ) f
+      JOIN articles a
+        ON a.from_search = false
+       AND a.summary IS NOT NULL AND a.summary <> ''
+       AND LOWER(a.summary) NOT LIKE 'unable to provide%'
+       AND ( (to_tsvector('english', COALESCE(a.title,'') || ' ' || COALESCE(a.summary,''))
+                @@ phraseto_tsquery('english', f.s)
+              AND CASE WHEN f.s = UPPER(f.s)
+                       THEN (COALESCE(a.title,'') || ' ' || COALESCE(a.summary,'')) ~
+                            ('\m' || regexp_replace(f.s, '([.*+?^$(){}|\[\]\\])', '\\\1', 'g') || '\M')
+                       ELSE (COALESCE(a.title,'') || ' ' || COALESCE(a.summary,'')) ~*
+                            ('\m' || regexp_replace(f.s, '([.*+?^$(){}|\[\]\\])', '\\\1', 'g') || '\M')
+                  END)
+             OR primer_term_keys(a.context_primer) && ARRAY[lower(btrim(f.s))] )
+     WHERE t.definition IS NOT NULL AND t.definition_source IS NOT NULL
+     GROUP BY t.slug, t.term, t.category, a.id, a.source_name
+  )
+  SELECT p.slug, p.term, p.category,
+         COUNT(*)::text AS article_count,
+         COUNT(DISTINCT COALESCE(sa.outlet_slug, op.slug, LOWER(p.source_name)))::text AS outlet_count,
+         COUNT(*) FILTER (WHERE NOT p.in_text)::text AS unnamed_count
+    FROM per p
+    LEFT JOIN source_name_aliases sa ON LOWER(sa.raw_source_name) = LOWER(p.source_name)
+    LEFT JOIN outlet_profiles op ON LOWER(op.name) = LOWER(p.source_name)
+   GROUP BY p.slug, p.term, p.category
+   ORDER BY COUNT(*) DESC`;
 
 async function getTermBySlugUncached(slug: string): Promise<TermProfile | null> {
   const trimmed = slug.trim().toLowerCase();

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -623,6 +623,24 @@ export interface TermProfile {
   notes: string | null;
 }
 
+/**
+ * A term as it appears on `/glossary` — identity plus the two numbers the
+ * list is sorted and argued by.
+ *
+ * `unnamedCount` is the interesting one: how many of a term's stories match
+ * only through the primer, i.e. turn on the term without ever printing it.
+ * Across the curated set that is 1,030 of 4,828 stories, and for some terms
+ * every single one — which is the case for the route existing at all.
+ */
+export interface TermListItem {
+  slug: string;
+  term: string;
+  category: string | null;
+  articleCount: number;
+  outletCount: number;
+  unnamedCount: number;
+}
+
 /** One outlet's share of a term's coverage, with its published lean. */
 export interface TermOutletCoverage {
   sourceName: string;


### PR DESCRIPTION
24 term pages existed with nothing linking to them — entry was search and the sitemap. This is the section they belong to.

## Leads with the finding, not the list

Following `/agencies`: a reader who stops after the first screen should still leave with the fact worth sending on.

> Across these terms, **1,030 of 4,828 stories in Sift's index turn on a term the coverage never names** — roughly 21 in every 100. For Prior Restraint it is every single story. That is the gap these pages exist to close: you cannot look up a word the article never used.

Per term, the share never naming it:

| | | | |
|---|---|---|---|
| Prior Restraint | **100%** | Injunction | 51% |
| Cloture | **100%** | Recusal | 51% |
| Certiorari | 94% | Subpoena | 48% |
| Qualified Immunity | 92% | Appropriations | 40% |
| Executive Privilege | 59% | Gerrymandering | 32% |

**Every number is computed from the live corpus, including which term is the starkest example.** Nothing is hardcoded, so the sentence can't drift from the data the way a written-in figure would.

## Naming

Route is `/glossary` — `/terms` is the Terms of Service, and `/agencies` and `/think-tanks` already establish that a collection page takes a plain-English name rather than the route segment its children sit under.

The copy key is **`termIndex`, not `glossary`**. `COPY.glossary` is already the inline entity-chip layer ("Mentioned in this story"). My first draft reused the key — a duplicate object literal key, which silently shadowed that namespace and broke `EntityChipTooltip` and `EntityLinksList` at the type level. The component moved to `components/term/TermIndex.tsx` beside `TermDossier` for the same reason. A test pins both shapes so a future rename can't quietly repeat it.

## Drive-by fix: `— Sift | Sift` on four pages

`app/layout.tsx` sets `template: "%s | Sift"`, and `/civic`, `/agencies` and `/think-tanks` each hardcode `— Sift` in their title. All three have been rendering **`... — Sift | Sift`** in production:

```
<title>Who controls a federal agency — Sift | Sift</title>
<title>How policy organizations describe themselves — Sift | Sift</title>
```

I reproduced it by matching their convention, then fixed all four rather than leave three wrong. Not cosmetic on pages built for search — Google truncates near 60 characters and this spent eight of them saying the brand twice. Page titles are now brand-free; `openGraph`/`twitter` keep the brand, the same split `dossierMetadata` already makes for the dossier routes.

**Flagging because it touches three pages outside this task.** Trivially revertible if you'd rather it were separate.

## Entry points

- Cross-link from `/civic`, beside the existing `/agencies` and `/think-tanks` ones — stating the payoff, not the destination, per the convention there
- `/news` footer nav
- Sitemap, `weekly` rather than `monthly`: the counts move with the pipeline, unlike the statutory text on `/agencies`

## Notes

- Floor is the same one `listSitemapEntries` applies — an index advertising pages the sitemap withholds would be two answers to one question. The gap note says out loud how many terms are held back, and is computed from an independent count rather than derived from the already-filtered list.
- Query measured at **785 ms** over 24 terms. Heavy for a page, fine for this one behind ISR 1800 — and the numbers are the argument, not decoration.
- 856 tests pass; verified against prod data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)