### PR TITLE
Make "Read the methodology" a link on the last two footers that lacked one

### DIFF
--- a/components/civic/CivicIndex.tsx
+++ b/components/civic/CivicIndex.tsx
@@ -334,9 +334,12 @@ export default function CivicIndex({
           >
             ← {c.backLink}
           </Link>
-          <p className="font-body text-[12px] text-(--text-tertiary) italic">
+          <Link
+            href="/methodology"
+            className="font-body text-meta text-(--text-tertiary) italic no-underline hover:text-(--accent) hover:not-italic transition-colors"
+          >
             {c.methodologyHint}
-          </p>
+          </Link>
         </div>
       </main>
     </div>

--- a/components/politician/PoliticianDossier.tsx
+++ b/components/politician/PoliticianDossier.tsx
@@ -416,7 +416,7 @@ export default function PoliticianDossier({
 
         <hr className="border-0 border-t border-(--border) my-10" />
 
-        {/* Footer: methodology hint placeholder + back link */}
+        {/* Footer: methodology link + back link */}
         <div className="flex items-center justify-between gap-4 flex-wrap">
           <Link
             href="/"
@@ -424,11 +424,12 @@ export default function PoliticianDossier({
           >
             <span aria-hidden>←</span> Back to Sift
           </Link>
-          {/* Methodology link goes live with Phase 2.D (PR #79). Until that
-              merges, render the hint as plain text rather than a 404 link. */}
-          <span className="font-body text-meta text-(--text-tertiary) italic">
+          <Link
+            href="/methodology"
+            className="font-body text-meta text-(--text-tertiary) italic no-underline hover:text-(--accent) hover:not-italic transition-colors"
+          >
             {c.methodologyHint}
-          </span>
+          </Link>
         </div>
       </main>
     </div>


### PR DESCRIPTION
The footnote line *"Data comes from public records. Read the methodology."* told the reader to go read the methodology, but on the politician dossier and the civic index it rendered as plain text — nothing to click.

`/methodology` has been live for a while (it's in the sitemap), and three of the five footers already linked to it:

| Footer | Before | After |
|---|---|---|
| `BillDossier` | `<Link href="/methodology">` | unchanged |
| `OrgDossier` | `<Link href="/methodology">` | unchanged |
| `OutletDossier` | `<Link href="/methodology">` | unchanged |
| `PoliticianDossier` | plain `<span>` | **linked** |
| `CivicIndex` | plain `<p>` | **linked** |

`PoliticianDossier` carried a comment deferring the link until "Phase 2.D (PR #79)" shipped, on the grounds that it would otherwise 404. That page shipped, so the rationale is stale and the comment goes with it. `CivicIndex` had no comment — it just never got the link.

Both now use the same treatment as the other three. `CivicIndex`'s hint was also on a one-off `text-[12px]`; it moves to the `text-meta` token, so all five footers are now identical — `grep` over `components/` returns a single unique className for them.

## Verification

- `npx tsc --noEmit` clean on top of `origin/main` (after #250, which had also touched `CivicIndex.tsx` — the two changes auto-merged).
- `npx jest __tests__/PoliticianDossier.test.tsx` — 14/14 pass. No existing test asserted the plain-text rendering.
- Asserted the anchor directly in a throwaway test: `tagName === "A"`, `href === "/methodology"`.
- Rendered `/civic` against the dev server: the footer hint is an `<a href="/methodology">` computing to `font-size: 11px`, `letter-spacing: 0.22px`, `line-height: 14.3px` — the `--text-meta` triple. `/methodology` returns the real page, not a 404.
- `/politician/<bioguide>` couldn't be checked in the browser; the local DB has no politician rows, so it 404s. The component test covers it instead.

No doc impact: no route, API shape, or env var changed, and nothing in `STATUS.md` or `docs/PROJECT_PLAN.md` referenced Phase 2.D or PR #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)