### PR TITLE
Stop attributing invented quotes to Reuters, the WSJ and Bloomberg

### DIFF
--- a/components/NewsAggregator.tsx
+++ b/components/NewsAggregator.tsx
@@ -212,11 +212,14 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     updateIndicator();
   }, [activeCategory, activeCustomTopic, showBookmarks, searchMode, compareMode, updateIndicator]);
 
-  const exitCompareMode = () => {
+  // Memoized so the Cmd+K effect below can declare it instead of suppressing
+  // exhaustive-deps. `clearCompare` is useCallback([])-stable in useCompare,
+  // so this identity never changes and the listener still binds exactly once.
+  const exitCompareMode = useCallback(() => {
     setCompareMode(false);
     setCompareInputValue("");
     clearCompare();
-  };
+  }, [clearCompare]);
 
   // Cmd+K / Ctrl+K keyboard shortcut for search
   useEffect(() => {
@@ -233,7 +236,7 @@ export default function NewsAggregator({ userId, authSlot }: NewsAggregatorProps
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [clearTopicSearch]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [clearTopicSearch, exitCompareMode]);
 
   // Fetch full bookmarked articles from DB when viewing bookmarks (signed in).
   // The key derives from view + user + bookmark set, so closing the view or

--- a/components/landing/ComparisonDemo.tsx
+++ b/components/landing/ComparisonDemo.tsx
@@ -8,10 +8,11 @@ const C = COPY.landingReskin.compare;
  *
  * With a daily example (sift-api generates one real comparison per UTC day),
  * this renders live output from the actual compare tool, dated. Without one
- * (first deploy, or the table hasn't been seeded), it falls back to the
- * original static Fed illustration, which noteLine keeps honest. This
- * resolves the old TODO(live-compare): real data replaced the fixture the
- * moment it could do so without fabricating anything.
+ * (first deploy, or the table unreachable), it falls back to a generic
+ * illustration of the format — no named outlets, no lean chips — which
+ * noteLine labels as written rather than quoted. This resolves the old
+ * TODO(live-compare): real data replaced the fixture the moment it could do
+ * so without fabricating anything.
  */
 export default function ComparisonDemo({
   example,
@@ -69,14 +70,13 @@ export default function ComparisonDemo({
                   <q>{claim.claim}</q>
                 </div>
               ))
-            : C.frames.map((f) => (
+            : // The fallback carries no lean chip: the frames are generic
+              // placeholders, and a rating badge beside one would imply a real
+              // outlet had been rated. noteLine labels the whole block instead.
+              C.frames.map((f) => (
                 <div className="sl-frame" key={f.outlet}>
                   <div className="sl-out">
                     <span className="sl-nm">{f.outlet}</span>
-                    <span className="sl-ln">
-                      <span className="sl-dot" aria-hidden />
-                      {f.lean}
-                    </span>
                   </div>
                   <q>{f.quote}</q>
                 </div>

--- a/lib/copy.ts
+++ b/lib/copy.ts
@@ -832,29 +832,33 @@ export const COPY = {
         "Sift shows what each outlet chose to emphasize — described, not labeled “biased” or “objective.” You read; the product does the legwork.",
       topicLabel: "Topic",
       topic: "The Federal Reserve's May rate decision",
+      // Shown only before the first daily comparison exists (or if the table
+      // is unreachable). The outlets are deliberately generic and the quotes
+      // are written, not sourced: attributing invented lines to Reuters, the
+      // WSJ and Bloomberg — which this block did until 2026-08-17, complete
+      // with "AllSides: Center" chips implying a rating had been applied —
+      // fabricated the one thing the product promises it never fabricates.
+      // noteLine now says outright that this is a mockup.
       frames: [
         {
-          outlet: "Reuters",
-          lean: "AllSides: Center",
+          outlet: "A wire service",
           quote: "Powell signals patience as inflation stays sticky; Fed leaves rates unchanged.",
         },
         {
-          outlet: "Wall Street Journal",
-          lean: "AllSides: Center",
+          outlet: "A financial daily",
           quote: "Markets read between the lines: rate cuts unlikely before the fall.",
         },
         {
-          outlet: "Bloomberg",
-          lean: "AllSides: Center",
+          outlet: "A markets desk",
           quote: "Wall Street recalibrates as rate-cut bets fade and bond yields climb.",
         },
       ],
       noteLine:
-        "Same event, three emphases. Sift puts them side by side and lets you draw the line.",
+        "An illustration of the format — the outlets are generic and the lines are written, not quoted. Sift replaces this with a real comparison once today's is generated.",
       // Live-example variants — used when the daily compare example exists
       // (sift-api writes one real comparison per UTC day, migration 021).
-      // The static Fed frames above stay as the fallback before the first
-      // generation ever runs, still labeled honestly by noteLine.
+      // The generic frames above stay as the fallback before the first
+      // generation ever runs; noteLine labels them as an illustration.
       liveTitleIt: "side by side.",
       liveTopicLabel: "Today's comparison",
       liveDisputedVs: " vs ",


### PR DESCRIPTION
Split out of #257, where it had landed on a shared branch alongside an unrelated copy change. Authored by @kristenmartino; opening it separately so the fix keeps its own title and reasoning in `main`'s history rather than being squashed under "Say which cycle the PAC figures are from…".

Commit message reproduced in full, since it is the rationale:

---

The landing's "How outlets framed it" section renders a live comparison when sift-api has generated one for the day, and a static block when it has not. That static block named three real outlets, put an invented sentence in each one's mouth, and stamped every one "AllSides: Center" — implying a rating had been applied to a quote that was never said.

It is reachable, not dead code: `getDailyCompareExample()` returns null on an empty table, a malformed payload, or a missing relation, and the catch in `app/page.tsx` turns a DB outage into the same null. So this is what a visitor sees on a first deploy or a bad database day.

The frames now carry generic roles, no lean chips, and a `noteLine` that says the lines are written rather than quoted. The comment claiming `noteLine` already "kept it honest" was the part that was wrong — it never said anything of the kind.

Nothing changes on the live branch, which was already real output.

Also drops the repo's last eslint suppression. The Cmd+K effect omitted `exitCompareMode` from its deps and disabled `exhaustive-deps` to do it; since `useCompare`'s `clear` is `useCallback([])`-stable, wrapping `exitCompareMode` in `useCallback` lets the effect declare it honestly and binds the listener exactly once, as before.

---

Verification on this branch, rebased onto current `main` (`da4f80e`): `npx jest` 57 suites / 864 tests pass, `npx tsc --noEmit` clean.