### PR TITLE
Fix CI reliability: use Google's Docker Hub mirror for pgvector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     # data and no secrets. See that file for why the build needs a DB at all.
     services:
       postgres:
-        image: pgvector/pgvector:pg16
+        image: mirror.gcr.io/pgvector/pgvector:pg16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
## Summary

Replaces the direct Docker Hub pull of `pgvector/pgvector:pg16` with `mirror.gcr.io/pgvector/pgvector:pg16`, Google's public, authentication-free pull-through cache for Docker Hub images.

This eliminates the Docker Hub anonymous-pull rate limit timeouts that occasionally fail the "Initialize containers" step before any tests run, causing false CI failures that block merges.

## Rationale for this approach

Three options were considered in the issue:
1. **Docker Hub authentication with a PAT** — requires a new secret
2. **Mirror to GHCR** — requires building and maintaining our own image
3. **Google's public mirror** — authentication-free, no new infrastructure needed

This PR uses option 3: the image is publicly available at `mirror.gcr.io/pgvector/pgvector:pg16` and resolves to the identical image (sha256:ccc6e83d6e35e931dc7c5def2022729d5a6c370318d099181995567ff1fb4d6b as of 2026-08-20).

## Verification

Locally confirmed that `docker pull mirror.gcr.io/pgvector/pgvector:pg16` succeeds and resolves to the expected image. CI will provide the final verification by successfully initializing the Postgres container in the exact GitHub Actions environment.

Closes #152