### PR TITLE
Pin eslint majors: blocked on eslint-config-next's eslint-plugin-react

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,8 +21,25 @@ updates:
     #
     # Lift the ignore when typescript-eslint ships TS 7 support; port the meta
     # guard after that, not before. See STATUS.md 2026-08-17 and #194.
+    #
+    # eslint is held back the same way, for a chain we don't control. eslint
+    # 10 removes an API (`context.getFilename`) that `eslint-plugin-react`
+    # 7.37.5 still calls, so linting any file throws:
+    #
+    #   TypeError: Error while loading rule 'react/display-name':
+    #   contextOrFilename.getFilename is not a function
+    #
+    # eslint-plugin-react is not a direct dependency here -- it arrives
+    # transitively, pinned by `eslint-config-next` 16.3.1, so there is nothing
+    # in this repo to bump. (`@typescript-eslint` is NOT part of this block:
+    # it peers `^8.57.0 || ^9.0.0 || ^10.0.0` and is fine on eslint 10.)
+    #
+    # Lift the ignore when eslint-config-next ships a version that pulls an
+    # eslint-10-compatible eslint-plugin-react. See #284.
     ignore:
       - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
     groups:
       production-dependencies:


### PR DESCRIPTION
## Summary

Pins `eslint` majors via `.github/dependabot.yml`, mirroring the existing TypeScript pin, and explains why #284 (eslint 9.39.5 -> 10.8.1) can't merge yet.

## The blocker

#284 fails the required Lint check:

```
TypeError: Error while loading rule 'react/display-name':
contextOrFilename.getFilename is not a function
```

(verbatim from #284's CI run, `Lint` step). `eslint-plugin-react@7.37.5` calls `context.getFilename()`, an API eslint 10 removed (`detectReactVersion` -> `resolveBasedir` in `eslint-plugin-react/lib/util/version.js`).

`eslint-plugin-react` is **not** a direct dependency of this repo — `package.json` only lists `eslint` and `eslint-config-next`. It arrives transitively:

```
node_modules/eslint-config-next/node_modules/eslint-plugin-react  7.37.5
  peerDependencies: { eslint: '^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7' }
```

pinned by `eslint-config-next@16.3.1`. There is nothing here to bump — the fix has to come from `eslint-config-next` shipping a version that pulls in an eslint-10-compatible `eslint-plugin-react`.

`@typescript-eslint` is **not** the blocker, despite being the other eslint-adjacent major dep — confirmed its peer range:

```
@typescript-eslint/eslint-plugin@8.60.0  peer eslint: "^8.57.0 || ^9.0.0 || ^10.0.0"
@typescript-eslint/parser@8.60.0          peer eslint: "^8.57.0 || ^9.0.0 || ^10.0.0"
```

that's fine on eslint 10.

## What this PR does

Adds an `ignore` entry for `eslint` majors to `.github/dependabot.yml`, alongside the existing `typescript` one, with a comment block in the same style explaining the chain and naming the exact condition that lifts it (`eslint-config-next` shipping an eslint-10-compatible `eslint-plugin-react`).

Validated the YAML still parses and that the typescript ignore entry, the `groups` block, and the `github-actions` ecosystem entry all survive intact (via `js-yaml` round-trip).

## Follow-up

Posting a comment on #284 explaining this and linking here. Not closing #284 myself — dependabot closes it automatically once the ignore rule lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
