### PR TITLE
Read stored coverage counts, and give the floor a single source

### DIFF
--- a/__tests__/copyFormatters.test.ts
+++ b/__tests__/copyFormatters.test.ts
@@ -406,3 +406,18 @@ describe("termIndex formatters", () => {
     expect(c.countLabel(24)).toContain("24 terms,");
   });
 });
+
+describe("termIndex.asOf", () => {
+  it("dates the counts instead of implying they are live", () => {
+    const s = COPY.termIndex.asOf("2026-08-18");
+    expect(s).toContain("2026-08-18");
+    expect(s).toMatch(/measured/i);
+  });
+
+  it("warns that per-term pages can be ahead", () => {
+    // /glossary reads stored counts; /term/<slug> computes live. A reader
+    // clicking through will sometimes see a bigger number, and finding that
+    // unexplained reads as one of them being wrong.
+    expect(COPY.termIndex.asOf("2026-08-18")).toMatch(/computed live|ahead/);
+  });
+});

--- a/__tests__/publishFloor.test.ts
+++ b/__tests__/publishFloor.test.ts
@@ -13,7 +13,6 @@ import type {
   OrgProfile,
   OutletProfile,
   PoliticianProfile,
-  TermCoverage,
   TermProfile,
 } from "@/lib/types";
 
@@ -375,7 +374,7 @@ describe("dossierRobotsMeta", () => {
 
 // ─── Terms ──────────────────────────────────────────────────────────────
 
-const term: TermProfile = {
+const term = (over: Partial<TermProfile> = {}): TermProfile => ({
   slug: "temporary-protected-status",
   term: "Temporary Protected Status",
   definition: "A federal designation that lets nationals of a named country stay.",
@@ -384,48 +383,40 @@ const term: TermProfile = {
   aliases: ["TPS"],
   category: "immigration",
   notes: null,
-};
-
-const coverage = (articleCount: number): TermCoverage => ({
-  articleCount,
-  outlets: [],
-  firstSeen: null,
-  lastSeen: null,
+  coverageArticleCount: 146,
+  coverageComputedAt: "2026-08-18",
+  ...over,
 });
 
 describe("isPublishableTerm", () => {
-  it("publishes a sourced definition with real coverage", () => {
-    expect(isPublishableTerm(term, coverage(146))).toBe(true);
+  it("publishes a sourced definition with measured coverage", () => {
+    expect(isPublishableTerm(term())).toBe(true);
   });
 
   it("withholds a term whose definition lost its source", () => {
     // lib/term.ts nulls the pair, so this is what an unsourced row looks like
-    // by the time the floor sees it. Publishing it would state what a legal
-    // term means on Sift's own authority.
-    const unsourced = { ...term, definition: null, definitionSource: null };
-    expect(isPublishableTerm(unsourced, coverage(146))).toBe(false);
-  });
-
-  it("withholds a well-sourced term with no corpus coverage", () => {
-    // `prior-restraint` in the shipped CSV: real term, cited to Cornell, zero
-    // articles. Without the coverage half the page is a definition Cornell
-    // wrote and we re-stated — strictly worse than Cornell, and exactly the
-    // "one row poured into a template" shape the floor exists to keep out.
-    expect(isPublishableTerm(term, coverage(0))).toBe(false);
+    // by the time the floor sees it.
+    expect(isPublishableTerm(term({ definition: null, definitionSource: null }))).toBe(false);
   });
 
   it("draws the line at TERM_MIN_ARTICLES", () => {
-    expect(isPublishableTerm(term, coverage(TERM_MIN_ARTICLES - 1))).toBe(false);
-    expect(isPublishableTerm(term, coverage(TERM_MIN_ARTICLES))).toBe(true);
+    expect(isPublishableTerm(term({ coverageArticleCount: TERM_MIN_ARTICLES - 1 }))).toBe(false);
+    expect(isPublishableTerm(term({ coverageArticleCount: TERM_MIN_ARTICLES }))).toBe(true);
   });
 
-  it("mirrors the SQL: definition AND source AND count, all three", () => {
-    // listSitemapEntries filters on
-    //   t.definition IS NOT NULL AND t.definition_source IS NOT NULL
-    //   ... WHERE tc.n >= TERM_MIN_ARTICLES
-    // Change one, change the other.
-    expect(isPublishableTerm({ ...term, definition: null }, coverage(146))).toBe(false);
-    expect(isPublishableTerm({ ...term, definitionSource: null }, coverage(146))).toBe(false);
-    expect(isPublishableTerm(term, coverage(1))).toBe(false);
+  it("treats a never-measured term as zero, not as unknown", () => {
+    // A freshly seeded term has no count until refresh_term_coverage.py runs.
+    // Failing closed costs a term publishing one refresh late; failing open
+    // would publish a page on a number nobody has looked at.
+    expect(isPublishableTerm(term({ coverageArticleCount: null }))).toBe(false);
+  });
+
+  it("reads the STORED count, so it cannot disagree with the sitemap", () => {
+    // The sitemap filters `article_count >= TERM_MIN_ARTICLES` on the same
+    // column. This predicate previously took a freshly computed TermCoverage,
+    // which meant two numbers for one decision — and a page emitting noindex
+    // while the sitemap advertised it. There is now one source.
+    expect(isPublishableTerm(term({ coverageArticleCount: 1000 }))).toBe(true);
+    expect(isPublishableTerm(term({ coverageArticleCount: 0 }))).toBe(false);
   });
 });

--- a/__tests__/structuredData.test.ts
+++ b/__tests__/structuredData.test.ts
@@ -252,6 +252,8 @@ describe("termJsonLd", () => {
     aliases: ["TPS"],
     category: "immigration",
     notes: "133 corpus articles as of 2026-08-10.",
+    coverageArticleCount: 146,
+    coverageComputedAt: "2026-08-18",
   };
 
   it("emits a DefinedTerm with the definition and its citation", () => {

--- a/__tests__/term.test.ts
+++ b/__tests__/term.test.ts
@@ -24,6 +24,8 @@ const row = (over: Partial<DbTermProfileRow> = {}): DbTermProfileRow => ({
   aliases: ["TPS"],
   category: "immigration",
   notes: null,
+  article_count: 146,
+  coverage_computed_at: "2026-08-18",
   ...over,
 });
 
@@ -36,6 +38,8 @@ const profile = (over: Partial<TermProfile> = {}): TermProfile => ({
   aliases: ["TPS"],
   category: "immigration",
   notes: null,
+  coverageArticleCount: 146,
+  coverageComputedAt: "2026-08-18",
   ...over,
 });
 
@@ -170,5 +174,30 @@ describe("termPatterns", () => {
     // The coverage queries short-circuit on this rather than building a
     // `WHERE ()` that Postgres rejects.
     expect(termPatterns(profile({ term: "", aliases: [] }))).toEqual([]);
+  });
+});
+
+describe("parseDbTermProfile — stored coverage (migration 034)", () => {
+  it("carries the stored count and stamp through to the profile", () => {
+    const t = parseDbTermProfile(row())!;
+    expect(t.coverageArticleCount).toBe(146);
+    expect(t.coverageComputedAt).toBe("2026-08-18");
+  });
+
+  it("keeps a never-measured term as null rather than coercing to 0", () => {
+    // The floor treats null as zero, but the PARSER must not — "never
+    // measured" and "measured, found nothing" are different facts, and only
+    // the parser can still tell them apart.
+    const t = parseDbTermProfile(
+      row({ article_count: null, coverage_computed_at: null }),
+    )!;
+    expect(t.coverageArticleCount).toBeNull();
+    expect(t.coverageComputedAt).toBeNull();
+  });
+
+  it("keeps a measured zero distinct from never-measured", () => {
+    const t = parseDbTermProfile(row({ article_count: 0 }))!;
+    expect(t.coverageArticleCount).toBe(0);
+    expect(t.coverageComputedAt).toBe("2026-08-18");
   });
 });

--- a/app/term/[slug]/page.tsx
+++ b/app/term/[slug]/page.tsx
@@ -26,10 +26,11 @@ export async function generateMetadata({
   const term = await getTermBySlug(slug);
   if (!term) return { title: "Term not found" };
 
-  // The floor reads coverage, so metadata has to compute it too. Both this
-  // and the page body call `getTermBySlug` + `getTermCoverage`; `getTermBySlug`
-  // is React-cached and the coverage query is 34-81ms on the GIN index, so the
-  // duplicate is one indexed lookup per render, not a second page load.
+  // Coverage is still fetched for the description, but indexability is NOT
+  // decided from it — `isPublishableTerm` reads the stored count (migration
+  // 034), the same column the sitemap query filters on. Deciding it from a
+  // freshly computed number here would let this page and the sitemap disagree
+  // about the same term.
   const coverage = await getTermCoverage(term);
 
   return dossierMetadata({
@@ -41,7 +42,7 @@ export async function generateMetadata({
       coverage.articleCount > 0
         ? `What ${term.term} means, and how ${coverage.outlets.length} outlets across the political spectrum are covering it — ${coverage.articleCount} stories in Sift's index.`
         : `What ${term.term} means, with its primary source, on Sift.`,
-    indexable: isPublishableTerm(term, coverage),
+    indexable: isPublishableTerm(term),
     ogType: "article",
   });
 }

--- a/components/term/TermIndex.tsx
+++ b/components/term/TermIndex.tsx
@@ -84,6 +84,13 @@ export default function TermIndex({ terms, heldCount }: TermIndexProps) {
 
   const gapNote = c.gapNote(terms.length, terms.length + heldCount);
 
+  // The oldest stamp across the set, not the newest — the page is only as
+  // fresh as its stalest row, and quoting the newest would overstate it.
+  const measuredAt = terms
+    .map((t) => t.computedAt)
+    .filter((d): d is string => d !== null)
+    .sort()[0] ?? null;
+
   return (
     <div className="min-h-screen bg-(--surface-base) text-(--text-primary)">
       <LandingMasthead />
@@ -130,6 +137,15 @@ export default function TermIndex({ terms, heldCount }: TermIndexProps) {
             <p className="font-body text-[14px] text-(--text-tertiary) mb-1.5 leading-relaxed">
               {c.countLabel(terms.length)}
             </p>
+            {/* When, not "now". The numbers above come from a periodic
+                measurement, and a reader who clicks into a term page may see
+                a slightly higher figure — better to explain that than to let
+                them find it. */}
+            {measuredAt && (
+              <p className="font-body text-[13px] text-(--text-tertiary) mb-1.5 leading-relaxed">
+                {c.asOf(measuredAt)}
+              </p>
+            )}
             {gapNote && (
               <p className="font-body text-[14px] text-(--text-tertiary) mb-8 max-w-[62ch] leading-relaxed">
                 {gapNote}

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -637,6 +637,14 @@ export const COPY = {
       "you cannot look up a word the article never used.",
     countLabel: (terms: number) =>
       `${terms} ${terms === 1 ? "term" : "terms"}, each with its source and its coverage.`,
+    // The counts on this page are measured periodically rather than on every
+    // load (migration 034 — recomputing them across the corpus was 1.5s at 37
+    // terms and getting worse). So the page says when, instead of implying
+    // now. The per-term pages still compute live, which is why they can
+    // differ slightly and why that is worth saying out loud.
+    asOf: (date: string) =>
+      `Counts measured ${date}. Each term's own page is computed live, so its ` +
+      "figures may be a little ahead of these.",
     // Says out loud what is missing, rather than showing only the flattering
     // subset. Mirrors agencies.contextNote's honesty about omissions.
     gapNote: (published: number, held: number) =>

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1297,7 +1297,15 @@ export async function listAllBillsLite(): Promise<BillListItem[]> {
 export type SitemapEntry = { path: string; lastModified: Date };
 
 /**
- * The `/term/*` branch of the sitemap union, held apart for two reasons.
+ * The `/term/*` branch of the sitemap union.
+ *
+ * Was a lateral recomputing coverage across the corpus per term. It now reads
+ * the count migration 034 stores, which is both far cheaper and the ONLY way
+ * this can agree with `isPublishableTerm` — two implementations of the same
+ * floor drift, and when they do a page says noindex while the sitemap
+ * advertises it.
+ *
+ * Historical note, kept because it is a trap worth not re-entering:
  *
  * **`String.raw` is mandatory here, not stylistic.** This SQL contains POSIX
  * word-boundary escapes (`\m`, `\M`) and a bracket expression of regex
@@ -1314,60 +1322,16 @@ export type SitemapEntry = { path: string; lastModified: Date };
  * branch is much larger than the other four — see the `listSitemapEntries`
  * header for what the rule is and why.
  */
-const SITEMAP_TERM_BRANCH = String.raw`
-       SELECT path, updated_at FROM (
-         SELECT '/term/' || t.slug AS path,
-                t.updated_at,
-                COUNT(DISTINCT m.id) AS n
-           FROM term_profiles t
-           -- One row per surface form, so each gets its own index-scannable
-           -- predicate. Do NOT collapse this into an
-           -- EXISTS (SELECT ... WHERE tsv @@ phraseto_tsquery(f.s)) over the
-           -- forms: that correlates the tsquery per *article*, the planner
-           -- gives up on idx_articles_fulltext, and the whole thing becomes a
-           -- seq scan of the corpus once per term — measured 7,000 ms for four
-           -- terms against 13 ms for this shape.
-           CROSS JOIN LATERAL (
-             SELECT t.term AS s
-             UNION
-             SELECT jsonb_array_elements_text(t.aliases)
-           ) f
-           -- LEFT, so a term with no coverage still produces a row and is
-           -- counted as 0 rather than vanishing before the outer WHERE.
-           LEFT JOIN LATERAL (
-             SELECT a.id
-               FROM articles a
-              WHERE a.from_search = false
-                AND a.summary IS NOT NULL AND a.summary <> ''
-                AND LOWER(a.summary) NOT LIKE 'unable to provide%'
-                -- Same two halves as termMatchSql, and they must stay the
-                -- same: this decides the sitemap, that decides the page, and
-                -- a disagreement means a page says noindex while the sitemap
-                -- lists it.
-                AND (
-                     (to_tsvector('english', COALESCE(a.title,'') || ' ' || COALESCE(a.summary,''))
-                        @@ phraseto_tsquery('english', f.s)
-                      -- Prefilter above, exact predicate below — both
-                      -- load-bearing. All-caps forms match case-sensitively,
-                      -- mirroring isAcronym in lib/term.ts.
-                      AND CASE WHEN f.s = UPPER(f.s)
-                               THEN (COALESCE(a.title,'') || ' ' || COALESCE(a.summary,'')) ~
-                                    ('\m' || regexp_replace(f.s, '([.*+?^$(){}|\[\]\\])', '\\\1', 'g') || '\M')
-                               ELSE (COALESCE(a.title,'') || ' ' || COALESCE(a.summary,'')) ~*
-                                    ('\m' || regexp_replace(f.s, '([.*+?^$(){}|\[\]\\])', '\\\1', 'g') || '\M')
-                          END)
-                     -- The primer half (migration 033). An article counts
-                     -- when Sift's reading-aid layer defined the term for it,
-                     -- even if the headline never says it.
-                     OR primer_term_keys(a.context_primer) && ARRAY[lower(btrim(f.s))]
-                    )
-           ) m ON TRUE
-          WHERE t.definition IS NOT NULL AND t.definition_source IS NOT NULL
-          GROUP BY t.slug, t.updated_at
-       ) tc
-        -- COUNT(DISTINCT) above, because an article matching both "Temporary
-        -- Protected Status" and "TPS" is one article, not two.
-        WHERE tc.n >= ${TERM_MIN_ARTICLES}`;
+const SITEMAP_TERM_BRANCH = `
+       SELECT '/term/' || slug, updated_at
+         FROM term_profiles
+        WHERE definition IS NOT NULL
+          AND definition_source IS NOT NULL
+          -- Stored count (migration 034), the same column isPublishableTerm
+          -- reads. NULL is never-measured and is excluded rather than
+          -- treated as unknown, so a freshly seeded term stays out of the
+          -- sitemap until refresh_term_coverage.py has measured it.
+          AND article_count >= ${TERM_MIN_ARTICLES}`;
 
 /**
  * Dossier URLs that are substantial enough to advertise to crawlers.
@@ -1680,18 +1644,20 @@ export async function listPublishedTerms(): Promise<TermListItem[]> {
       slug: string;
       term: string;
       category: string | null;
-      article_count: string;
-      outlet_count: string;
-      unnamed_count: string;
+      article_count: number | null;
+      outlet_count: number | null;
+      unnamed_count: number | null;
+      coverage_computed_at: Date | string | null;
     }>(GLOSSARY_QUERY);
     return result.rows
       .map((r) => ({
         slug: r.slug,
         term: r.term,
         category: r.category,
-        articleCount: Number(r.article_count),
-        outletCount: Number(r.outlet_count),
-        unnamedCount: Number(r.unnamed_count),
+        articleCount: r.article_count ?? 0,
+        outletCount: r.outlet_count ?? 0,
+        unnamedCount: r.unnamed_count ?? 0,
+        computedAt: toIsoDate(r.coverage_computed_at),
       }))
       .filter((t) => t.articleCount >= TERM_MIN_ARTICLES);
   } catch (err) {
@@ -1725,55 +1691,26 @@ export async function countDefinedTerms(): Promise<number> {
 }
 
 /**
- * `String.raw` for the same reason `SITEMAP_TERM_BRANCH` is — the POSIX
- * word-boundary escapes `\m` and `\M` are eaten by an ordinary template
- * literal, which would silently turn word matching into substring matching.
+ * Reads the counts `scripts/refresh_term_coverage.py` measured (migration
+ * 034) instead of recomputing them across the corpus.
+ *
+ * The query this replaced was a lateral over term x surface-form x corpus:
+ * 785 ms at 24 terms, 1,522 ms at 37, and the slope steepened because more
+ * terms means more matched rows to aggregate. This is 66 ms and flat — the
+ * work no longer depends on corpus size at all.
+ *
+ * No `String.raw` here any more, and nothing to get wrong: the word-boundary
+ * escapes that made the old version fragile now live only in the refresh
+ * script.
  */
-const GLOSSARY_QUERY = String.raw`
-  WITH per AS (
-    SELECT t.slug, t.term, t.category, a.id, a.source_name,
-           -- Named in the text by ANY of its surface forms. Per (term,
-           -- article), so a story that says "TPS" but not "Temporary
-           -- Protected Status" still counts as named.
-           bool_or(
-             to_tsvector('english', COALESCE(a.title,'') || ' ' || COALESCE(a.summary,''))
-               @@ phraseto_tsquery('english', f.s)
-             AND CASE WHEN f.s = UPPER(f.s)
-                      THEN (COALESCE(a.title,'') || ' ' || COALESCE(a.summary,'')) ~
-                           ('\m' || regexp_replace(f.s, '([.*+?^$(){}|\[\]\\])', '\\\1', 'g') || '\M')
-                      ELSE (COALESCE(a.title,'') || ' ' || COALESCE(a.summary,'')) ~*
-                           ('\m' || regexp_replace(f.s, '([.*+?^$(){}|\[\]\\])', '\\\1', 'g') || '\M')
-                 END
-           ) AS in_text
-      FROM term_profiles t
-      CROSS JOIN LATERAL (
-        SELECT t.term AS s UNION SELECT jsonb_array_elements_text(t.aliases)
-      ) f
-      JOIN articles a
-        ON a.from_search = false
-       AND a.summary IS NOT NULL AND a.summary <> ''
-       AND LOWER(a.summary) NOT LIKE 'unable to provide%'
-       AND ( (to_tsvector('english', COALESCE(a.title,'') || ' ' || COALESCE(a.summary,''))
-                @@ phraseto_tsquery('english', f.s)
-              AND CASE WHEN f.s = UPPER(f.s)
-                       THEN (COALESCE(a.title,'') || ' ' || COALESCE(a.summary,'')) ~
-                            ('\m' || regexp_replace(f.s, '([.*+?^$(){}|\[\]\\])', '\\\1', 'g') || '\M')
-                       ELSE (COALESCE(a.title,'') || ' ' || COALESCE(a.summary,'')) ~*
-                            ('\m' || regexp_replace(f.s, '([.*+?^$(){}|\[\]\\])', '\\\1', 'g') || '\M')
-                  END)
-             OR primer_term_keys(a.context_primer) && ARRAY[lower(btrim(f.s))] )
-     WHERE t.definition IS NOT NULL AND t.definition_source IS NOT NULL
-     GROUP BY t.slug, t.term, t.category, a.id, a.source_name
-  )
-  SELECT p.slug, p.term, p.category,
-         COUNT(*)::text AS article_count,
-         COUNT(DISTINCT COALESCE(sa.outlet_slug, op.slug, LOWER(p.source_name)))::text AS outlet_count,
-         COUNT(*) FILTER (WHERE NOT p.in_text)::text AS unnamed_count
-    FROM per p
-    LEFT JOIN source_name_aliases sa ON LOWER(sa.raw_source_name) = LOWER(p.source_name)
-    LEFT JOIN outlet_profiles op ON LOWER(op.name) = LOWER(p.source_name)
-   GROUP BY p.slug, p.term, p.category
-   ORDER BY COUNT(*) DESC`;
+const GLOSSARY_QUERY = `
+  SELECT slug, term, category,
+         article_count, outlet_count, unnamed_count, coverage_computed_at
+    FROM term_profiles
+   WHERE definition IS NOT NULL
+     AND definition_source IS NOT NULL
+     AND article_count IS NOT NULL
+   ORDER BY article_count DESC`;
 
 async function getTermBySlugUncached(slug: string): Promise<TermProfile | null> {
   const trimmed = slug.trim().toLowerCase();
@@ -1782,7 +1719,7 @@ async function getTermBySlugUncached(slug: string): Promise<TermProfile | null> 
   try {
     const result = await pool.query<DbTermProfileRow>(
       `SELECT slug, term, definition, definition_source, definition_checked,
-              aliases, category, notes
+              aliases, category, notes, article_count, coverage_computed_at
          FROM term_profiles
         WHERE slug = $1
         LIMIT 1`,

--- a/lib/publishFloor.ts
+++ b/lib/publishFloor.ts
@@ -36,7 +36,6 @@ import type {
   OrgProfile,
   OutletProfile,
   PoliticianProfile,
-  TermCoverage,
   TermProfile,
 } from "./types";
 
@@ -186,7 +185,7 @@ export function isPublishableOutlet(o: OutletProfile): boolean {
 export const TERM_MIN_ARTICLES = 8;
 
 /**
- * A sourced definition **and** enough coverage to be about something.
+ * A sourced definition **and** enough measured coverage to be about something.
  *
  * Both halves, deliberately. `lib/term.ts` already drops a definition that
  * lost its source, so a null definition here means the row cannot state what
@@ -194,14 +193,20 @@ export const TERM_MIN_ARTICLES = 8;
  * page. Unlike the other four types, this floor reads a computed value rather
  * than a column, because coverage is not stored anywhere.
  */
-export function isPublishableTerm(
-  t: TermProfile,
-  coverage: TermCoverage,
-): boolean {
+export function isPublishableTerm(t: TermProfile): boolean {
   return (
     present(t.definition) &&
     present(t.definitionSource) &&
-    coverage.articleCount >= TERM_MIN_ARTICLES
+    // Stored count, not a freshly computed one. Both the sitemap query and
+    // this predicate now read the same column, which is the only way they can
+    // agree — and they have to, or a page emits noindex while the sitemap
+    // advertises it.
+    //
+    // null (never measured) is treated as zero, so a freshly seeded term is
+    // withheld until scripts/refresh_term_coverage.py has looked at it. Fails
+    // closed: the cost is a term publishing a refresh late, versus a term
+    // publishing on a number nobody has checked.
+    (t.coverageArticleCount ?? 0) >= TERM_MIN_ARTICLES
   );
 }
 

--- a/lib/term.ts
+++ b/lib/term.ts
@@ -27,6 +27,9 @@ export interface DbTermProfileRow {
   aliases: unknown; // JSONB — validated below
   category: string | null;
   notes: string | null;
+  // Migration 034. Read by the publish floor; see TermProfile.
+  article_count: number | null;
+  coverage_computed_at: Date | string | null;
 }
 
 /** Coerce a Postgres DATE (Date | ISO string | null) to `YYYY-MM-DD`. */
@@ -83,6 +86,9 @@ export function parseDbTermProfile(
   return {
     slug,
     term,
+    coverageArticleCount:
+      typeof row.article_count === "number" ? row.article_count : null,
+    coverageComputedAt: asIsoDate(row.coverage_computed_at),
     definition: sourced ? row.definition!.trim() : null,
     definitionSource: sourced ? row.definition_source!.trim() : null,
     definitionChecked: sourced ? asIsoDate(row.definition_checked) : null,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -612,6 +612,19 @@ export interface OutletProfile {
 export interface TermProfile {
   slug: string;
   term: string;
+  /**
+   * Stored coverage count (migration 034), and when it was measured.
+   *
+   * The publish floor reads THESE, not a freshly computed figure, and does so
+   * on the term page as well as in the sitemap — the two must agree or a page
+   * emits noindex while the sitemap advertises it. `null` means never
+   * measured, which the floor treats as zero rather than unknown.
+   *
+   * The page still renders live coverage. Only indexability is decided from
+   * the stored number.
+   */
+  coverageArticleCount: number | null;
+  coverageComputedAt: string | null;
   /** Never non-null without `definitionSource`. See lib/term.ts. */
   definition: string | null;
   definitionSource: string | null;
@@ -639,6 +652,8 @@ export interface TermListItem {
   articleCount: number;
   outletCount: number;
   unnamedCount: number;
+  /** ISO YYYY-MM-DD the counts were measured. Rendered as "as of". */
+  computedAt: string | null;
 }
 
 /** One outlet's share of a term's coverage, with its published lean. */


### PR DESCRIPTION
**Depends on [sift-api#258](https://github.com/kristenmartino/sift-api/pull/258)** (migration 034 + the refresh script). Merge that first.

`/glossary` and the sitemap floor recomputed coverage across the corpus on every read — 785 ms at 24 terms, 1,522 ms at 37, slope steepening. Both now read stored counts: **66 ms, flat in corpus size.**

`/term/<slug>` still computes live — per-term, 34–81 ms regardless of table size, and keeping it live means the per-term view is never stale even when the index is.

## The part that matters more than the speed

`isPublishableTerm` no longer takes a freshly computed `TermCoverage`. It reads `coverageArticleCount` — **the same column the sitemap query filters on** — so there is exactly one number behind one decision.

Two implementations of one floor drift. When *this* floor drifts, a page emits `noindex` while the sitemap advertises it, which is the failure the invariant comment in `listSitemapEntries` has warned about since Phase 0e. Previously the sitemap computed coverage in SQL and the page computed it in TypeScript — same rule, two code paths. Now it's one column.

Verified end to end against prod: **all 37 sitemap terms emit `index, follow`, zero mismatches.**

## Fails closed on both sides

`null` means never measured. `?? 0` here; `NULL >= 8` is `NULL` in the SQL and the row is excluded — checked rather than assumed.

The **parser deliberately does not coerce**. "Never measured" and "measured, found nothing" are different facts, and the parser is the only place that can still tell them apart; a test pins that.

## Saying so on the page

Counts are periodic now, so `/glossary` says *"Counts measured 2026-08-18"* rather than implying now, and warns a term's own page may be slightly ahead. The stamp is the **oldest** across the set, not the newest — the page is only as fresh as its stalest row.

Also drops `String.raw` from the glossary query: the POSIX word-boundary escapes that made it fragile now live only in the refresh script.

864 tests pass; verified against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)