### PR TITLE
Make the tests able to fail: real guards on /api/compare, a meta-suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,14 @@ jobs:
       - run: npm ci
         if: steps.scope.outputs.docs_only != 'true'
 
+      # No `continue-on-error`. It carried one until 2026-08-17, which meant a
+      # high-severity advisory printed and the build passed — the one step in
+      # this workflow whose entire purpose is to fail could not. Measured 0
+      # vulnerabilities at high or above when the flag came off, so this gate
+      # started green rather than being switched on over a known-red tree.
       - name: Security audit
         if: steps.scope.outputs.docs_only != 'true'
         run: npm audit --audit-level=high
-        continue-on-error: true
 
       - name: Type check
         if: steps.scope.outputs.docs_only != 'true'

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -22,11 +22,16 @@ const mockGetLastRefreshed = jest.fn<Promise<Date | null>, [string]>();
 // Tests pre-date both, so default to empty results (= API returns articles
 // without outlet/entityLinks, which is the graceful-degradation path the UI
 // tolerates).
+// Controllable so the spectrumBuckets tests can hand specific outlets back;
+// defaults to null in beforeEach, which is the pre-existing behaviour every
+// other test in this file was written against.
+const mockResolveOutlet = jest.fn();
+
 jest.mock("@/lib/db", () => ({
   getStoriesWithArticles: (...args: [string]) => mockGetStoriesWithArticles(...args),
   getLastRefreshed: (...args: [string]) => mockGetLastRefreshed(...args),
   getOutletProfilesMap: jest.fn().mockResolvedValue(new Map()),
-  resolveOutletForSourceName: jest.fn().mockReturnValue(null),
+  resolveOutletForSourceName: (...args: unknown[]) => mockResolveOutlet(...args),
   getArticleEntityLinks: jest.fn().mockResolvedValue(new Map()),
 }));
 
@@ -99,6 +104,8 @@ function makeRequest(category?: string) {
 beforeEach(() => {
   mockGetStoriesWithArticles.mockReset();
   mockGetLastRefreshed.mockReset();
+  mockResolveOutlet.mockReset();
+  mockResolveOutlet.mockReturnValue(null);
   mockGetStoriesWithArticles.mockResolvedValue(makeDefaultReturn());
   mockGetLastRefreshed.mockResolvedValue(MOCK_LAST_REFRESHED);
 });
@@ -461,5 +468,190 @@ describe("GET /api/news", () => {
       await GET(makeRequest("world"));
       expect(mockGetLastRefreshed).toHaveBeenCalledWith("world");
     });
+  });
+});
+
+// ─── Sanitization at the API boundary ───────────────────
+//
+// `stripHtml` itself is covered thoroughly in __tests__/sanitize.test.ts. What
+// was missing until 2026-08-17 was any coverage of its CALL SITES: no fixture
+// in this file contained a single HTML tag, so all six `stripHtml(...)` calls
+// in app/api/news/route.ts could be deleted with the whole suite green
+// (verified). Story headlines, summaries, framings and entities are all
+// LLM-synthesized from external article text and land in the client render
+// path, so this is the boundary where the escaping has to hold.
+
+describe("GET /api/news — sanitizes external text", () => {
+  const MARKUP = '<img src=x onerror=alert(1)>Fed holds';
+  const ENCODED = '&lt;script&gt;alert(1)&lt;/script&gt;Cuts likely';
+
+  function storyWithMarkup() {
+    return {
+      stories: [{
+        id: "story1",
+        headline: MARKUP,
+        summary: `<b>Bold</b> claim`,
+        category: "technology",
+        framings: [{
+          source_name: `<i>Reuters</i>`,
+          framing: ENCODED,
+          tone: "neutral",
+        }],
+        entities: [{
+          people: [`<b>Alice</b>`],
+          organizations: [`<span>Acme</span>`],
+          locations: [`<em>NYC</em>`],
+          event_description: `<script>x</script>A rate decision`,
+        }],
+        article_count: 1,
+        outlet_count: 1,
+        grim_share: null,
+        opinion_share: null,
+        avg_importance: 3,
+        max_importance: 3,
+        representative_image_url: null,
+        published_date: new Date("2026-03-28T10:00:00Z"),
+        synthesis_status: "complete",
+      }],
+      storyArticles: { story1: [{ ...MOCK_DB_ROWS[0], story_id: "story1" }] },
+      standaloneArticles: [],
+    };
+  }
+
+  it("strips markup from the story headline and summary", async () => {
+    mockGetStoriesWithArticles.mockResolvedValue(storyWithMarkup());
+    const body = await (await GET(makeRequest("technology"))).json();
+
+    expect(body.stories[0].headline).toBe("Fed holds");
+    expect(body.stories[0].summary).toBe("Bold claim");
+  });
+
+  it("strips markup from framing source names and framing text", async () => {
+    mockGetStoriesWithArticles.mockResolvedValue(storyWithMarkup());
+    const body = await (await GET(makeRequest("technology"))).json();
+    const framing = body.stories[0].framings[0];
+
+    expect(framing.sourceName).toBe("Reuters");
+    // `stripHtml` decodes entities FIRST and then removes tags, so an encoded
+    // <script> cannot survive as text a client later un-escapes into markup.
+    // It removes tags, not the text between them — hence the bare "alert(1)".
+    // That is the intended contract (lib/sanitize.ts:23-28): the security
+    // property is that no bracket survives, which the backstop below pins.
+    expect(framing.framing).toBe("alert(1)Cuts likely");
+  });
+
+  it("strips markup from every entity list and the event description", async () => {
+    mockGetStoriesWithArticles.mockResolvedValue(storyWithMarkup());
+    const body = await (await GET(makeRequest("technology"))).json();
+    const entities = body.stories[0].entities[0];
+
+    expect(entities.people).toEqual(["Alice"]);
+    expect(entities.organizations).toEqual(["Acme"]);
+    expect(entities.locations).toEqual(["NYC"]);
+    // Tags removed, inner text kept — see the note above.
+    expect(entities.eventDescription).toBe("xA rate decision");
+  });
+
+  it("leaves no angle bracket anywhere in the serialized story", async () => {
+    mockGetStoriesWithArticles.mockResolvedValue(storyWithMarkup());
+    const body = await (await GET(makeRequest("technology"))).json();
+
+    // A backstop for call sites added later: any new unsanitized story field
+    // fails here even if no one adds a test for it by name.
+    expect(JSON.stringify(body.stories[0])).not.toMatch(/[<>]/);
+  });
+});
+
+// ─── Ranking v2 stage 1: spectrumBuckets ────────────────
+//
+// `countOccupiedBuckets` is unit-tested in __tests__/crossSpectrum.test.ts,
+// but until 2026-08-17 the string "spectrumBuckets" did not appear anywhere in
+// this suite — the route's WIRING of it was untested, including the stage-4
+// `reportedSources` filter that stops op-ed-only framings counting as
+// cross-spectrum corroboration (sift-api#200).
+
+describe("GET /api/news — spectrumBuckets", () => {
+  const OUTLETS: Record<string, { allSidesRating: string }> = {
+    Reuters: { allSidesRating: "center" },
+    "The Nation": { allSidesRating: "left" },
+    "NY Post": { allSidesRating: "right" },
+  };
+
+  function storyAcrossSpectrum(childOverrides: Array<Record<string, unknown>>) {
+    return {
+      stories: [{
+        id: "story1",
+        headline: "Rate decision",
+        summary: "A synthesized summary.",
+        category: "technology",
+        framings: [
+          { source_name: "Reuters", framing: "Timeline", tone: "neutral" },
+          { source_name: "The Nation", framing: "Labor angle", tone: "neutral" },
+          { source_name: "NY Post", framing: "Markets angle", tone: "neutral" },
+        ],
+        entities: [],
+        article_count: 3,
+        outlet_count: 3,
+        grim_share: null,
+        opinion_share: null,
+        avg_importance: 3,
+        max_importance: 3,
+        representative_image_url: null,
+        published_date: new Date("2026-03-28T10:00:00Z"),
+        synthesis_status: "complete",
+      }],
+      storyArticles: {
+        story1: childOverrides.map((o, i) => ({
+          ...MOCK_DB_ROWS[0],
+          id: `child${i}`,
+          story_id: "story1",
+          ...o,
+        })),
+      },
+      standaloneArticles: [],
+    };
+  }
+
+  beforeEach(() => {
+    mockResolveOutlet.mockImplementation(
+      (_map: unknown, sourceName: string) => OUTLETS[sourceName] ?? null,
+    );
+  });
+
+  it("counts the distinct L/C/R buckets the reported framings occupy", async () => {
+    mockGetStoriesWithArticles.mockResolvedValue(
+      storyAcrossSpectrum([
+        { source_name: "Reuters", is_opinion: false },
+        { source_name: "The Nation", is_opinion: false },
+        { source_name: "NY Post", is_opinion: false },
+      ]),
+    );
+    const body = await (await GET(makeRequest("technology"))).json();
+    expect(body.stories[0].spectrumBuckets).toBe(3);
+  });
+
+  it("does not count framings whose outlet only filed opinion pieces", async () => {
+    // Stage 4: op-eds across lanes are disagreement, not corroboration. Only
+    // Reuters filed a REPORTED piece, so one bucket is occupied, not three.
+    mockGetStoriesWithArticles.mockResolvedValue(
+      storyAcrossSpectrum([
+        { source_name: "Reuters", is_opinion: false },
+        { source_name: "The Nation", is_opinion: true },
+        { source_name: "NY Post", is_opinion: true },
+      ]),
+    );
+    const body = await (await GET(makeRequest("technology"))).json();
+    expect(body.stories[0].spectrumBuckets).toBe(1);
+  });
+
+  it("omits spectrumBuckets entirely when no framing resolves to a bucket", async () => {
+    // Omitted rather than 0 — the client re-rank defines "no signal" itself,
+    // and a second definition here is how the two ends drifted apart before.
+    mockResolveOutlet.mockReturnValue(null);
+    mockGetStoriesWithArticles.mockResolvedValue(
+      storyAcrossSpectrum([{ source_name: "Reuters", is_opinion: false }]),
+    );
+    const body = await (await GET(makeRequest("technology"))).json();
+    expect(body.stories[0]).not.toHaveProperty("spectrumBuckets");
   });
 });

--- a/__tests__/compare.test.ts
+++ b/__tests__/compare.test.ts
@@ -3,25 +3,37 @@
  *
  * Contract test for the /api/compare proxy route. Locks the frontend half of
  * the compare contract aligned in sift#114 / sift#122 (and sift-api#77 / #78):
- * auth required, CSRF-gated, max 5 sources, forwards to the preferred
- * /v1/analyze/compare route with the pipeline key, trims the topic, and never
- * leaks backend error detail.
+ * auth required, CSRF-gated, rate-limited per user, max 5 sources, forwards to
+ * the preferred /v1/analyze/compare route with the pipeline key, trims the
+ * topic, and never leaks backend error detail.
  *
- * Mocks are declared before importing the route so the handler picks them up.
+ * WHAT IS AND IS NOT MOCKED, and why it matters here more than elsewhere.
+ *
+ * This file previously mocked `@/lib/rate-limit` and `@/lib/security` and then
+ * asserted on the values it had just configured on those mocks — `mockRateLimit`
+ * was never referenced by a single assertion, and there was no 429 test at all.
+ * Verified 2026-08-17: with the entire limiter (`route.ts:34-36`) deleted, all
+ * six tests passed. So did `"X-Pipeline-Key": ""`, because the header was only
+ * asserted with `toBeDefined()` and `SIFT_API_KEY` defaults to `""`.
+ *
+ * That is worth guarding properly: every request here is a 20-90s LLM job on
+ * the backend, so the limiter is both the abuse vector and the cost ceiling.
+ *
+ * The limiter and the CSRF gate now run for real. Only two things are stubbed:
+ * Clerk's `auth` (no session to be had in a unit test) and `@/lib/siftApi`,
+ * which is import-time config, not behaviour — stubbing it is what lets the
+ * pipeline-key header be asserted by exact value instead of mere presence.
  */
 import { NextRequest } from "next/server";
 
-const mockAuth = jest.fn();
+const mockAuth = jest.fn<Promise<{ userId: string | null }>, []>();
 jest.mock("@clerk/nextjs/server", () => ({ auth: () => mockAuth() }));
 
-const mockRateLimit = jest.fn();
-jest.mock("@/lib/rate-limit", () => ({
-  rateLimit: (...args: unknown[]) => mockRateLimit(...args),
-}));
-
-const mockCheckCsrf = jest.fn();
-jest.mock("@/lib/security", () => ({
-  checkCsrf: (...args: unknown[]) => mockCheckCsrf(...args),
+// Import-time config, not logic. Fixed values so the forwarded URL and the
+// pipeline key can be asserted exactly.
+jest.mock("@/lib/siftApi", () => ({
+  SIFT_API_URL: "https://api.test.local",
+  SIFT_API_KEY: "test-pipeline-key",
 }));
 
 import { POST } from "../app/api/compare/route";
@@ -37,28 +49,47 @@ const BACKEND_OK = {
   duration_ms: 1234,
 };
 
-function makeRequest(body: unknown) {
+/**
+ * The real limiter's store is module-global and survives across tests in a
+ * file, and the route keys it on `compare:${userId}` at 5/min. Each test
+ * therefore gets a fresh user id, exactly as primerExpandRoute.test.ts walks
+ * the IP — otherwise the sixth request of the *file* would 429 and the failure
+ * would land on whichever test happened to run last.
+ */
+let userCounter = 0;
+function freshUser(): string {
+  userCounter += 1;
+  return `user_${userCounter}`;
+}
+
+function makeRequest(
+  body: unknown,
+  headers: Record<string, string> = {},
+): NextRequest {
   return new NextRequest("http://localhost/api/compare", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      // What a browser sends on a same-origin fetch; the real checkCsrf reads it.
+      "sec-fetch-site": "same-origin",
+      ...headers,
+    },
     body: JSON.stringify(body),
   });
 }
 
 beforeEach(() => {
   mockAuth.mockReset();
-  mockRateLimit.mockReset();
-  mockCheckCsrf.mockReset();
   mockFetch.mockReset();
-  // Happy-path defaults: authed, CSRF ok, under rate limit, backend returns ok.
-  mockAuth.mockResolvedValue({ userId: "user_1" });
-  mockCheckCsrf.mockReturnValue(null);
-  mockRateLimit.mockReturnValue({ allowed: true, retryAfterMs: 0 });
-  mockFetch.mockResolvedValue(
-    new Response(JSON.stringify(BACKEND_OK), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    }),
+  mockAuth.mockResolvedValue({ userId: freshUser() });
+  // A fresh Response per call, not a shared one: a body can only be read once,
+  // and the rate-limit tests below drive the route five times in a row.
+  mockFetch.mockImplementation(
+    async () =>
+      new Response(JSON.stringify(BACKEND_OK), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
   );
 });
 
@@ -71,11 +102,14 @@ describe("POST /api/compare contract", () => {
   });
 
   it("honors the CSRF gate before doing anything else", async () => {
-    mockCheckCsrf.mockReturnValue(
-      new Response(JSON.stringify({ error: "Invalid origin" }), { status: 403 }),
+    const res = await POST(
+      makeRequest({ topic: "Federal Reserve" }, { "sec-fetch-site": "cross-site" }),
     );
-    const res = await POST(makeRequest({ topic: "Federal Reserve" }));
     expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Forbidden" });
+    // The ordering half of the claim in this test's name: the gate has to run
+    // before the session lookup, not merely somewhere before the fetch.
+    expect(mockAuth).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -98,9 +132,11 @@ describe("POST /api/compare contract", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
     const [url, options] = mockFetch.mock.calls[0];
-    expect(String(url)).toMatch(/\/v1\/analyze\/compare$/);
+    expect(String(url)).toBe("https://api.test.local/v1/analyze/compare");
     const headers = options.headers as Record<string, string>;
-    expect(headers["X-Pipeline-Key"]).toBeDefined();
+    // By value, not `toBeDefined()`: SIFT_API_KEY falls back to "" when unset
+    // (lib/siftApi.ts), and "" is defined — so presence proves nothing.
+    expect(headers["X-Pipeline-Key"]).toBe("test-pipeline-key");
 
     const body = await res.json();
     expect(body.comparison).toBe(BACKEND_OK.comparison);
@@ -114,16 +150,50 @@ describe("POST /api/compare contract", () => {
   });
 
   it("does not leak backend error detail to the client", async () => {
-    mockFetch.mockResolvedValue(
-      new Response(
-        JSON.stringify({ detail: "secret db connection string here" }),
-        { status: 500 },
-      ),
+    mockFetch.mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({ detail: "secret db connection string here" }),
+          { status: 500 },
+        ),
     );
     const res = await POST(makeRequest({ topic: "Federal Reserve" }));
     const body = await res.json();
     expect(res.status).toBe(502);
     expect(JSON.stringify(body)).not.toContain("secret");
     expect(body.error).toBe("Comparison service unavailable");
+  });
+});
+
+describe("POST /api/compare rate limiting", () => {
+  it("429s with a Retry-After once one user passes 5 comparisons a minute", async () => {
+    const userId = freshUser();
+    mockAuth.mockResolvedValue({ userId });
+
+    for (let i = 0; i < 5; i++) {
+      expect((await POST(makeRequest({ topic: "Federal Reserve" }))).status).toBe(200);
+    }
+
+    const res = await POST(makeRequest({ topic: "Federal Reserve" }));
+    expect(res.status).toBe(429);
+    await expect(res.json()).resolves.toEqual({ error: "Too many requests" });
+    expect(Number(res.headers.get("Retry-After"))).toBeGreaterThan(0);
+    // The ceiling is a spend ceiling: the sixth request must not reach the
+    // backend, where it would start another 20-90s LLM job.
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+  });
+
+  it("meters each user separately, so one user cannot exhaust another's budget", async () => {
+    const heavy = freshUser();
+    mockAuth.mockResolvedValue({ userId: heavy });
+    for (let i = 0; i < 5; i++) {
+      await POST(makeRequest({ topic: "Federal Reserve" }));
+    }
+    expect((await POST(makeRequest({ topic: "Federal Reserve" }))).status).toBe(429);
+
+    // A second user is unaffected — this is what pins the limiter key to the
+    // session. Keyed on a constant instead of `userId`, the line below 429s.
+    mockAuth.mockResolvedValue({ userId: freshUser() });
+    expect((await POST(makeRequest({ topic: "Federal Reserve" }))).status).toBe(200);
   });
 });

--- a/__tests__/copy.test.ts
+++ b/__tests__/copy.test.ts
@@ -67,46 +67,67 @@ describe("COPY strings", () => {
     });
   });
 
+  // Exact values, not `toBeTruthy()`. This block used to assert only that ~20
+  // keys were non-empty, which passes for any wrong-but-present string — you
+  // could swap `topics.confirm` and `topics.cancel`, or set `error.body` to
+  // "x", and it stayed green. These keys are referenced nowhere else in the
+  // suite, so presence checks were the only thing standing behind them.
   describe("static strings", () => {
-    it("has header tagline", () => {
-      expect(COPY.header.tagline).toBeTruthy();
-    });
-
-    it("has footer text", () => {
-      expect(COPY.footer.main()).toBeTruthy();
+    it("has the header tagline and footer", () => {
+      expect(COPY.header.tagline).toBe("The news, with footnotes");
+      expect(COPY.footer.main()).toContain(
+        "Sift curates outlets across the political spectrum",
+      );
+      expect(COPY.footer.main()).toContain("Every link goes to the original.");
     });
 
     it("has error strings", () => {
-      expect(COPY.error.title).toBeTruthy();
-      expect(COPY.error.body).toBeTruthy();
-      expect(COPY.error.button).toBeTruthy();
+      expect(COPY.error.title).toBe("We hit a snag pulling today's stories");
+      expect(COPY.error.body).toBe(
+        "Our AI is having a slow morning. Give it another shot — it usually sorts itself out.",
+      );
+      expect(COPY.error.button).toBe("Try again");
     });
 
     it("has loading strings", () => {
-      expect(COPY.loading.slow).toBeTruthy();
-      expect(COPY.loading.slowTopic).toBeTruthy();
-      expect(COPY.loading.refresh).toBeTruthy();
+      expect(COPY.loading.slow).toBe(
+        "Still reading through sources… good stories take a moment",
+      );
+      expect(COPY.loading.slowTopic).toBe(
+        "Searching articles… good matches take a moment",
+      );
+      expect(COPY.loading.refresh).toBe("Checking for new stories…");
     });
 
     it("has topic modal strings", () => {
-      expect(COPY.topics.modalTitle).toBeTruthy();
-      expect(COPY.topics.modalPlaceholder).toBeTruthy();
-      expect(COPY.topics.generating).toBeTruthy();
-      expect(COPY.topics.previewTitle).toBeTruthy();
-      expect(COPY.topics.confirm).toBeTruthy();
-      expect(COPY.topics.cancel).toBeTruthy();
-      expect(COPY.topics.edit).toBeTruthy();
-      expect(COPY.topics.maxReached).toBeTruthy();
+      expect(COPY.topics.modalTitle).toBe("What do you want to track?");
+      expect(COPY.topics.modalPlaceholder).toBe(
+        "e.g. Florida utilities, AI in healthcare, Series A funding",
+      );
+      expect(COPY.topics.generating).toBe("Interpreting your topic…");
+      expect(COPY.topics.previewTitle).toBe("Here\u2019s what I\u2019ll track");
+      expect(COPY.topics.maxReached).toBe(
+        "You\u2019ve hit the 5-topic limit. Remove one to add another.",
+      );
+    });
+
+    it("keeps the confirm / cancel / edit actions distinct and correctly labelled", () => {
+      // Named separately because a swap between these three is the one copy
+      // bug with a destructive outcome — a reader clicking "Add topic" and
+      // getting the cancel path. `toBeTruthy()` could never see it.
+      expect(COPY.topics.confirm).toBe("Add topic");
+      expect(COPY.topics.cancel).toBe("Cancel");
+      expect(COPY.topics.edit).toBe("Edit");
     });
 
     it("has compare strings", () => {
-      expect(COPY.compare.button).toBeTruthy();
-      expect(COPY.compare.placeholder).toBeTruthy();
+      expect(COPY.compare.button).toBe("Compare coverage");
+      expect(COPY.compare.placeholder).toContain("Compare coverage across sources");
     });
 
     it("has bookmark strings", () => {
-      expect(COPY.bookmarks.title).toBeTruthy();
-      expect(COPY.bookmarks.emptyTitle).toBeTruthy();
+      expect(COPY.bookmarks.title).toBe("Saved Articles");
+      expect(COPY.bookmarks.emptyTitle).toBe("Nothing saved yet");
     });
   });
 

--- a/__tests__/meta.test.ts
+++ b/__tests__/meta.test.ts
@@ -1,0 +1,283 @@
+/**
+ * @jest-environment node
+ *
+ * Meta-tests: deterministic checks that this test suite is itself sound.
+ *
+ * The suite certifies everything else in `sift`; nothing certified the suite.
+ * `sift-api` has had `tests/test_meta_suite.py` doing this job since the
+ * `stable_hash("hello") == stable_hash("hello")` defect; this is the frontend
+ * half, and it adds the check that file was missing — a test can assert
+ * something and still be incapable of failing.
+ *
+ * The motivating cases here were real, all found 2026-08-17:
+ *   - `compare.test.ts` mocked the rate limiter and then never asserted on it.
+ *     Deleting the limiter from the route left all six tests green.
+ *   - `utils.test.ts` asserted `stableHash(url) === stableHash(url)` — true for
+ *     every possible implementation of a pure function.
+ *   - `copy.test.ts` asserted ~20 copy keys were `toBeTruthy()`, so swapping
+ *     "Add topic" and "Cancel" passed.
+ *
+ * ESLint catches none of this: no rule asks whether a test can fail.
+ *
+ * WHAT IS NOT CHECKED HERE, and why — see `describe("known gaps")` at the
+ * bottom, which pins the measurement rather than leaving it to memory.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+const TESTS_DIR = path.join(__dirname);
+
+/**
+ * Escape hatch. Put `meta-ok: <reason>` in a comment inside the test body when
+ * a check below is a false positive — e.g. `expect(a()).toBe(a())` is a
+ * tautology for a pure function but a real assertion for a memoized one, since
+ * `toBe` compares identity. Requiring the reason in prose keeps it deliberate.
+ */
+const PRAGMA = "meta-ok:";
+
+interface TestFn {
+  file: string;
+  name: string;
+  describePath: string[];
+  body: ts.Node | undefined;
+  text: string;
+  isEach: boolean;
+}
+
+function sourceFiles(): { file: string; src: ts.SourceFile }[] {
+  return readdirSync(TESTS_DIR)
+    .filter((f) => /\.tsx?$/.test(f))
+    .sort()
+    .map((file) => ({
+      file,
+      src: ts.createSourceFile(
+        file,
+        readFileSync(path.join(TESTS_DIR, file), "utf8"),
+        ts.ScriptTarget.Latest,
+        /* setParentNodes */ true,
+        file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+      ),
+    }));
+}
+
+/** `it`, `it.only`, `it.each(...)` and `test` variants all resolve to the root. */
+function rootCallee(expr: ts.Expression): string {
+  if (ts.isIdentifier(expr)) return expr.text;
+  if (ts.isPropertyAccessExpression(expr)) return rootCallee(expr.expression);
+  if (ts.isCallExpression(expr)) return rootCallee(expr.expression);
+  return "";
+}
+
+function isEachForm(expr: ts.Expression): boolean {
+  // it.each(table)("name %s", fn) — the name is a template, not a fixed string.
+  if (ts.isCallExpression(expr)) return isEachForm(expr.expression);
+  if (ts.isPropertyAccessExpression(expr)) {
+    return expr.name.text === "each" || isEachForm(expr.expression);
+  }
+  return false;
+}
+
+function collectTests(): TestFn[] {
+  const out: TestFn[] = [];
+  for (const { file, src } of sourceFiles()) {
+    if (file === "meta.test.ts") continue; // don't audit the auditor's own shape
+    const walk = (node: ts.Node, describePath: string[]) => {
+      if (ts.isCallExpression(node)) {
+        const callee = rootCallee(node.expression);
+        const [nameArg, fnArg] = node.arguments;
+        const name =
+          nameArg && ts.isStringLiteralLike(nameArg) ? nameArg.text : "<dynamic>";
+        if (callee === "describe") {
+          ts.forEachChild(node, (c) => walk(c, [...describePath, name]));
+          return;
+        }
+        if (callee === "it" || callee === "test") {
+          out.push({
+            file,
+            name,
+            describePath,
+            body: fnArg,
+            text: fnArg ? fnArg.getText(src) : "",
+            isEach: isEachForm(node.expression),
+          });
+          return;
+        }
+      }
+      ts.forEachChild(node, (c) => walk(c, describePath));
+    };
+    walk(src, []);
+  }
+  return out;
+}
+
+/** Anything in a test body that can turn it red. */
+function assertionCount(fn: TestFn): number {
+  if (!fn.body) return 0;
+  let n = 0;
+  const walk = (node: ts.Node) => {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      // expect(...)  /  expect.assertions(n)  /  expect.hasAssertions()
+      if (ts.isIdentifier(callee) && callee.text === "expect") n++;
+      if (
+        ts.isPropertyAccessExpression(callee) &&
+        ts.isIdentifier(callee.expression) &&
+        callee.expression.text === "expect"
+      ) {
+        n++;
+      }
+      // A bare `fail()` or an explicit throw-assertion helper.
+      if (ts.isIdentifier(callee) && callee.text === "fail") n++;
+    }
+    ts.forEachChild(node, walk);
+  };
+  ts.forEachChild(fn.body, walk);
+  return n;
+}
+
+const ALL_TESTS = collectTests();
+
+describe("the meta guard actually sees the suite", () => {
+  // Guard the guard: if the directory read, the glob, or the AST walk ever
+  // stops matching, every check below passes vacuously — the exact failure
+  // mode this file exists to prevent. Ratcheted to just under the measured
+  // values (849 tests / 57 files on 2026-08-17) rather than a token floor:
+  // sift-api's equivalent asserted `> 100` against 770 real functions, which
+  // tolerated losing 87% of the suite before firing.
+  it("finds the whole suite, not a fraction of it", () => {
+    expect(ALL_TESTS.length).toBeGreaterThan(800);
+    expect(new Set(ALL_TESTS.map((t) => t.file)).size).toBeGreaterThan(50);
+  });
+
+  it("can actually parse every test file it claims to read", () => {
+    // A file that fails to parse yields zero tests and would otherwise be
+    // silently skipped by every check below.
+    for (const { file, src } of sourceFiles()) {
+      expect(`${file}:${src.statements.length}`).not.toBe(`${file}:0`);
+    }
+  });
+});
+
+describe("every test can fail", () => {
+  it("has at least one assertion in every test body", () => {
+    const offenders = ALL_TESTS.filter(
+      (t) => assertionCount(t) === 0 && !t.text.includes(PRAGMA),
+    ).map((t) => `${t.file} :: ${[...t.describePath, t.name].join(" › ")}`);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("never compares a value to itself", () => {
+    // `expect(f(x)).toBe(f(x))` passes for every possible implementation of a
+    // pure `f`. This is the original form of the defect that motivated
+    // sift-api's meta-suite, and neither that suite nor any lint rule catches
+    // it — they check for the ABSENCE of an assertion, not a vacuous one.
+    const IDENTITY_MATCHERS = new Set(["toBe", "toEqual", "toStrictEqual"]);
+    const offenders: string[] = [];
+
+    for (const { file, src } of sourceFiles()) {
+      if (file === "meta.test.ts") continue;
+      const walk = (node: ts.Node) => {
+        if (
+          ts.isCallExpression(node) &&
+          ts.isPropertyAccessExpression(node.expression) &&
+          IDENTITY_MATCHERS.has(node.expression.name.text) &&
+          node.arguments.length === 1
+        ) {
+          const receiver = node.expression.expression;
+          if (
+            ts.isCallExpression(receiver) &&
+            ts.isIdentifier(receiver.expression) &&
+            receiver.expression.text === "expect" &&
+            receiver.arguments.length === 1
+          ) {
+            const norm = (n: ts.Node) => n.getText(src).replace(/\s+/g, " ").trim();
+            const left = norm(receiver.arguments[0]);
+            const right = norm(node.arguments[0]);
+            if (left === right) {
+              // Walk up for a pragma on the enclosing test.
+              let scope: ts.Node | undefined = node;
+              let exempt = false;
+              while (scope) {
+                if (scope.getText(src).includes(PRAGMA)) { exempt = true; break; }
+                scope = scope.parent;
+              }
+              if (!exempt) offenders.push(`${file} :: expect(${left}).${node.expression.name.text}(${right})`);
+            }
+          }
+        }
+        ts.forEachChild(node, walk);
+      };
+      walk(src);
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("no test silently shadows another", () => {
+  it("has no duplicate test name inside a single describe block", () => {
+    // A duplicated `it("x")` in the same block does not shadow in Jest the way
+    // a duplicated Python `def` does — both run — but it makes a failure
+    // report ambiguous, and it is nearly always a copy-paste that meant to
+    // change something. Scoped to the enclosing describe, because two
+    // different blocks may each legitimately test "returns null".
+    const seen = new Map<string, number>();
+    for (const t of ALL_TESTS) {
+      if (t.isEach || t.name === "<dynamic>") continue;
+      const key = `${t.file} :: ${[...t.describePath, t.name].join(" › ")}`;
+      seen.set(key, (seen.get(key) ?? 0) + 1);
+    }
+    const dupes = [...seen.entries()]
+      .filter(([, n]) => n > 1)
+      .map(([k, n]) => `${k} (x${n})`);
+
+    expect(dupes).toEqual([]);
+  });
+});
+
+describe("known gaps", () => {
+  it("records the vacuous-loop class this guard does not yet enforce", () => {
+    // A test whose assertions ALL sit inside a `for`/`forEach`/`if` runs zero
+    // assertions if the collection is empty, and still reports green. On
+    // 2026-08-17 that shape covered 22 tests here — nearly all legitimate
+    // table-driven tests over module constants, which is why this is measured
+    // rather than enforced: a rule with 22 false positives is a rule people
+    // route around.
+    //
+    // The mitigation that DOES scale is a self-guard — one
+    // `expect(table.length).toBeGreaterThan(0)` at the top of the loop body's
+    // enclosing test. utils.test.ts's golden-hash test carries one as the
+    // worked example; see the note there.
+    //
+    // This test pins the count so the class cannot quietly grow unnoticed.
+    const loopy = ALL_TESTS.filter((t) => {
+      if (!t.body) return false;
+      let total = 0;
+      let nested = 0;
+      const walk = (node: ts.Node, depth: number) => {
+        if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "expect") {
+          total++;
+          if (depth > 0) nested++;
+        }
+        const opensScope =
+          ts.isForStatement(node) ||
+          ts.isForOfStatement(node) ||
+          ts.isForInStatement(node) ||
+          ts.isWhileStatement(node) ||
+          ts.isIfStatement(node) ||
+          (ts.isCallExpression(node) &&
+            ts.isPropertyAccessExpression(node.expression) &&
+            ["forEach", "map", "filter"].includes(node.expression.name.text));
+        ts.forEachChild(node, (c) => walk(c, depth + (opensScope ? 1 : 0)));
+      };
+      ts.forEachChild(t.body, (c) => walk(c, 0));
+      return total > 0 && total === nested;
+    });
+
+    // Ratchet DOWNWARD only. Raising this number to make a build green is the
+    // one edit this line exists to make someone think twice about.
+    expect(loopy.length).toBeLessThanOrEqual(22);
+  });
+});

--- a/__tests__/og.test.tsx
+++ b/__tests__/og.test.tsx
@@ -11,7 +11,6 @@ import {
   clampOgTitle,
   dossierOgCard,
   loadOgFonts,
-  OG,
   OG_SIZE,
   siftIconCard,
 } from "@/lib/og";
@@ -80,9 +79,12 @@ describe("dossierOgCard", () => {
     expect(text).not.toContain("null");
   });
 
-  it("uses the warm dark palette, not the retired indigo", () => {
-    expect(OG.bg).toBe("#15120C");
-    expect(OG.accent).toBe("#ec5b39");
+  it("renders at the 1200x630 size social scrapers expect", () => {
+    // Kept because this is an EXTERNAL contract — Open Graph consumers crop or
+    // reject other ratios, so the numbers are not ours to change freely.
+    // The `OG.bg` / `OG.accent` assertions that used to sit here were dropped:
+    // they restated lib/og.tsx with no invariant behind them, so they enforced
+    // nothing and only made a palette change a two-file edit.
     expect(OG_SIZE).toEqual({ width: 1200, height: 630 });
   });
 });
@@ -111,6 +113,9 @@ describe("loadOgFonts", () => {
   });
 
   it("memoizes so repeat renders do not re-read the files", async () => {
+    // meta-ok: this reads as a self-comparison but is not one. `toBe` is
+    // identity, so an unmemoized loadOgFonts returning a fresh array each call
+    // fails here — which is precisely the behaviour under test.
     expect(await loadOgFonts()).toBe(await loadOgFonts());
   });
 });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -154,8 +154,19 @@ const GOLDEN_STABLE_HASH: Record<string, string> = {
   "https://www.npr.org/2026/06/04/x": "c9vv14",
 };
 
+// Two cases were removed here on 2026-08-17: `stableHash(url) === stableHash(url)`
+// (a tautology — no implementation of a pure function fails it) and a
+// length/typeof check that asserted a type rather than a value. Both were
+// fully subsumed by the golden-value test below, which pins the exact hashes
+// shared with sift-api's services/rss.py. Don't add them back.
 describe("stableHash", () => {
   it("matches the golden values shared with sift-api", () => {
+    // Self-guard, and the worked example __tests__/meta.test.ts points at: every
+    // assertion below sits inside the loop, so an emptied GOLDEN_STABLE_HASH
+    // would run zero of them and still report green — on the test guarding the
+    // primary key of every row in `articles`.
+    expect(Object.keys(GOLDEN_STABLE_HASH).length).toBeGreaterThanOrEqual(5);
+
     for (const [input, expected] of Object.entries(GOLDEN_STABLE_HASH)) {
       expect(stableHash(input)).toBe(expected);
     }
@@ -167,19 +178,8 @@ describe("stableHash", () => {
     expect(Math.abs(-2147483648).toString(36)).toBe("zik0zk");
   });
 
-  it("returns same hash for same input", () => {
-    const url = "https://reuters.com/article/123";
-    expect(stableHash(url)).toBe(stableHash(url));
-  });
-
   it("returns different hash for different input", () => {
     expect(stableHash("https://a.com")).not.toBe(stableHash("https://b.com"));
-  });
-
-  it("returns a non-empty string", () => {
-    const hash = stableHash("test");
-    expect(hash.length).toBeGreaterThan(0);
-    expect(typeof hash).toBe("string");
   });
 
   it("handles empty string", () => {


### PR DESCRIPTION
Split out of #266, where it had landed on a shared branch alongside an unrelated STATUS entry. Authored by @kristenmartino; opened separately so a 652-line test-hardening change keeps its own title and history rather than being squashed under "STATUS: open the source-credibility-weighting question".

Adds `__tests__/meta.test.ts` plus real guards on `/api/compare`, and replaces presence-only assertions. From the `copy.test.ts` diff:

> Exact values, not `toBeTruthy()`. This block used to assert only that ~20 keys were non-empty, which passes for any wrong-but-present string — you could swap `topics.confirm` and `topics.cancel`, or set `error.body` to "x", and it stayed green.

Also touches `.github/workflows/ci.yml`.

Verified on this branch, rebased onto current `main` (`a5a7d48`): `npx jest` **58 suites / 879 tests** pass, `npx tsc --noEmit` clean.

Worth noting the same defect class turned up independently in #253 tonight — an existing dossier test flipped `chamber` to `"senate"` *and* blanked the role, but asserted only on the role, so the chamber change was decorative and `"foreign-executive"` would have passed it too.