### PR TITLE
Deposit: opened a PR for work that was already sitting open

### DIFF
--- a/.mistakes/worklog/2026-08-20T135229Z-duplicate-of-open-work.md
+++ b/.mistakes/worklog/2026-08-20T135229Z-duplicate-of-open-work.md
@@ -1,0 +1,1 @@
+2026-08-20 [duplicate-of-open-work] Opened #287 to bump next 16.3.0->16.3.1 while dependabot's #281, already open and listed in my own output minutes earlier, contained that exact bump — ref: PR #287 / #281


### PR DESCRIPTION
One `.mistakes/worklog/` deposit, in the one-line no-diagnosis format the policy asks for. Analysis belongs to a later `audit-mistakes-log` pass run with none of this session's context.

```
2026-08-20 [duplicate-of-open-work] Opened #287 to bump next 16.3.0->16.3.1 while
dependabot's #281, already open and listed in my own output minutes earlier,
contained that exact bump — ref: PR #287 / #281
```

## What it cost

Not the wasted PR — that part was cheap. Landing the `next` bump separately dissolved dependabot's production group, so it closed #281 with *"Looks like these dependencies are updatable in another way, so this is no longer needed."* The other two bumps in that group, `@anthropic-ai/sdk` and `@clerk/nextjs`, went unlanded until dependabot re-proposed them as #288 the following day.

The open-PR list was in my own printed output minutes before I started. I didn't read it.

## Why this is a separate worktree

The shared checkout is currently on `docs-194-271-closure` with an unpushed commit from another session. Committing there would have put this deposit on their branch. This branch is cut from `origin/main` in an isolated worktree, and the untracked copy in the shared checkout should be removed once this lands — otherwise it will block that session's next `git pull` with an "untracked working tree file would be overwritten" error.

## State after this

Three pending candidates, which is the threshold that trips the SessionStart nudge:

| deposit | |
|---|---|
| `[reference-verification]` | polled CI with a hardcoded PR number and reported another PR's checks as mine |
| `[ci-build-flake]` | Turbopack/postcss failure recurring on branches touching no build inputs |
| `[duplicate-of-open-work]` | this one |

Worth running the audit in a fresh session — I made all three, so I'm the worst-placed thing to judge whether any of them is a pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)