### PR TITLE
Re-home unverified-pr-reference and unverified-git-shell-state rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,6 @@ Before opening the PR:
 - Touched `docs/IOS_*.md` (plan / assessment / platform analysis)? Update the status banner at the top to reflect current state (Active / Under review / Archived).
 - **Did this satisfy something another document says is pending?** If it closes a "will be updated", "in progress", "not yet measured" or "blocked on" claim in `STATUS.md`, [`docs/DECISIONS.md`](./docs/DECISIONS.md), or a sibling repo's `STATUS.md`, go back and say so. Deferrals survive on their own because an open issue keeps asserting itself; completions do not, and nothing else will notice. Four instances of this in one day are recorded in [`MISTAKES.md`](./MISTAKES.md).
 - **Republished a hosted artifact this session? Commit the source file too.** `sift-system-walkthrough.html` is published to claude.ai and is built by nothing, so no test, lint or deploy fails when the repo copy falls behind the live page. It has already happened once: the 2026-08-10 revision went live uncommitted and the repo copy sat 13 days stale, missing six features that were live on the page. **Before editing it, `WebFetch` its artifact URL and diff against the file** — publishing over a stale base silently reverts whatever the last session shipped. Same rule for any other standalone HTML here that gets published (`sift-product-os.html` is the other candidate).
-- **Opening a PR or checking CI status for one? Re-confirm the PR/issue number against output this session already produced** (e.g. a `gh pr list` a few messages back) — don't reuse a number carried over from earlier context. See [`MISTAKES.md`](./MISTAKES.md) → unverified-pr-reference.
 
 ## Where to file new work (decision tree)
 
@@ -53,9 +52,14 @@ When you discover something during a session that's worth tracking, use this to 
 
 Commits do **not** cross repos — a "push the branch" request usually means just this one. Confirm before touching siblings.
 
-**Verify shell/git state before trusting it.** A `cd` into a worktree or sibling repo can silently fail if the shell's cwd already reset — confirm with `pwd` before assuming later commands ran where intended. Before any command that can discard uncommitted state (`git reset --hard`, `checkout --`, `clean`), check `git status`/`git diff --stat` first — an uncommitted change is invisible to that command and gone without a trace. See [`MISTAKES.md`](./MISTAKES.md) → unverified-git-shell-state.
-
 **Architecture note (D35):** new AI / search / write work belongs in **sift-api** (it owns the AI + write path). The one current exception — the topic-search AI fallback in `app/api/news/topic/route.ts` — is grandfathered and being migrated to sift-api (Slice 1 = sift-api#79). See [`docs/DECISIONS.md`](./docs/DECISIONS.md) D35.
+
+## Verify before trusting
+
+Two habits, evidenced separately in [`MISTAKES.md`](./MISTAKES.md) — grouped here by theme, not because they're the same root cause:
+
+- **Re-confirm a PR/issue number against this session's own output before citing or acting on it** — a CI poll, a `gh` call, opening new work — rather than reusing a number carried over from earlier context. See `MISTAKES.md` → unverified-pr-reference.
+- **Verify shell/git state before trusting it.** A `cd` into a worktree or sibling repo can silently fail if the shell's cwd already reset — confirm with `pwd` before assuming later commands ran where intended. Before any command that can discard uncommitted state (`git reset --hard`, `checkout --`, `clean`), check `git status`/`git diff --stat` first — an uncommitted change is invisible to that command and gone without a trace. See `MISTAKES.md` → unverified-git-shell-state.
 
 ## Mistake logging & rule graduation
 

--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -62,9 +62,9 @@ prevention, and whether it graduated into a CLAUDE.md rule.
 |---|---:|---|---|
 | completion-not-propagated | 4 | graduated (partial) | CLAUDE.md → "Republished a hosted artifact? Commit the source too" (artifact case only) + End-of-PR item on satisfied-elsewhere claims |
 | reference-verification | 0 here (borrowed) | guard installed | `.claude/hooks/guard-close-keywords.sh` — evidence is GridPulse's, not sift's |
-| unverified-pr-reference | 2 | graduated | CLAUDE.md → End-of-PR doc-impact check (PR/issue-number reconfirmation bullet) |
+| unverified-pr-reference | 2 | graduated | CLAUDE.md → Verify before trusting (PR/issue-number reconfirmation bullet) |
 | ci-build-flake | 2 (via #276, #286) | resolved | `next` floor `^16.3.1` (PR #287) — mechanical, no CLAUDE.md line |
-| unverified-git-shell-state | 2 (via #296, #298) | graduated | CLAUDE.md → Sibling repos (verify shell/git state before trusting it) |
+| unverified-git-shell-state | 2 (via #296, #298) | graduated | CLAUDE.md → Verify before trusting (verify shell/git state before trusting it) |
 
 ### Entries
 
@@ -136,8 +136,11 @@ prevention, and whether it graduated into a CLAUDE.md rule.
   command (CI poll, `gh` call) or opening new work, re-confirm it against
   output this session has already produced, rather than carrying a number
   over from earlier context.
-- **Status:** graduated → CLAUDE.md § End-of-PR doc-impact check
-  (2026-08-20). Incident 1 was low-severity (nothing shipped wrong).
+- **Status:** graduated → CLAUDE.md § Verify before trusting
+  (2026-08-20; re-homed from § End-of-PR doc-impact check on 2026-08-21 — a
+  fresh audit pass flagged that section as scoped to pre-PR-open checks,
+  while this rule also covers CI-status checks that happen later). Incident
+  1 was low-severity (nothing shipped wrong).
   Incident 2's direct overlap was self-resolved by dependabot, but it had a
   real, if minor, cost — a full group-dissolution side effect delaying two
   unrelated dependency bumps by a day — so this graduated on both the Repeat
@@ -197,7 +200,10 @@ prevention, and whether it graduated into a CLAUDE.md rule.
   later commands ran where intended; before any command that can discard
   uncommitted state (`git reset --hard`, `checkout --`, `clean`), check
   `git status`/`git diff --stat` first for anything you intend to keep.
-- **Status:** graduated → CLAUDE.md § Sibling repos (2026-08-20). Neither
+- **Status:** graduated → CLAUDE.md § Verify before trusting (2026-08-20;
+  re-homed from § Sibling repos on 2026-08-21 — a fresh audit pass flagged
+  that section as scoped to cross-repo boundaries, and neither incident
+  behind this rule was actually about a sibling repo). Neither
   incident was independently severe enough to graduate alone (an empty push,
   a reverted timestamp — both caught and fixed within the same session or
   the next), so this graduated on the Repeat bar, not Severity.


### PR DESCRIPTION
## Summary
- Fresh, decontextualized audit pass (a separate agent, no memory of the sessions that graduated these two rules) flagged both as misplaced:
  - `unverified-pr-reference` lived under "End-of-PR doc-impact check" despite also covering CI-status checks that happen after a PR is already open.
  - `unverified-git-shell-state` lived under "Sibling repos" despite neither supporting incident (#296, #298) actually being about a sibling repo — "worktree" appeared nowhere else in the repo's docs but that one rule.
- Pulled both into a new "Verify before trusting" section. Kept them as two distinct bullets/MISTAKES.md categories rather than merging into one root cause — the agent noted they're similar in *theme* ("acted on unconfirmed context") but different in *mechanism*.
- Updated `MISTAKES.md`'s tally table and both entries' Status lines to point at the new location, with a note on why they moved.
- Also verified (no fix needed): `nudge-check-past-mistakes-plan.sh` is correctly wired in `.claude/settings.json` (PostToolUse/ExitPlanMode) and syntactically valid — its silent hook-activity log just means it hasn't had cause to fire yet, not that it's broken.

## Test plan
- [x] Grepped for other "worktree" references in the repo's docs — confirmed there were none outside the misplaced rule
- [x] Confirmed markdown list continuation indentation is consistent after editing MISTAKES.md's Status paragraphs (no accidental paragraph breaks)
- [x] `bash -n .claude/hooks/nudge-check-past-mistakes-plan.sh` — syntax OK
- [x] Confirmed hook wiring directly in `.claude/settings.json` rather than inferring from log absence

🤖 Generated with [Claude Code](https://claude.com/claude-code)