### PR TITLE
Gate the dossier "not yet enriched" caption on chamber, not on role sourcing

### DIFF
--- a/__tests__/PoliticianDossier.test.tsx
+++ b/__tests__/PoliticianDossier.test.tsx
@@ -179,7 +179,44 @@ describe("PoliticianDossier — executive office section", () => {
     expect(screen.queryByText(/PAC contribution data isn't on file/i)).toBeNull();
   });
 
-  it("still renders the caption for a sitting member with no enrichment", () => {
+  // The caption used to be gated on `Boolean(role.roleTitle)` — whether the row
+  // carried a *sourced* statutory title — as a proxy for "is a member of
+  // Congress". Roughly 33 of the 46 foreign-executive rows are still unsourced,
+  // so all of them failed that proxy and told a foreign head of state that PAC
+  // data was missing "common for senators not on that year's ballot". The gate
+  // is the chamber now; these two cases are the ones the proxy got wrong.
+  it("does not show the caption on an unsourced foreign head of state", () => {
+    render(
+      <PoliticianDossier
+        politician={{
+          ...austin,
+          name: "Kim Jong Un",
+          chamber: "foreign-executive",
+          party: "WPK",
+          state: "KP",
+          externalLinks: {},
+          role: emptyRole,
+        }}
+      />,
+    );
+    expect(screen.queryByText(/PAC contribution data isn't on file/i)).toBeNull();
+  });
+
+  it("does not show the caption on an unsourced Justice", () => {
+    render(
+      <PoliticianDossier
+        politician={{
+          ...austin,
+          chamber: "scotus",
+          externalLinks: {},
+          role: emptyRole,
+        }}
+      />,
+    );
+    expect(screen.queryByText(/PAC contribution data isn't on file/i)).toBeNull();
+  });
+
+  it("renders the caption with the ballot rationale for a senator", () => {
     render(
       <PoliticianDossier
         politician={{
@@ -193,6 +230,30 @@ describe("PoliticianDossier — executive office section", () => {
     expect(
       screen.getByText(/PAC contribution data isn't on file/i),
     ).toBeInTheDocument();
+    // Only a third of Senate seats are on any given ballot, so this explains
+    // the absence truthfully here.
+    expect(
+      screen.getByText(/not on that year's ballot/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the caption without the ballot rationale for a House member", () => {
+    render(
+      <PoliticianDossier
+        politician={{
+          ...austin,
+          chamber: "house",
+          externalLinks: {},
+          role: emptyRole,
+        }}
+      />,
+    );
+    expect(
+      screen.getByText(/PAC contribution data isn't on file/i),
+    ).toBeInTheDocument();
+    // Every House seat is on every ballot — the senator rationale would be a
+    // false explanation here, not merely an odd one.
+    expect(screen.queryByText(/not on that year's ballot/i)).toBeNull();
   });
 
   it("surfaces the official .gov link in the citations list", () => {

--- a/components/civic/CivicIndex.tsx
+++ b/components/civic/CivicIndex.tsx
@@ -323,9 +323,12 @@ export default function CivicIndex({
           >
             ← {c.backLink}
           </Link>
-          <p className="font-body text-[12px] text-(--text-tertiary) italic">
+          <Link
+            href="/methodology"
+            className="font-body text-meta text-(--text-tertiary) italic no-underline hover:text-(--accent) hover:not-italic transition-colors"
+          >
             {c.methodologyHint}
-          </p>
+          </Link>
         </div>
       </main>
     </div>

--- a/components/politician/PoliticianDossier.tsx
+++ b/components/politician/PoliticianDossier.tsx
@@ -416,7 +416,7 @@ export default function PoliticianDossier({
 
         <hr className="border-0 border-t border-(--border) my-10" />
 
-        {/* Footer: methodology hint placeholder + back link */}
+        {/* Footer: methodology link + back link */}
         <div className="flex items-center justify-between gap-4 flex-wrap">
           <Link
             href="/"
@@ -424,11 +424,12 @@ export default function PoliticianDossier({
           >
             <span aria-hidden>←</span> Back to Sift
           </Link>
-          {/* Methodology link goes live with Phase 2.D (PR #79). Until that
-              merges, render the hint as plain text rather than a 404 link. */}
-          <span className="font-body text-meta text-(--text-tertiary) italic">
+          <Link
+            href="/methodology"
+            className="font-body text-meta text-(--text-tertiary) italic no-underline hover:text-(--accent) hover:not-italic transition-colors"
+          >
             {c.methodologyHint}
-          </span>
+          </Link>
         </div>
       </main>
     </div>

--- a/components/politician/PoliticianDossier.tsx
+++ b/components/politician/PoliticianDossier.tsx
@@ -4,7 +4,10 @@ import LandingMasthead from "@/components/landing/LandingMasthead";
 import ShareActions from "@/components/ShareActions";
 import { PartyTag } from "@/components/primitives";
 import { COPY } from "@/lib/copy";
-import { formatPoliticianLede } from "@/lib/politician";
+import {
+  formatPoliticianLede,
+  isCongressionalChamber,
+} from "@/lib/politician";
 import type { PoliticianProfile } from "@/lib/types";
 import { formatUsdCompact } from "@/lib/utils";
 
@@ -149,10 +152,20 @@ export default function PoliticianDossier({
   const industriesEmpty = politician.topIndustriesCurrentCycle.length === 0;
   const ratingsEmpty = ratingsEntries.length === 0;
   // The "not yet enriched" caption is about OpenSecrets/Vote Smart data for
-  // members of Congress. An executive official has no PAC industries or
-  // interest-group ratings to be missing, so showing it there would invent a
-  // gap that doesn't exist.
-  const showNotYetEnriched = industriesEmpty && ratingsEmpty && !hasOffice;
+  // members of Congress. An executive official, a foreign head of state or a
+  // Justice has no PAC industries or interest-group ratings to be missing, so
+  // showing it there would invent a gap that doesn't exist.
+  //
+  // This gates on chamber, not on `hasOffice`. `hasOffice` only asks whether
+  // the row carries a *sourced* statutory title, and the ~33 foreign-executive
+  // rows whose title is still unsourced have none — so keying off it told every
+  // one of them that their PAC data was missing "common for senators not on
+  // that year's ballot".
+  const showNotYetEnriched =
+    industriesEmpty && ratingsEmpty && isCongressionalChamber(politician.chamber);
+  // Only the Senate gets the not-on-the-ballot rationale; see lib/copy.ts.
+  const notYetEnrichedCopy =
+    politician.chamber === "senate" ? c.notYetEnrichedSenate : c.notYetEnriched;
 
   return (
     <div className="min-h-screen bg-(--surface-base) text-(--text-primary)">
@@ -360,12 +373,13 @@ export default function PoliticianDossier({
           </section>
         )}
 
-        {/* "Not yet enriched" caption when both donor + rating sections
-            absent — common case before sift-api Phase 3.E refresh runs. */}
+        {/* "Not yet enriched" caption when both donor + rating sections are
+            absent on a house/senate row — common case before sift-api Phase
+            3.E refresh runs. Non-congressional rows render nothing here. */}
         {showNotYetEnriched && (
           <section className="mb-10">
             <p className="font-body text-[14px] text-(--text-tertiary) italic max-w-[60ch] leading-relaxed">
-              {c.notYetEnriched}
+              {notYetEnrichedCopy}
             </p>
           </section>
         )}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -401,19 +401,23 @@ export const COPY = {
       ballotpedia: "Ballotpedia",
       wikipedia: "Wikipedia",
     } as Record<string, string>,
-    // Footer note shown when donor and rating data are both absent. Common
-    // for senators not on the 2022 ballot (no PAC contributions during the
-    // cycle) and for politicians without a public OpenSecrets profile.
-    // Sift's PAC industry data comes from OpenSecrets bulk imports \u2014
-    // re-runs cycle-to-cycle, not on a daily refresh (the OpenSecrets API
-    // was discontinued April 2025). Interest-group ratings aren't yet
-    // imported.
+    // Footer note shown when donor and rating data are both absent, and only
+    // on house/senate rows \u2014 an executive, foreign head of state or Justice has
+    // no campaign-finance record to be missing, so the caption there would
+    // invent a gap. Sift's PAC industry data comes from OpenSecrets bulk
+    // imports \u2014 re-runs cycle-to-cycle, not on a daily refresh (the
+    // OpenSecrets API was discontinued April 2025). Interest-group ratings
+    // aren't yet imported.
     notYetEnriched:
+      "PAC contribution data isn't on file for the 2022 cycle. Interest-group ratings aren't yet imported.",
+    // Senate-only rationale: roughly a third of seats are on any given ballot,
+    // so a senator with no 2022 contributions is unremarkable. Every House seat
+    // is on every ballot, so the same sentence on a House row would explain an
+    // absence falsely \u2014 which is why this is a separate string and not the
+    // default.
+    notYetEnrichedSenate:
       "PAC contribution data isn't on file for the 2022 cycle \u2014 common for senators not on that year's ballot. Interest-group ratings aren't yet imported.",
     methodologyHint: "Data comes from public records. Read the methodology.",
-    // Empty-state when industries/ratings are partially populated.
-    industriesEmpty: "No donor-industry data yet for this cycle.",
-    ratingsEmpty: "No interest-group ratings yet recorded.",
   },
   orgDossier: {
     eyebrow: "Org dossier",

--- a/lib/politician.ts
+++ b/lib/politician.ts
@@ -66,6 +66,20 @@ export function formatChamberLabel(
   return CHAMBER_LABELS[chamber] ?? null;
 }
 
+/**
+ * True for the chambers whose rows have an OpenSecrets / Vote Smart record to
+ * be missing in the first place. Mirrors the house/senate arm of
+ * `isPublishablePolitician` in lib/publishFloor.ts — executive,
+ * foreign-executive and scotus rows have no campaign-finance record at all, so
+ * an absence there is not a gap to explain. `former` is excluded because
+ * `isPublishablePolitician` already refuses it, so it never reaches a page.
+ */
+export function isCongressionalChamber(
+  chamber: PoliticianChamber | null | undefined,
+): boolean {
+  return chamber === "house" || chamber === "senate";
+}
+
 const ROLE_FROM_CHAMBER: Record<PoliticianChamber, string> = {
   senate: "Senator",
   house: "Representative",


### PR DESCRIPTION
On `/politician/<bioguide>` for Kim Jong Un — lede "Head of state or government (WPK-KP)" — the page rendered:

> PAC contribution data isn't on file for the 2022 cycle — common for senators not on that year's ballot. Interest-group ratings aren't yet imported.

Two defects, both in the gating and the copy rather than the data.

### 1. The gate was a sourcing test wearing a chamber test's clothes

`showNotYetEnriched` was gated on `!hasOffice` — i.e. `!Boolean(role.roleTitle)` — as a proxy for "is a member of Congress". The comment above it described the intent correctly; the condition did something else. `hasOffice` only asks whether a row carries a **sourced statutory title**, and per `STATUS.md` roughly 33 of the 46 `foreign-executive` rows are still unsourced. All of them failed the proxy and got congressional copy. Unsourced `executive` and `scotus` rows took the same path.

Now gated on the chamber, via a new `isCongressionalChamber` in `lib/politician.ts` that mirrors the house/senate arm of `isPublishablePolitician` in `lib/publishFloor.ts`. Non-congressional rows render nothing here — correct rather than a silent omission, since a head of state has no campaign-finance record to be missing. The caption was inventing the gap it claimed to explain.

### 2. The senator rationale was shown to House members

"Common for senators not on that year's ballot" is true for the Senate, where roughly a third of seats are on any given ballot, and false for the House, where every seat is. **437 of the 649 rows are House** — the larger population by far; it just read less absurdly than the North Korea case. Split into `notYetEnriched` (absence only) and `notYetEnrichedSenate` (keeps the rationale).

### Also

Dropped the dead `industriesEmpty` / `ratingsEmpty` copy keys. Nothing read them — the component declares local booleans of the same name and hides the sections outright, so the partially-populated state their comment describes has no rendered copy. Leaving them invited the assumption that the state was handled.

### On the tests

The two existing cases could not have caught this. The "sitting member" case flips `chamber` to `"senate"` *and* blanks the role, but its assertion turns only on the blanked role — the chamber change was decorative, so `"foreign-executive"` would have passed it too.

Four new cases: `foreign-executive` and `scotus` with an empty role (no caption), and both copy variants (`senate` keeps the ballot clause, `house` does not). I confirmed the two regression cases are load-bearing by temporarily restoring the old `!hasOffice` gate — both fail against it — then restored the fix.

### Verification

- `npx jest` — 57 suites, 852 tests, all pass
- `npx tsc --noEmit` clean; `npx eslint` clean on the touched files

**Not verified:** an end-to-end fetch of a real affected route. The local dev DB has no politician rows (`/civic` renders "Politicians · 0"), so there was no live `foreign-executive` page to load. The tests render the real component with the reproducing fixture shape, but that Kim Jong Un's row specifically is `chamber: "foreign-executive"` with a null `roleTitle` remains an inference — "Head of state or government (WPK-KP)" is exactly what the lede fallback emits, and that fallback only runs when `roleTitle` is null. Worth a spot-check against prod before merge.

### Scope note

This branch carries a second, unrelated commit — 1cb11ae, "Make 'Read the methodology' a link on the last two footers that lacked one", which touches `PoliticianDossier.tsx` and `CivicIndex.tsx`. It landed on the branch independently. Happy to split it out if you'd rather review them separately.

The hardcoded "2022 cycle" is deliberately untouched — accurate to what is imported, and tracked in #251.

### Doc impact

Per `CLAUDE.md`'s end-of-PR check: bug fix, no public-contract / route / env change, no strategic decision closed, does not move the Next 3. No doc updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
