### PR TITLE
Fix PWA manifest icon routes (sift#244)

### DIFF
--- a/app/api/icon-192/route.ts
+++ b/app/api/icon-192/route.ts
@@ -1,0 +1,10 @@
+import { ImageResponse } from "next/og";
+
+import { siftIconCard } from "@/lib/og";
+
+export const GET = () => {
+  return new ImageResponse(siftIconCard({ radius: 36, mark: 120 }), {
+    width: 192,
+    height: 192,
+  });
+};

--- a/app/api/icon-512/route.ts
+++ b/app/api/icon-512/route.ts
@@ -1,0 +1,10 @@
+import { ImageResponse } from "next/og";
+
+import { siftIconCard } from "@/lib/og";
+
+export const GET = () => {
+  return new ImageResponse(siftIconCard({ radius: 96, mark: 320 }), {
+    width: 512,
+    height: 512,
+  });
+};

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -10,8 +10,8 @@ export default function manifest(): MetadataRoute.Manifest {
     theme_color: "#E0492A",
     icons: [
       { src: "/favicon.svg", sizes: "any", type: "image/svg+xml" },
-      { src: "/icon-192", sizes: "192x192", type: "image/png" },
-      { src: "/icon-512", sizes: "512x512", type: "image/png" },
+      { src: "/api/icon-192", sizes: "192x192", type: "image/png" },
+      { src: "/api/icon-512", sizes: "512x512", type: "image/png" },
     ],
   };
 }


### PR DESCRIPTION
## Summary

The PWA manifest referenced icon URLs `/icon-192` and `/icon-512` that returned 404s. While the code to generate these icons existed in `app/icon-192.tsx` and `app/icon-512.tsx`, Next.js 16 doesn't recognize these file names as metadata routes—only standard names like `icon.tsx` and `apple-icon.tsx` are auto-routed.

## Solution

Created two API routes to serve the 192x192 and 512x512 icons:
- `app/api/icon-192/route.ts` — 192x192 PNG icon
- `app/api/icon-512/route.ts` — 512x512 PNG icon

Updated the manifest to reference `/api/icon-192` and `/api/icon-512` instead of the broken URLs.

## Verification

- ✓ `/api/icon-192` returns 200 with `Content-Type: image/png`
- ✓ `/api/icon-512` returns 200 with `Content-Type: image/png`
- ✓ `/manifest.webmanifest` contains correct icon URLs with no 404s

Fixes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)