### PR TITLE
Carry the corrected cost figure into the docs that quote it

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -336,8 +336,12 @@ today's news instead of a screenshot.
 
 **Cost here does not scale with users.** Model spend scales with *articles
 ingested* — one reader or ten thousand costs the same — so the row that matters
-is not in this table. Per 1,000 articles, all in, spend went **$5.38 → $2.69**
-across August via incremental threading and linker roster narrowing. Re-derive
+is not in this table. Per 1,000 articles, all in, spend went **$5.38 → ~$2.29**
+across August via incremental threading and linker roster narrowing — a 57%
+reduction, measured over eight settled days (range $2.01–$2.54) rather than
+projected. The ranking inverted on the way: the entity linker was 46.2% of
+spend and the largest line, and now measures ~$0.21/1k; the summarizer is the
+largest at ~$0.71. Re-derive
 from `sift-api/scripts/verify_cost_baseline.py`; do not quote a monthly figure
 from this file, which has been wrong by an order of magnitude before.
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -546,7 +546,7 @@ We considered three approaches:
 
 **Attribution landed 2026-08-05, and the cost work it gated landed after it.** Five clean days of `ai_usage_daily` put spend at **$8.99/day**: `entity_linker_llm.link_text` 46.2% ($4.15), `story_synthesizer.synthesize` 26.3%, `story_clusterer.cluster` 17.1%, `summarizer.batch` 10.3%, Voyage 0.02%. Threading (clusterer + synthesizer) was **43.4%** — this entry's own code comment guessed 39%, which was close by luck rather than by method, since nothing had checked it.
 
-The root cause of the linker line was a volume assumption, not pricing: `services/entity_linker_llm.py` documents its economics as "~100 new articles/day" against an actual ingest of ~2,000. Two changes followed, both verified against the ledger rather than asserted — incremental threading (below) and roster narrowing on the linker. Measured per 1,000 articles, all in: **$3.88 → $2.69, roughly $204/mo → $141/mo**. Always re-baseline from `sift-api/scripts/verify_cost_baseline.py`, and read the per-1k figure rather than the daily one, which moves with the news.
+The root cause of the linker line was a volume assumption, not pricing: `services/entity_linker_llm.py` documents its economics as "~100 new articles/day" against an actual ingest of ~2,000. Two changes followed, both verified against the ledger rather than asserted — incremental threading (below) and roster narrowing on the linker. Measured per 1,000 articles, all in: **$3.88 → $2.69, roughly $204/mo → $141/mo**. *(Re-read against the ledger 2026-08-20: the realized figure settled at **~$2.29/1k**, better than the $2.69 recorded here. The $2.69 stands as what was measurable when this entry was written.)* Always re-baseline from `sift-api/scripts/verify_cost_baseline.py`, and read the per-1k figure rather than the daily one, which moves with the news.
 
 **Why this matters for a portfolio:** Good judgment > raw complexity. A hiring manager who sees a 5-node workflow where one node is a SQL ORDER BY will question your engineering taste. Four nodes where each earns its place shows you know when to reach for an LLM and when not to.
 
@@ -884,9 +884,9 @@ Both share tool handlers, the cost-cap pool, the Anthropic SDK pattern, and SSE;
 
 ---
 
-**Update 2026-08-18 — the economics were measured, and two of the blockers moved.** No expansion has been executed; the outlet set is still 56, ingested through 59 feeds. What changed is that the cost of doing it is no longer a guess: [`sift-api/docs/SOURCE_SCALING.md`](https://github.com/kristenmartino/sift-api/blob/main/docs/SOURCE_SCALING.md) (2026-08-11) prices expansion from measured per-stage tokens rather than from estimates.
+**Update 2026-08-18 — the economics were measured, and two of the blockers moved.** No expansion has been executed; the outlet set is still 56, ingested through 59 feeds. What changed is that the cost of doing it is no longer a guess: [`sift-api/docs/SOURCE_SCALING.md`](https://github.com/kristenmartino/sift-api/blob/main/docs/SOURCE_SCALING.md) (2026-08-11) prices expansion from measured per-stage tokens rather than from estimates. **These figures are now conservative:** realized spend settled at ~$2.29/1k by 2026-08-20, below the $2.69 the table is keyed on, so each column overstates.
 
-| expansion | at $2.69/1k (today) | at $3.88/1k (pre-narrowing) |
+| expansion | at $2.69/1k (as of 2026-08-18) | at $3.88/1k (pre-narrowing) |
 |---|---:|---:|
 | +50 outlets | $173–224/mo | $197/mo |
 | +100 outlets | $212–324/mo | $252–322/mo |


### PR DESCRIPTION
Follow-up to #290, which updated the walkthrough to the measured **~$2.29/1k** but merged before this landed — GitHub had auto-updated the branch, my push was rejected as non-fast-forward, and the merge went ahead with only the artifact change.

**Caught by `check-past-mistakes`** against CLAUDE.md's doc-impact rule: three places in this repo still asserted the superseded $2.69. Updating the artifact alone leaves the repo half-current, which is exactly what that rule exists to prevent.

## Three sites, handled differently on purpose

**`docs/ARCHITECTURE.md`** — a present-tense claim of current state, so corrected outright: `$5.38 → ~$2.29`, with the range and the ranking inversion (the entity linker was 46.2% of spend and the largest line, now ~$0.21/1k; the summarizer is largest at ~$0.71).

**`docs/DECISIONS.md`, the 2026-08-05 attribution entry** — a dated record of what was measurable then. **Appended, not rewritten**: $2.69 stands as what that entry measured, with the later reading noted beside it. Rewriting a decision log to match today would destroy the thing it's for.

**`docs/DECISIONS.md`, the expansion table** — keyed on "$2.69/1k (today)", where *today* was 2026-08-18. Re-dated, and marked conservative: every column now overstates. **Not recomputed** — `sift-api/docs/SOURCE_SCALING.md` owns that model and this repo shouldn't fork it.

Docs only.