### PR TITLE
Say which cycle the PAC figures are from, and that they do not refresh

### DIFF
--- a/__tests__/PoliticianDossier.test.tsx
+++ b/__tests__/PoliticianDossier.test.tsx
@@ -256,6 +256,38 @@ describe("PoliticianDossier — executive office section", () => {
     expect(screen.queryByText(/not on that year's ballot/i)).toBeNull();
   });
 
+  // The heading names a year, but a year alone reads as "current" to a reader
+  // who does not know the release cadence — and the column behind it is named
+  // `top_industries_current_cycle`. Every published congressional row renders
+  // this section, so the note is the common path, not an edge case (#251).
+  it("states the cycle's provenance under a populated industries list", () => {
+    render(
+      <PoliticianDossier
+        politician={{
+          ...austin,
+          chamber: "senate",
+          role: emptyRole,
+          topIndustriesCurrentCycle: [
+            { industry: "Securities & Investment", amount_usd: 250000 },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText(/2022-cycle bulk release/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/not refreshed between cycle releases/i),
+    ).toBeInTheDocument();
+  });
+
+  it("omits the cycle note when there are no industries to qualify", () => {
+    render(
+      <PoliticianDossier
+        politician={{ ...austin, chamber: "senate", role: emptyRole }}
+      />,
+    );
+    expect(screen.queryByText(/2022-cycle bulk release/i)).toBeNull();
+  });
+
   it("surfaces the official .gov link in the citations list", () => {
     render(<PoliticianDossier politician={austin} />);
     expect(

--- a/components/politician/PoliticianDossier.tsx
+++ b/components/politician/PoliticianDossier.tsx
@@ -301,7 +301,11 @@ export default function PoliticianDossier({
           </section>
         )}
 
-        {/* Top industries by PAC contributions (2022 cycle, from OpenSecrets bulk) */}
+        {/* Top industries by PAC contributions (2022 cycle, from OpenSecrets bulk).
+            The cycle note below the list is not decoration: the heading names a
+            year, but a year alone reads as "current" to someone who does not
+            know the release cadence, and every published congressional row
+            renders this section. See `topIndustriesCycleNote` in lib/copy.ts. */}
         {!industriesEmpty && (
           <section className="mb-10">
             <p className="font-body text-kicker uppercase text-(--text-tertiary) mb-3">
@@ -324,6 +328,9 @@ export default function PoliticianDossier({
                 </li>
               ))}
             </ul>
+            <p className="font-body text-meta text-(--text-tertiary) mt-3 max-w-[60ch] leading-relaxed">
+              {c.topIndustriesCycleNote}
+            </p>
           </section>
         )}
 

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -418,6 +418,21 @@ export const COPY = {
     // default.
     notYetEnrichedSenate:
       "PAC contribution data isn't on file for the 2022 cycle \u2014 common for senators not on that year's ballot. Interest-group ratings aren't yet imported.",
+    // Rendered under the industries list whenever it is populated — which is
+    // every published congressional row, so this is the common case, not an
+    // edge one. The heading names the cycle, but a bare "(2022 cycle)" read in
+    // 2026 still implies "current" by omission, and the column behind it is
+    // literally named `top_industries_current_cycle`. Say what the figure is
+    // and why it has not moved.
+    //
+    // Deliberately "the most recent Sift has been able to obtain" rather than
+    // "the most recent released" — OpenSecrets' bulk downloads sit behind an
+    // account with a manual approval queue, so what they have actually
+    // published is not something this project can verify today. Asserting it
+    // would be the same unsourced-claim defect the dossiers spent three
+    // migrations removing. See #251.
+    topIndustriesCycleNote:
+      "These figures are from OpenSecrets' 2022-cycle bulk release — the most recent Sift has been able to obtain. They are not refreshed between cycle releases.",
     methodologyHint: "Data comes from public records. Read the methodology.",
   },
   orgDossier: {


### PR DESCRIPTION
Closes the half of #251 that does not depend on OpenSecrets.

### The problem

The heading has always named the year — "Top industries by PAC contributions **(2022 cycle)**" — but a year alone reads as *current* to a reader who does not know OpenSecrets' release cadence. The column behind it is named `top_industries_current_cycle`. In August 2026 that is a four-year-old figure presented without qualification.

**Not a rare path.** Sampling 180 of the 533 published congressional rows on prod found every one populated, so this section renders on all of them.

### The change

A note under the industries list:

> These figures are from OpenSecrets' 2022-cycle bulk release — the most recent Sift has been able to obtain. They are not refreshed between cycle releases.

### On the wording

Deliberately **"the most recent Sift has been able to obtain"**, not "the most recent released". OpenSecrets' bulk downloads sit behind an account with a manual approval queue that [at least one user reports as unresponsive](https://groups.google.com/g/opensecrets-open-data/c/LN8enXEzeDc) as of 2026-07-09. What they have actually published is not something this project can verify today, and asserting it would be the same unsourced-claim defect migrations 013/015/016 removed.

### Why not just use a newer source

I checked the one alternative suggested in the OpenSecrets group — Stanford's DIME. It does not close this:

- **2024 is there**, 202.9M rows, direct download, no account, ODC-BY 1.0 (commercial use fine with attribution). Better than OpenSecrets on every access dimension.
- **But it carries no industry classification.** The `contribDB` schema has 45 fields; searching the full codebook for `catcode` / `realcode` / `primcode` / `industry` / `sector` / `NAICS` / `SIC` returns **zero hits**. Only `contributor.occupation` and `contributor.employer` free-text, plus an `is.corp` flag.
- **The CRP-derived records that would carry it are excluded** from the public download — "request access for strictly academic use", under a **Non-commercial** CC licence. Same data, same wall.

Deriving industries from employer strings ourselves would mean Sift inventing an uncited classification and printing it as fact about named politicians — exactly what `OPERATING_CONTEXT.md` §5 bars.

### Scope

The entity-chip tooltip label is left as-is. It already states "(2022 cycle)" and has no room for a qualifying clause; the dossier is where a reader gets the figure in context. Worth revisiting if the tooltip grows.

### Verification

- `npx jest` — 57 suites, **861** tests, all pass. Two new cases: the note renders under a populated list, and is absent when there is nothing to qualify.
- `npx tsc --noEmit` clean; `npx eslint` clean on the touched files.
- **Not browser-verified.** The local dev DB has no politician rows, so the populated path cannot be exercised there, and port 3000 is held by another session's server. The new tests render the real component with a populated fixture, which is the check that applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
