### PR TITLE
Replace a ratio that rots with a floor that cannot

### DIFF
--- a/__tests__/copyFormatters.test.ts
+++ b/__tests__/copyFormatters.test.ts
@@ -421,3 +421,16 @@ describe("termIndex.asOf", () => {
     expect(COPY.termIndex.asOf("2026-08-18")).toMatch(/computed live|ahead/);
   });
 });
+
+describe("civicIndex.termIndexCrossLink", () => {
+  it("states a floor, not a ratio", () => {
+    // This shipped as "one story in five" and was false within a day —
+    // adding 13 terms moved the corpus-wide share 21% -> 16%. A ratio drifts
+    // both ways as the table grows; a floor only becomes more true. The live
+    // figure is computed on /glossary; this string cannot be, so it must not
+    // carry anything that rots.
+    const s = COPY.civicIndex.termIndexCrossLink;
+    expect(s).toContain("over a thousand");
+    expect(s).not.toMatch(/one story in (five|six|seven)|\d+%/);
+  });
+});

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -1064,10 +1064,19 @@ export const COPY = {
     thinkTanksCrossLink:
       "How these organizations describe themselves \u2014 in their own words, quoted and linked \u2192",
     // Third cross-link, same rule as the two above: state the payoff, not the
-    // destination. "See the glossary" gives nobody a reason to click; one
-    // story in five turning on an unnamed term does.
+    // destination. "See the glossary" gives nobody a reason to click; stories
+    // turning on a term nobody names does.
+    //
+    // Phrased as a floor ("over a thousand") rather than a ratio on purpose.
+    // This shipped as "one story in five" and was wrong within a day: adding
+    // 13 terms took the corpus-wide share from 21% to 16%, because the new
+    // ones are mostly named in headlines (IPO 1% unnamed, Medicaid 1%). A
+    // ratio moves in BOTH directions as the table grows; a floor only ever
+    // becomes more true, since both the term count and the corpus grow.
+    // /glossary itself computes the live figure -- this is the one place the
+    // number could not be computed without an extra query on /civic.
     termIndexCrossLink:
-      "The words the news assumes you know \u2014 one story in five turns on a term it never names \u2192",
+      "The words the news assumes you know \u2014 over a thousand stories turn on a term the coverage never names \u2192",
     emptyBills: "No bills curated yet.",
     billsMoreSoon: "More bills as they're curated.",
     backLink: "Back to Sift",


### PR DESCRIPTION
The `/civic` cross-link read *"one story in five turns on a term it never names."* True when written, **false a day later**: adding 13 terms ([sift-api#257](https://github.com/kristenmartino/sift-api/pull/257)) moved the corpus-wide share from **21% to 16%**, because that batch is mostly named in headlines — IPO 1% unnamed, Medicaid 1%, DNI 1%.

A ratio moves in *both* directions as the table grows. A floor only ever becomes more true, since the term count and the corpus both only grow. So it now reads **"over a thousand stories"** — 1,713 today.

`/glossary` computes the live figure and needed no change. This was the one place the number couldn't be computed without adding a query to `/civic`, which is exactly why it was hardcoded and exactly why it drifted. A test pins the shape so a percentage can't be put back.

Small, but it's the second time today a written-in number went stale within hours — the other was "992 terms clear the floor", which turned out to be 1,442 and couldn't be reproduced from any predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)